### PR TITLE
Update cmake instructions in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 # under the License.
 
 build/
+install/
 cmake-build-debug/
 cmake-build-release/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ C++ implementation of [Apache Iceberg™](https://iceberg.apache.org/).
 
 ```bash
 cd iceberg-cpp
-cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/path/to/install -DICEBERG_BUILD_STATIC=ON -DICEBERG_BUILD_SHARED=ON
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/path/to/install -DICEBERG_BUILD_STATIC=ON -DICEBERG_BUILD_SHARED=ON -DICEBERG_BUILD_TESTS=OFF -DICEBERG_ARROW=OFF
 cmake --build build
 cmake --install build
 ```


### PR DESCRIPTION
Build `Core Libraries` w/o `Arrow`, as there is another section about building `Iceberg Arrow Library` explicitly.