### PR TITLE
ci: add initial collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -40,6 +40,13 @@ github:
     wiki: true
     issues: true
     projects: true
+  collaborators:
+    - gaborkaszab
+    - lidavidm
+    - pitrou
+    - raulcd
+    - wgtmac
+    - zhjwpku
 
 notifications:
   commits:      commits@iceberg.apache.org


### PR DESCRIPTION
Add some active contributors who are not yet Iceberg committers as collaborators to facilitate contribution.