### PR TITLE
Add basic CI to build iceberg and example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,8 @@ env:
 
 jobs:
   ubuntu:
-    name: AMD64 Ubuntu latest
-    runs-on: ubuntu-latest
+    name: AMD64 Ubuntu 24.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -55,8 +55,8 @@ jobs:
         shell: bash
         run: ci/scripts/build_example.sh $(pwd)/example
   macos:
-    name: AArch64 macOS latest
-    runs-on: macos-latest
+    name: AArch64 macOS 14
+    runs-on: macos-14
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         run: ci/scripts/build_example.sh $(pwd)/example
   macos:
     name: AArch64 macOS 14
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Test
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ICEBERG_HOME: /tmp/iceberg
+
+jobs:
+  ubuntu:
+    name: AMD64 Ubuntu 24.04
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout iceberg-cpp
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Build
+        shell: bash
+        run: ci/scripts/build_iceberg.sh $(pwd)
+      - name: Build Example
+        shell: bash
+        run: ci/scripts/build_example.sh $(pwd)/example
+  macos:
+    name: AArch64 macOS 14
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout iceberg-cpp
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Build Iceberg
+        shell: bash
+        run: ci/scripts/build_iceberg.sh $(pwd)
+      - name: Build Example
+        shell: bash
+        run: ci/scripts/build_example.sh $(pwd)/example

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   ubuntu:
-    name: AMD64 Ubuntu 24.04
+    name: AMD64 Ubuntu latest
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         run: ci/scripts/build_example.sh $(pwd)/example
   macos:
-    name: AArch64 macOS 14
+    name: AArch64 macOS latest
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
   ubuntu:
     name: AMD64 Ubuntu latest
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -58,7 +57,6 @@ jobs:
   macos:
     name: AArch64 macOS latest
     runs-on: macos-latest
-    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -76,7 +74,6 @@ jobs:
   windows:
     name: AMD64 Windows 2019
     runs-on: windows-2019
-    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     steps:
       - name: Checkout iceberg-cpp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - name: Build
+      - name: Build Iceberg
         shell: bash
         run: ci/scripts/build_iceberg.sh $(pwd)
       - name: Build Example

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,3 +73,23 @@ jobs:
       - name: Build Example
         shell: bash
         run: ci/scripts/build_example.sh $(pwd)/example
+  windows:
+    name: AMD64 Windows 2019
+    runs-on: windows-2019
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout iceberg-cpp
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Build Iceberg
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          bash -c "ci/scripts/build_iceberg.sh $(pwd)
+      - name: Build Example
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          bash -c "ci/scripts/build_example.sh $(pwd)/example

--- a/ci/scripts/build_example.sh
+++ b/ci/scripts/build_example.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,14 +17,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Please set CMAKE_PREFIX_PATH to the install prefix of iceberg.
-cmake_minimum_required(VERSION 3.25)
+set -eux
 
-project(example)
+source_dir=${1}
+build_dir=${1}/build
 
-find_package(iceberg CONFIG REQUIRED)
-find_package(puffin CONFIG REQUIRED)
+mkdir ${build_dir}
+pushd ${build_dir}
 
-add_executable(demo_example demo_example.cc)
+cmake \
+    -DCMAKE_PREFIX_PATH=${CMAKE_INSTALL_PREFIX:-${ICEBERG_HOME}} \
+    ${source_dir}
+cmake --build .
 
-target_link_libraries(demo_example PRIVATE iceberg::iceberg_core_static puffin::iceberg_puffin_static)
+popd
+
+# clean up between builds
+rm -rf ${build_dir}

--- a/ci/scripts/build_iceberg.sh
+++ b/ci/scripts/build_iceberg.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,14 +17,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Please set CMAKE_PREFIX_PATH to the install prefix of iceberg.
-cmake_minimum_required(VERSION 3.25)
+set -eux
 
-project(example)
+source_dir=${1}
+build_dir=${1}/build
 
-find_package(iceberg CONFIG REQUIRED)
-find_package(puffin CONFIG REQUIRED)
+mkdir ${build_dir}
+pushd ${build_dir}
 
-add_executable(demo_example demo_example.cc)
+cmake \
+    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-${ICEBERG_HOME}} \
+    -DICEBERG_BUILD_STATIC=ON \
+    -DICEBERG_BUILD_SHARED=ON \
+    ${source_dir}
+cmake --build . --target install
 
-target_link_libraries(demo_example PRIVATE iceberg::iceberg_core_static puffin::iceberg_puffin_static)
+popd
+
+# clean up between builds
+rm -rf ${build_dir}

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -20,6 +20,8 @@ cmake_minimum_required(VERSION 3.25)
 
 project(example)
 
+set(CMAKE_CXX_STANDARD 20)
+
 find_package(iceberg CONFIG REQUIRED)
 find_package(puffin CONFIG REQUIRED)
 


### PR DESCRIPTION
This PR adds a minimal build for Ubuntu 24.04, macOS 14 and Windows 2019 for both Iceberg CPP and the Example to validate follow up PRs build correctly.