### PR TITLE
chore: don't include expected.h but result.h

### DIFF
--- a/src/iceberg/arrow/arrow_error_transform_internal.h
+++ b/src/iceberg/arrow/arrow_error_transform_internal.h
@@ -22,7 +22,6 @@
 #include <arrow/result.h>
 #include <arrow/status.h>
 
-#include "iceberg/expected.h"
 #include "iceberg/result.h"
 
 namespace iceberg::arrow {

--- a/src/iceberg/json_internal.cc
+++ b/src/iceberg/json_internal.cc
@@ -24,7 +24,6 @@
 
 #include <nlohmann/json.hpp>
 
-#include "iceberg/expected.h"
 #include "iceberg/partition_spec.h"
 #include "iceberg/result.h"
 #include "iceberg/schema.h"
@@ -32,7 +31,7 @@
 #include "iceberg/sort_order.h"
 #include "iceberg/transform.h"
 #include "iceberg/type.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 #include "iceberg/util/macros.h"
 
 namespace iceberg {

--- a/src/iceberg/json_internal.h
+++ b/src/iceberg/json_internal.h
@@ -20,11 +20,9 @@
 #pragma once
 
 #include <memory>
-#include <string_view>
 
 #include <nlohmann/json_fwd.hpp>
 
-#include "iceberg/expected.h"
 #include "iceberg/result.h"
 #include "iceberg/type_fwd.h"
 

--- a/src/iceberg/partition_field.cc
+++ b/src/iceberg/partition_field.cc
@@ -23,7 +23,7 @@
 
 #include "iceberg/transform.h"
 #include "iceberg/type.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/src/iceberg/partition_field.h
+++ b/src/iceberg/partition_field.h
@@ -26,7 +26,6 @@
 #include <memory>
 #include <string>
 #include <string_view>
-#include <vector>
 
 #include "iceberg/iceberg_export.h"
 #include "iceberg/type_fwd.h"

--- a/src/iceberg/partition_spec.cc
+++ b/src/iceberg/partition_spec.cc
@@ -23,7 +23,7 @@
 
 #include "iceberg/schema.h"
 #include "iceberg/type.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/src/iceberg/schema_field.cc
+++ b/src/iceberg/schema_field.cc
@@ -22,7 +22,7 @@
 #include <format>
 
 #include "iceberg/type.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/src/iceberg/schema_internal.cc
+++ b/src/iceberg/schema_internal.cc
@@ -24,7 +24,6 @@
 #include <optional>
 #include <string>
 
-#include "iceberg/expected.h"
 #include "iceberg/schema.h"
 #include "iceberg/type.h"
 

--- a/src/iceberg/schema_internal.h
+++ b/src/iceberg/schema_internal.h
@@ -23,7 +23,6 @@
 
 #include <nanoarrow/nanoarrow.h>
 
-#include "iceberg/expected.h"
 #include "iceberg/result.h"
 #include "iceberg/type_fwd.h"
 

--- a/src/iceberg/sort_field.cc
+++ b/src/iceberg/sort_field.cc
@@ -22,8 +22,7 @@
 #include <format>
 
 #include "iceberg/transform.h"
-#include "iceberg/type.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/src/iceberg/sort_field.h
+++ b/src/iceberg/sort_field.h
@@ -26,9 +26,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
-#include <vector>
 
-#include "iceberg/expected.h"
 #include "iceberg/iceberg_export.h"
 #include "iceberg/result.h"
 #include "iceberg/type_fwd.h"

--- a/src/iceberg/sort_order.cc
+++ b/src/iceberg/sort_order.cc
@@ -21,7 +21,7 @@
 
 #include <format>
 
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/src/iceberg/transform.h
+++ b/src/iceberg/transform.h
@@ -26,7 +26,6 @@
 #include <variant>
 
 #include "iceberg/arrow_c_data.h"
-#include "iceberg/expected.h"
 #include "iceberg/iceberg_export.h"
 #include "iceberg/result.h"
 #include "iceberg/type_fwd.h"

--- a/src/iceberg/type.cc
+++ b/src/iceberg/type.cc
@@ -21,10 +21,9 @@
 
 #include <format>
 #include <iterator>
-#include <stdexcept>
 
 #include "iceberg/exception.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/test/json_internal_test.cc
+++ b/test/json_internal_test.cc
@@ -30,7 +30,7 @@
 #include "iceberg/sort_field.h"
 #include "iceberg/sort_order.h"
 #include "iceberg/transform.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/test/partition_field_test.cc
+++ b/test/partition_field_test.cc
@@ -25,7 +25,7 @@
 #include <iceberg/type.h>
 
 #include "iceberg/transform.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/test/partition_spec_test.cc
+++ b/test/partition_spec_test.cc
@@ -28,7 +28,7 @@
 #include "iceberg/partition_field.h"
 #include "iceberg/schema.h"
 #include "iceberg/transform.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/test/schema_field_test.cc
+++ b/test/schema_field_test.cc
@@ -25,7 +25,7 @@
 #include <gtest/gtest.h>
 
 #include "iceberg/type.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 TEST(SchemaFieldTest, Basics) {
   {

--- a/test/schema_test.cc
+++ b/test/schema_test.cc
@@ -26,7 +26,7 @@
 #include <gtest/gtest.h>
 
 #include "iceberg/schema_field.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 TEST(SchemaTest, Basics) {
   {

--- a/test/sort_field_test.cc
+++ b/test/sort_field_test.cc
@@ -25,7 +25,7 @@
 
 #include "iceberg/transform.h"
 #include "iceberg/type.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/test/sort_order_test.cc
+++ b/test/sort_order_test.cc
@@ -27,7 +27,7 @@
 #include "iceberg/schema.h"
 #include "iceberg/sort_field.h"
 #include "iceberg/transform.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/test/transform_test.cc
+++ b/test/transform_test.cc
@@ -26,7 +26,7 @@
 #include <gtest/gtest.h>
 
 #include "iceberg/type.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {
 

--- a/test/type_test.cc
+++ b/test/type_test.cc
@@ -28,7 +28,7 @@
 #include <gtest/gtest.h>
 
 #include "iceberg/exception.h"
-#include "iceberg/util/formatter.h"
+#include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 struct TypeTestCase {
   /// Test case name, must be safe for Googletest (alphanumeric + underscore)


### PR DESCRIPTION
It is suggested that we include result.h instead of expected.h so that in the future we can simply replace this ported iceberg::expected with std::expected.

Besides that, I fix some IWYU warning in this PR.