### PR TITLE
fix wrong copyright year range

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Iceberg C++
-Copyright 2023-2024 The Apache Software Foundation
+Copyright 2024-2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Iceberg C++ was started at year 2024, so change to it.