### PR TITLE
Build/link to Rust iceberg-c library

### DIFF
--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -198,3 +198,38 @@ endfunction()
 if(ICEBERG_AVRO)
   resolve_avro_dependency()
 endif()
+
+# ----------------------------------------------------------------------
+# Apache Iceberg (Rust)
+
+function(resolve_iceberg_c_dependency)
+  prepare_fetchcontent()
+
+  fetchcontent_declare(IcebergC
+                       ${FC_DECLARE_COMMON_OPTIONS}
+                       GIT_REPOSITORY https://github.com/lidavidm/iceberg-rust.git
+                       GIT_TAG add-c-binding
+                       SOURCE_SUBDIR
+                       bindings/c
+                       FIND_PACKAGE_ARGS)
+
+  fetchcontent_makeavailable(IcebergC)
+
+  if(icebergc_SOURCE_DIR)
+    message(STATUS "Using vendored Iceberg C library")
+    set(ICEBERG_C_VENDORED TRUE)
+  else()
+    message(STATUS "Using system Iceberg C library")
+    set(ICEBERG_C_VENDORED FALSE)
+    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES IcebergC)
+  endif()
+
+  set(ICEBERG_SYSTEM_DEPENDENCIES
+      ${ICEBERG_SYSTEM_DEPENDENCIES}
+      PARENT_SCOPE)
+  set(ICEBERG_C_VENDORED
+      ${ICEBERG_C_VENDORED}
+      PARENT_SCOPE)
+endfunction()
+
+resolve_iceberg_c_dependency()

--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -21,7 +21,11 @@ add_iceberg_lib(iceberg
                 SOURCES
                 ${ICEBERG_SOURCES}
                 PRIVATE_INCLUDES
-                ${ICEBERG_INCLUDES})
+                ${ICEBERG_INCLUDES}
+                SHARED_LINK_LIBS
+                IcebergC::iceberg_c_shared
+                STATIC_LINK_LIBS
+                IcebergC::iceberg_c_static)
 
 iceberg_install_all_headers(iceberg)
 


### PR DESCRIPTION
Requires https://github.com/apache/iceberg-rust/pull/966 with changes from https://github.com/lidavidm/iceberg-rust/tree/add-c-binding.