### PR TITLE
chore: use chrono::milliseconds in snapshot and consolidate error usage

### DIFF
--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -36,7 +36,8 @@ set(ICEBERG_SOURCES
     transform_function.cc
     type.cc
     snapshot.cc
-    util/murmurhash3_internal.cc)
+    util/murmurhash3_internal.cc
+    util/timepoint.cc)
 
 set(ICEBERG_STATIC_BUILD_INTERFACE_LIBS)
 set(ICEBERG_SHARED_BUILD_INTERFACE_LIBS)

--- a/src/iceberg/expression/expression.h
+++ b/src/iceberg/expression/expression.h
@@ -68,8 +68,7 @@ class ICEBERG_EXPORT Expression {
 
   /// \brief Returns the negation of this expression, equivalent to not(this).
   virtual Result<std::shared_ptr<Expression>> Negate() const {
-    return unexpected(
-        Error(ErrorKind::kInvalidExpression, "Expression cannot be negated"));
+    return InvalidExpressionError("Expression cannot be negated");
   }
 
   /// \brief Returns whether this expression will accept the same values as another.

--- a/src/iceberg/file_io.h
+++ b/src/iceberg/file_io.h
@@ -52,8 +52,7 @@ class ICEBERG_EXPORT FileIO {
   virtual Result<std::string> ReadFile(const std::string& file_location,
                                        std::optional<size_t> length) {
     // We provide a default implementation to avoid Windows linker error LNK2019.
-    return unexpected<Error>{
-        {.kind = ErrorKind::kNotImplemented, .message = "ReadFile not implemented"}};
+    return NotImplementedError("ReadFile not implemented");
   }
 
   /// \brief Write the given content to the file at the given location.
@@ -64,8 +63,7 @@ class ICEBERG_EXPORT FileIO {
   /// file exists.
   /// \return void if the write succeeded, an error code if the write failed.
   virtual Status WriteFile(const std::string& file_location, std::string_view content) {
-    return unexpected<Error>{
-        {.kind = ErrorKind::kNotImplemented, .message = "WriteFile not implemented"}};
+    return NotImplementedError("WriteFile not implemented");
   }
 
   /// \brief Delete a file at the given location.
@@ -73,8 +71,7 @@ class ICEBERG_EXPORT FileIO {
   /// \param file_location The location of the file to delete.
   /// \return void if the delete succeeded, an error code if the delete failed.
   virtual Status DeleteFile(const std::string& file_location) {
-    return unexpected<Error>{
-        {.kind = ErrorKind::kNotImplemented, .message = "DeleteFile not implemented"}};
+    return NotImplementedError("DeleteFile not implemented");
   }
 };
 

--- a/src/iceberg/json_internal.cc
+++ b/src/iceberg/json_internal.cc
@@ -26,6 +26,7 @@
 #include <type_traits>
 #include <unordered_set>
 
+#include <iceberg/util/timepoint.h>
 #include <nlohmann/json.hpp>
 
 #include "iceberg/partition_spec.h"
@@ -499,7 +500,7 @@ nlohmann::json ToJson(const Snapshot& snapshot) {
   if (snapshot.sequence_number > TableMetadata::kInitialSequenceNumber) {
     json[kSequenceNumber] = snapshot.sequence_number;
   }
-  json[kTimestampMs] = snapshot.timestamp_ms;
+  json[kTimestampMs] = UnixMsFromTimePointMs(snapshot.timestamp_ms);
   json[kManifestList] = snapshot.manifest_list;
   // If there is an operation, write the summary map
   if (snapshot.operation().has_value()) {
@@ -712,7 +713,9 @@ Result<std::unique_ptr<Snapshot>> SnapshotFromJson(const nlohmann::json& json) {
   ICEBERG_ASSIGN_OR_RAISE(auto snapshot_id, GetJsonValue<int64_t>(json, kSnapshotId));
   ICEBERG_ASSIGN_OR_RAISE(auto sequence_number,
                           GetJsonValueOptional<int64_t>(json, kSequenceNumber));
-  ICEBERG_ASSIGN_OR_RAISE(auto timestamp_ms, GetJsonValue<int64_t>(json, kTimestampMs));
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto timestamp_ms,
+      GetJsonValue<int64_t>(json, kTimestampMs).and_then(TimePointMsFromUnixMs));
   ICEBERG_ASSIGN_OR_RAISE(auto manifest_list,
                           GetJsonValue<std::string>(json, kManifestList));
 
@@ -725,24 +728,14 @@ Result<std::unique_ptr<Snapshot>> SnapshotFromJson(const nlohmann::json& json) {
   if (summary_json.has_value()) {
     for (const auto& [key, value] : summary_json->items()) {
       if (!kValidSnapshotSummaryFields.contains(key)) {
-        return unexpected<Error>({
-            .kind = ErrorKind::kJsonParseError,
-            .message = std::format("Invalid snapshot summary field: {}", key),
-        });
+        return JsonParseError("Invalid snapshot summary field: {}", key);
       }
       if (!value.is_string()) {
-        return unexpected<Error>({
-            .kind = ErrorKind::kJsonParseError,
-            .message =
-                std::format("Invalid snapshot summary field value: {}", value.dump()),
-        });
+        return JsonParseError("Invalid snapshot summary field value: {}", value.dump());
       }
       if (key == SnapshotSummaryFields::kOperation &&
           !kValidDataOperation.contains(value.get<std::string>())) {
-        return unexpected<Error>({
-            .kind = ErrorKind::kJsonParseError,
-            .message = std::format("Invalid snapshot operation: {}", value.dump()),
-        });
+        return JsonParseError("Invalid snapshot operation: {}", value.dump());
       }
       summary[key] = value.get<std::string>();
     }

--- a/src/iceberg/result.h
+++ b/src/iceberg/result.h
@@ -28,20 +28,19 @@
 namespace iceberg {
 
 /// \brief Error types for iceberg.
-/// TODO: add more and sort them based on some rules.
 enum class ErrorKind {
-  kNoSuchNamespace,
   kAlreadyExists,
-  kNoSuchTable,
   kCommitStateUnknown,
-  kInvalidSchema,
   kInvalidArgument,
-  kIOError,
-  kNotImplemented,
-  kUnknownError,
-  kNotSupported,
   kInvalidExpression,
+  kInvalidSchema,
+  kIOError,
   kJsonParseError,
+  kNoSuchNamespace,
+  kNoSuchTable,
+  kNotImplemented,
+  kNotSupported,
+  kUnknownError,
 };
 
 /// \brief Error with a kind and a message.
@@ -62,11 +61,50 @@ using Result = expected<T, E>;
 
 using Status = Result<void>;
 
-/// \brief Create an unexpected error with kNotImplemented
+/// \brief Create an unexpected error with kAlreadyExists
 template <typename... Args>
-auto NotImplementedError(const std::format_string<Args...> fmt, Args&&... args)
+auto AlreadyExistsError(const std::format_string<Args...> fmt, Args&&... args)
     -> unexpected<Error> {
-  return unexpected<Error>({.kind = ErrorKind::kNotImplemented,
+  return unexpected<Error>({.kind = ErrorKind::kAlreadyExists,
+                            .message = std::format(fmt, std::forward<Args>(args)...)});
+}
+
+/// \brief Create an unexpected error with kCommitStateUnknown
+template <typename... Args>
+auto CommitStateUnknownError(const std::format_string<Args...> fmt, Args&&... args)
+    -> unexpected<Error> {
+  return unexpected<Error>({.kind = ErrorKind::kCommitStateUnknown,
+                            .message = std::format(fmt, std::forward<Args>(args)...)});
+}
+
+/// \brief Create an unexpected error with kInvalidArgument
+template <typename... Args>
+auto InvalidArgumentError(const std::format_string<Args...> fmt, Args&&... args)
+    -> unexpected<Error> {
+  return unexpected<Error>({.kind = ErrorKind::kInvalidArgument,
+                            .message = std::format(fmt, std::forward<Args>(args)...)});
+}
+
+/// \brief Create an unexpected error with kInvalidExpression
+template <typename... Args>
+auto InvalidExpressionError(const std::format_string<Args...> fmt, Args&&... args)
+    -> unexpected<Error> {
+  return unexpected<Error>({.kind = ErrorKind::kInvalidExpression,
+                            .message = std::format(fmt, std::forward<Args>(args)...)});
+}
+
+/// \brief Create an unexpected error with kInvalidSchema
+template <typename... Args>
+auto InvalidSchemaError(const std::format_string<Args...> fmt, Args&&... args)
+    -> unexpected<Error> {
+  return unexpected<Error>({.kind = ErrorKind::kInvalidSchema,
+                            .message = std::format(fmt, std::forward<Args>(args)...)});
+}
+
+/// \brief Create an unexpected error with kIOError
+template <typename... Args>
+auto IOError(const std::format_string<Args...> fmt, Args&&... args) -> unexpected<Error> {
+  return unexpected<Error>({.kind = ErrorKind::kIOError,
                             .message = std::format(fmt, std::forward<Args>(args)...)});
 }
 
@@ -78,11 +116,43 @@ auto JsonParseError(const std::format_string<Args...> fmt, Args&&... args)
                             .message = std::format(fmt, std::forward<Args>(args)...)});
 }
 
-/// \brief Create an unexpected error with kInvalidExpression
+/// \brief Create an unexpected error with kNoSuchNamespace
 template <typename... Args>
-auto InvalidExpressionError(const std::format_string<Args...> fmt, Args&&... args)
+auto NoSuchNamespaceError(const std::format_string<Args...> fmt, Args&&... args)
     -> unexpected<Error> {
-  return unexpected<Error>({.kind = ErrorKind::kInvalidExpression,
+  return unexpected<Error>({.kind = ErrorKind::kNoSuchNamespace,
+                            .message = std::format(fmt, std::forward<Args>(args)...)});
+}
+
+/// \brief Create an unexpected error with kNoSuchTable
+template <typename... Args>
+auto NoSuchTableError(const std::format_string<Args...> fmt, Args&&... args)
+    -> unexpected<Error> {
+  return unexpected<Error>({.kind = ErrorKind::kNoSuchTable,
+                            .message = std::format(fmt, std::forward<Args>(args)...)});
+}
+
+/// \brief Create an unexpected error with kNotImplemented
+template <typename... Args>
+auto NotImplementedError(const std::format_string<Args...> fmt, Args&&... args)
+    -> unexpected<Error> {
+  return unexpected<Error>({.kind = ErrorKind::kNotImplemented,
+                            .message = std::format(fmt, std::forward<Args>(args)...)});
+}
+
+/// \brief Create an unexpected error with kNotSupported
+template <typename... Args>
+auto NotSupportedError(const std::format_string<Args...> fmt, Args&&... args)
+    -> unexpected<Error> {
+  return unexpected<Error>({.kind = ErrorKind::kNotSupported,
+                            .message = std::format(fmt, std::forward<Args>(args)...)});
+}
+
+/// \brief Create an unexpected error with kUnknownError
+template <typename... Args>
+auto UnknownError(const std::format_string<Args...> fmt, Args&&... args)
+    -> unexpected<Error> {
+  return unexpected<Error>({.kind = ErrorKind::kUnknownError,
                             .message = std::format(fmt, std::forward<Args>(args)...)});
 }
 

--- a/src/iceberg/schema_internal.cc
+++ b/src/iceberg/schema_internal.cc
@@ -24,8 +24,11 @@
 #include <optional>
 #include <string>
 
+#include <iceberg/result.h>
+
 #include "iceberg/schema.h"
 #include "iceberg/type.h"
+#include "iceberg/util/macros.h"
 
 namespace iceberg {
 
@@ -170,18 +173,14 @@ ArrowErrorCode ToArrowSchema(const Type& type, bool optional, std::string_view n
 
 Status ToArrowSchema(const Schema& schema, ArrowSchema* out) {
   if (out == nullptr) [[unlikely]] {
-    return unexpected<Error>{{.kind = ErrorKind::kInvalidArgument,
-                              .message = "Output Arrow schema cannot be null"}};
+    return InvalidArgumentError("Output Arrow schema cannot be null");
   }
 
   if (ArrowErrorCode errorCode = ToArrowSchema(schema, /*optional=*/false, /*name=*/"",
                                                /*field_id=*/std::nullopt, out);
       errorCode != NANOARROW_OK) {
-    return unexpected<Error>{
-        {.kind = ErrorKind::kInvalidSchema,
-         .message = std::format(
-             "Failed to convert Iceberg schema to Arrow schema, error code: {}",
-             errorCode)}};
+    return InvalidSchemaError(
+        "Failed to convert Iceberg schema to Arrow schema, error code: {}", errorCode);
   }
 
   return {};
@@ -208,15 +207,12 @@ int32_t GetFieldId(const ArrowSchema& schema) {
 Result<std::shared_ptr<Type>> FromArrowSchema(const ArrowSchema& schema) {
   auto to_schema_field =
       [](const ArrowSchema& schema) -> Result<std::unique_ptr<SchemaField>> {
-    auto field_type_result = FromArrowSchema(schema);
-    if (!field_type_result) {
-      return unexpected<Error>(field_type_result.error());
-    }
+    ICEBERG_ASSIGN_OR_RAISE(auto field_type, FromArrowSchema(schema));
 
     auto field_id = GetFieldId(schema);
     bool is_optional = (schema.flags & ARROW_FLAG_NULLABLE) != 0;
-    return std::make_unique<SchemaField>(
-        field_id, schema.name, std::move(field_type_result.value()), is_optional);
+    return std::make_unique<SchemaField>(field_id, schema.name, std::move(field_type),
+                                         is_optional);
   };
 
   ArrowError arrow_error;
@@ -225,10 +221,8 @@ Result<std::shared_ptr<Type>> FromArrowSchema(const ArrowSchema& schema) {
   ArrowSchemaView schema_view;
   if (auto error_code = ArrowSchemaViewInit(&schema_view, &schema, &arrow_error);
       error_code != NANOARROW_OK) {
-    return unexpected<Error>{
-        {.kind = ErrorKind::kInvalidSchema,
-         .message = std::format("Failed to read Arrow schema, code: {}, message: {}",
-                                error_code, arrow_error.message)}};
+    return InvalidSchemaError("Failed to read Arrow schema, code: {}, message: {}",
+                              error_code, arrow_error.message);
   }
 
   switch (schema_view.type) {
@@ -237,35 +231,24 @@ Result<std::shared_ptr<Type>> FromArrowSchema(const ArrowSchema& schema) {
       fields.reserve(schema.n_children);
 
       for (int i = 0; i < schema.n_children; i++) {
-        auto field_result = to_schema_field(*schema.children[i]);
-        if (!field_result) {
-          return unexpected<Error>(field_result.error());
-        }
-        fields.emplace_back(std::move(*field_result.value()));
+        ICEBERG_ASSIGN_OR_RAISE(auto field, to_schema_field(*schema.children[i]));
+        fields.emplace_back(std::move(*field));
       }
 
       return std::make_shared<StructType>(std::move(fields));
     }
     case NANOARROW_TYPE_LIST: {
-      auto element_field_result = to_schema_field(*schema.children[0]);
-      if (!element_field_result) {
-        return unexpected<Error>(element_field_result.error());
-      }
-      return std::make_shared<ListType>(std::move(*element_field_result.value()));
+      ICEBERG_ASSIGN_OR_RAISE(auto element_field_result,
+                              to_schema_field(*schema.children[0]));
+      return std::make_shared<ListType>(std::move(*element_field_result));
     }
     case NANOARROW_TYPE_MAP: {
-      auto key_field_result = to_schema_field(*schema.children[0]->children[0]);
-      if (!key_field_result) {
-        return unexpected<Error>(key_field_result.error());
-      }
+      ICEBERG_ASSIGN_OR_RAISE(auto key_field,
+                              to_schema_field(*schema.children[0]->children[0]));
+      ICEBERG_ASSIGN_OR_RAISE(auto value_field,
+                              to_schema_field(*schema.children[0]->children[1]));
 
-      auto value_field_result = to_schema_field(*schema.children[0]->children[1]);
-      if (!value_field_result) {
-        return unexpected<Error>(value_field_result.error());
-      }
-
-      return std::make_shared<MapType>(std::move(*key_field_result.value()),
-                                       std::move(*value_field_result.value()));
+      return std::make_shared<MapType>(std::move(*key_field), std::move(*value_field));
     }
     case NANOARROW_TYPE_BOOL:
       return std::make_shared<BooleanType>();
@@ -284,20 +267,16 @@ Result<std::shared_ptr<Type>> FromArrowSchema(const ArrowSchema& schema) {
       return std::make_shared<DateType>();
     case NANOARROW_TYPE_TIME64:
       if (schema_view.time_unit != NANOARROW_TIME_UNIT_MICRO) {
-        return unexpected<Error>{
-            {.kind = ErrorKind::kInvalidSchema,
-             .message = std::format("Unsupported time unit for Arrow time type: {}",
-                                    static_cast<int>(schema_view.time_unit))}};
+        return InvalidSchemaError("Unsupported time unit for Arrow time type: {}",
+                                  static_cast<int>(schema_view.time_unit));
       }
       return std::make_shared<TimeType>();
     case NANOARROW_TYPE_TIMESTAMP: {
       bool with_timezone =
           schema_view.timezone != nullptr && std::strlen(schema_view.timezone) > 0;
       if (schema_view.time_unit != NANOARROW_TIME_UNIT_MICRO) {
-        return unexpected<Error>{
-            {.kind = ErrorKind::kInvalidSchema,
-             .message = std::format("Unsupported time unit for Arrow timestamp type: {}",
-                                    static_cast<int>(schema_view.time_unit))}};
+        return InvalidSchemaError("Unsupported time unit for Arrow timestamp type: {}",
+                                  static_cast<int>(schema_view.time_unit));
       }
       if (with_timezone) {
         return std::make_shared<TimestampTzType>();
@@ -314,18 +293,15 @@ Result<std::shared_ptr<Type>> FromArrowSchema(const ArrowSchema& schema) {
                                                  schema_view.extension_name.size_bytes);
           extension_name == kArrowUuidExtensionName) {
         if (schema_view.fixed_size != 16) {
-          return unexpected<Error>{{.kind = ErrorKind::kInvalidSchema,
-                                    .message = "UUID type must have a fixed size of 16"}};
+          return InvalidSchemaError("UUID type must have a fixed size of 16");
         }
         return std::make_shared<UuidType>();
       }
       return std::make_shared<FixedType>(schema_view.fixed_size);
     }
     default:
-      return unexpected<Error>{
-          {.kind = ErrorKind::kInvalidSchema,
-           .message = std::format("Unsupported Arrow type: {}",
-                                  ArrowTypeString(schema_view.type))}};
+      return InvalidSchemaError("Unsupported Arrow type: {}",
+                                ArrowTypeString(schema_view.type));
   }
 }
 
@@ -342,16 +318,10 @@ std::unique_ptr<Schema> FromStructType(StructType&& struct_type, int32_t schema_
 
 Result<std::unique_ptr<Schema>> FromArrowSchema(const ArrowSchema& schema,
                                                 int32_t schema_id) {
-  auto type_result = FromArrowSchema(schema);
-  if (!type_result) {
-    return unexpected<Error>(type_result.error());
-  }
+  ICEBERG_ASSIGN_OR_RAISE(auto type, FromArrowSchema(schema));
 
-  auto& type = type_result.value();
   if (type->type_id() != TypeId::kStruct) {
-    return unexpected<Error>{
-        {.kind = ErrorKind::kInvalidSchema,
-         .message = "Arrow schema must be a struct type for Iceberg schema"}};
+    return InvalidSchemaError("Arrow schema must be a struct type for Iceberg schema");
   }
 
   auto& struct_type = static_cast<StructType&>(*type);

--- a/src/iceberg/snapshot.h
+++ b/src/iceberg/snapshot.h
@@ -27,6 +27,7 @@
 
 #include "iceberg/iceberg_export.h"
 #include "iceberg/result.h"
+#include "iceberg/util/timepoint.h"
 
 namespace iceberg {
 
@@ -55,9 +56,7 @@ ICEBERG_EXPORT constexpr Result<SnapshotRefType> SnapshotRefTypeFromString(
     std::string_view str) noexcept {
   if (str == "branch") return SnapshotRefType::kBranch;
   if (str == "tag") return SnapshotRefType::kTag;
-  return unexpected<Error>(
-      {.kind = ErrorKind::kInvalidArgument,
-       .message = "Invalid snapshot reference type: {}" + std::string(str)});
+  return InvalidArgumentError("Invalid snapshot reference type: {}", str);
 }
 
 /// \brief A reference to a snapshot, either a branch or a tag.
@@ -241,7 +240,7 @@ struct ICEBERG_EXPORT Snapshot {
   int64_t sequence_number;
   /// A timestamp when the snapshot was created, used for garbage collection and table
   /// inspection.
-  int64_t timestamp_ms;
+  TimePointMs timestamp_ms;
   /// The location of a manifest list for this snapshot that tracks manifest files with
   /// additional metadata.
   std::string manifest_list;

--- a/src/iceberg/sort_field.h
+++ b/src/iceberg/sort_field.h
@@ -57,9 +57,7 @@ ICEBERG_EXPORT constexpr Result<SortDirection> SortDirectionFromString(
     std::string_view str) {
   if (str == "asc") return SortDirection::kAscending;
   if (str == "desc") return SortDirection::kDescending;
-  return unexpected<Error>(
-      {.kind = ErrorKind::kInvalidArgument,
-       .message = "Invalid SortDirection string: " + std::string(str)});
+  return InvalidArgumentError("Invalid SortDirection string: {}", str);
 }
 
 enum class NullOrder {
@@ -83,8 +81,7 @@ ICEBERG_EXPORT constexpr std::string_view NullOrderToString(NullOrder null_order
 ICEBERG_EXPORT constexpr Result<NullOrder> NullOrderFromString(std::string_view str) {
   if (str == "nulls-first") return NullOrder::kFirst;
   if (str == "nulls-last") return NullOrder::kLast;
-  return unexpected<Error>({.kind = ErrorKind::kInvalidArgument,
-                            .message = "Invalid NullOrder string: " + std::string(str)});
+  return InvalidArgumentError("Invalid NullOrder string: {}", str);
 }
 
 /// \brief a field with its transform.

--- a/src/iceberg/table_metadata.h
+++ b/src/iceberg/table_metadata.h
@@ -22,27 +22,16 @@
 /// \file iceberg/table_metadata.h
 /// Table metadata for Iceberg tables.
 
-#include <chrono>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "iceberg/iceberg_export.h"
-#include "iceberg/result.h"
 #include "iceberg/type_fwd.h"
+#include "iceberg/util/timepoint.h"
 
 namespace iceberg {
-
-/// \brief A time point in milliseconds
-using TimePointMs =
-    std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>;
-
-/// \brief Returns a TimePointMs from a Unix timestamp in milliseconds
-ICEBERG_EXPORT Result<TimePointMs> TimePointMsFromUnixMs(int64_t unix_ms);
-
-/// \brief Returns a Unix timestamp in milliseconds from a TimePointMs
-ICEBERG_EXPORT int64_t UnixMsFromTimePointMs(const TimePointMs& time_point_ms);
 
 /// \brief Represents a snapshot log entry
 struct ICEBERG_EXPORT SnapshotLogEntry {

--- a/src/iceberg/transform.cc
+++ b/src/iceberg/transform.cc
@@ -22,6 +22,8 @@
 #include <format>
 #include <regex>
 
+#include <iceberg/result.h>
+
 #include "iceberg/transform_function.h"
 #include "iceberg/type.h"
 
@@ -119,22 +121,16 @@ Result<std::unique_ptr<TransformFunction>> Transform::Bind(
       if (auto param = std::get_if<int32_t>(&param_)) {
         return std::make_unique<BucketTransform>(source_type, *param);
       }
-      return unexpected<Error>({
-          .kind = ErrorKind::kInvalidArgument,
-          .message = std::format(
-              "Bucket requires int32 param, none found in transform '{}'", type_str),
-      });
+      return InvalidArgumentError(
+          "Bucket requires int32 param, none found in transform '{}'", type_str);
     }
 
     case TransformType::kTruncate: {
       if (auto param = std::get_if<int32_t>(&param_)) {
         return std::make_unique<TruncateTransform>(source_type, *param);
       }
-      return unexpected<Error>({
-          .kind = ErrorKind::kInvalidArgument,
-          .message = std::format(
-              "Truncate requires int32 param, none found in transform '{}'", type_str),
-      });
+      return InvalidArgumentError(
+          "Truncate requires int32 param, none found in transform '{}'", type_str);
     }
 
     case TransformType::kYear:
@@ -149,10 +145,7 @@ Result<std::unique_ptr<TransformFunction>> Transform::Bind(
       return std::make_unique<VoidTransform>(source_type);
 
     default:
-      return unexpected<Error>({
-          .kind = ErrorKind::kNotSupported,
-          .message = std::format("Unsupported transform type: '{}'", type_str),
-      });
+      return NotSupportedError("Unsupported transform type: '{}'", type_str);
   }
 }
 
@@ -216,10 +209,7 @@ Result<std::shared_ptr<Transform>> TransformFromString(std::string_view transfor
     }
   }
 
-  return unexpected<Error>({
-      .kind = ErrorKind::kInvalidArgument,
-      .message = std::format("Invalid Transform string: {}", transform_str),
-  });
+  return InvalidArgumentError("Invalid Transform string: {}", transform_str);
 }
 
 }  // namespace iceberg

--- a/src/iceberg/transform_function.cc
+++ b/src/iceberg/transform_function.cc
@@ -19,8 +19,6 @@
 
 #include "iceberg/transform_function.h"
 
-#include <format>
-
 #include "iceberg/type.h"
 
 namespace iceberg {
@@ -29,17 +27,14 @@ IdentityTransform::IdentityTransform(std::shared_ptr<Type> const& source_type)
     : TransformFunction(TransformType::kIdentity, source_type) {}
 
 Result<ArrowArray> IdentityTransform::Transform(const ArrowArray& input) {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "IdentityTransform::Transform"});
+  return NotImplementedError("IdentityTransform::Transform");
 }
 
 Result<std::shared_ptr<Type>> IdentityTransform::ResultType() const {
   auto src_type = source_type();
   if (!src_type || !src_type->is_primitive()) {
-    return unexpected(Error{
-        .kind = ErrorKind::kNotSupported,
-        .message = std::format("{} is not a valid input type for identity transform",
-                               src_type ? src_type->ToString() : "null")});
+    return NotSupportedError("{} is not a valid input type for identity transform",
+                             src_type ? src_type->ToString() : "null");
   }
   return src_type;
 }
@@ -49,13 +44,11 @@ BucketTransform::BucketTransform(std::shared_ptr<Type> const& source_type,
     : TransformFunction(TransformType::kBucket, source_type), num_buckets_(num_buckets) {}
 
 Result<ArrowArray> BucketTransform::Transform(const ArrowArray& input) {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "BucketTransform::Transform"});
+  return NotImplementedError("BucketTransform::Transform");
 }
 
 Result<std::shared_ptr<Type>> BucketTransform::ResultType() const {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "BucketTransform::result_type"});
+  return NotImplementedError("BucketTransform::result_type");
 }
 
 TruncateTransform::TruncateTransform(std::shared_ptr<Type> const& source_type,
@@ -63,78 +56,66 @@ TruncateTransform::TruncateTransform(std::shared_ptr<Type> const& source_type,
     : TransformFunction(TransformType::kTruncate, source_type), width_(width) {}
 
 Result<ArrowArray> TruncateTransform::Transform(const ArrowArray& input) {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "TruncateTransform::Transform"});
+  return NotImplementedError("TruncateTransform::Transform");
 }
 
 Result<std::shared_ptr<Type>> TruncateTransform::ResultType() const {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "TruncateTransform::result_type"});
+  return NotImplementedError("TruncateTransform::result_type");
 }
 
 YearTransform::YearTransform(std::shared_ptr<Type> const& source_type)
     : TransformFunction(TransformType::kTruncate, source_type) {}
 
 Result<ArrowArray> YearTransform::Transform(const ArrowArray& input) {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "YearTransform::Transform"});
+  return NotImplementedError("YearTransform::Transform");
 }
 
 Result<std::shared_ptr<Type>> YearTransform::ResultType() const {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "YearTransform::result_type"});
+  return NotImplementedError("YearTransform::result_type");
 }
 
 MonthTransform::MonthTransform(std::shared_ptr<Type> const& source_type)
     : TransformFunction(TransformType::kMonth, source_type) {}
 
 Result<ArrowArray> MonthTransform::Transform(const ArrowArray& input) {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "MonthTransform::Transform"});
+  return NotImplementedError("MonthTransform::Transform");
 }
 
 Result<std::shared_ptr<Type>> MonthTransform::ResultType() const {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "MonthTransform::result_type"});
+  return NotImplementedError("MonthTransform::result_type");
 }
 
 DayTransform::DayTransform(std::shared_ptr<Type> const& source_type)
     : TransformFunction(TransformType::kDay, source_type) {}
 
 Result<ArrowArray> DayTransform::Transform(const ArrowArray& input) {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "DayTransform::Transform"});
+  return NotImplementedError("DayTransform::Transform");
 }
 
 Result<std::shared_ptr<Type>> DayTransform::ResultType() const {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "DayTransform::result_type"});
+  return NotImplementedError("DayTransform::result_type");
 }
 
 HourTransform::HourTransform(std::shared_ptr<Type> const& source_type)
     : TransformFunction(TransformType::kHour, source_type) {}
 
 Result<ArrowArray> HourTransform::Transform(const ArrowArray& input) {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "HourTransform::Transform"});
+  return NotImplementedError("HourTransform::Transform");
 }
 
 Result<std::shared_ptr<Type>> HourTransform::ResultType() const {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "HourTransform::result_type"});
+  return NotImplementedError("HourTransform::result_type");
 }
 
 VoidTransform::VoidTransform(std::shared_ptr<Type> const& source_type)
     : TransformFunction(TransformType::kVoid, source_type) {}
 
 Result<ArrowArray> VoidTransform::Transform(const ArrowArray& input) {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "VoidTransform::Transform"});
+  return NotImplementedError("VoidTransform::Transform");
 }
 
 Result<std::shared_ptr<Type>> VoidTransform::ResultType() const {
-  return unexpected<Error>(
-      {.kind = ErrorKind::kNotImplemented, .message = "VoidTransform::result_type"});
+  return NotImplementedError("VoidTransform::result_type");
 }
 
 }  // namespace iceberg

--- a/src/iceberg/util/timepoint.cc
+++ b/src/iceberg/util/timepoint.cc
@@ -17,21 +17,30 @@
  * under the License.
  */
 
-#include "iceberg/table_metadata.h"
+#include "iceberg/util/timepoint.h"
 
-#include <format>
-#include <string>
+#include <chrono>
 
 namespace iceberg {
 
-std::string ToString(const SnapshotLogEntry& entry) {
-  return std::format("SnapshotLogEntry[timestampMillis={},snapshotId={}]",
-                     entry.timestamp_ms, entry.snapshot_id);
+Result<TimePointMs> TimePointMsFromUnixMs(int64_t unix_ms) {
+  return TimePointMs{std::chrono::milliseconds(unix_ms)};
 }
 
-std::string ToString(const MetadataLogEntry& entry) {
-  return std::format("MetadataLogEntry[timestampMillis={},file={}]", entry.timestamp_ms,
-                     entry.metadata_file);
+int64_t UnixMsFromTimePointMs(const TimePointMs& time_point_ms) {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             time_point_ms.time_since_epoch())
+      .count();
+}
+
+Result<TimePointNs> TimePointNsFromUnixNs(int64_t unix_ns) {
+  return TimePointNs{std::chrono::nanoseconds(unix_ns)};
+}
+
+int64_t UnixNsFromTimePointNs(const TimePointNs& time_point_ns) {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             time_point_ns.time_since_epoch())
+      .count();
 }
 
 }  // namespace iceberg

--- a/src/iceberg/util/timepoint.h
+++ b/src/iceberg/util/timepoint.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+
+#include "iceberg/iceberg_export.h"
+#include "iceberg/result.h"
+
+namespace iceberg {
+
+/// \brief A time point in milliseconds
+using TimePointMs =
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>;
+
+/// \brief A time point in nanoseconds
+using TimePointNs =
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>;
+
+/// \brief Returns a TimePointMs from a Unix timestamp in milliseconds
+ICEBERG_EXPORT Result<TimePointMs> TimePointMsFromUnixMs(int64_t unix_ms);
+
+/// \brief Returns a Unix timestamp in milliseconds from a TimePointMs
+ICEBERG_EXPORT int64_t UnixMsFromTimePointMs(const TimePointMs& time_point_ms);
+
+/// \brief Returns a TimePointNs from a Unix timestamp in nanoseconds
+ICEBERG_EXPORT Result<TimePointNs> TimePointNsFromUnixNs(int64_t unix_ns);
+
+/// \brief Returns a Unix timestamp in nanoseconds from a TimePointNs
+ICEBERG_EXPORT int64_t UnixNsFromTimePointNs(const TimePointNs& time_point_ns);
+
+}  // namespace iceberg

--- a/test/json_internal_test.cc
+++ b/test/json_internal_test.cc
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 #include <iceberg/result.h>
+#include <iceberg/util/timepoint.h>
 #include <nlohmann/json.hpp>
 
 #include "gmock/gmock.h"
@@ -197,7 +198,7 @@ TEST(JsonInternalTest, Snapshot) {
   Snapshot snapshot{.snapshot_id = 1234567890,
                     .parent_snapshot_id = 9876543210,
                     .sequence_number = 99,
-                    .timestamp_ms = 1234567890123,
+                    .timestamp_ms = TimePointMsFromUnixMs(1234567890123).value(),
                     .manifest_list = "/path/to/manifest_list",
                     .summary = summary,
                     .schema_id = 42};

--- a/test/snapshot_test.cc
+++ b/test/snapshot_test.cc
@@ -19,6 +19,7 @@
 #include "iceberg/snapshot.h"
 
 #include <gtest/gtest.h>
+#include <iceberg/util/timepoint.h>
 
 namespace iceberg {
 
@@ -83,7 +84,7 @@ TEST_F(SnapshotTest, ConstructionAndFieldAccess) {
   Snapshot snapshot{.snapshot_id = 12345,
                     .parent_snapshot_id = 54321,
                     .sequence_number = 1,
-                    .timestamp_ms = 1615569200000,
+                    .timestamp_ms = TimePointMsFromUnixMs(1615569200000).value(),
                     .manifest_list = "s3://example/manifest_list.avro",
                     .summary = summary1,
                     .schema_id = 10};
@@ -92,7 +93,7 @@ TEST_F(SnapshotTest, ConstructionAndFieldAccess) {
   EXPECT_TRUE(snapshot.parent_snapshot_id.has_value());
   EXPECT_EQ(*snapshot.parent_snapshot_id, 54321);
   EXPECT_EQ(snapshot.sequence_number, 1);
-  EXPECT_EQ(snapshot.timestamp_ms, 1615569200000);
+  EXPECT_EQ(snapshot.timestamp_ms.time_since_epoch().count(), 1615569200000);
   EXPECT_EQ(snapshot.manifest_list, "s3://example/manifest_list.avro");
   EXPECT_EQ(snapshot.operation().value(), DataOperation::kAppend);
   EXPECT_EQ(snapshot.summary.at(std::string(SnapshotSummaryFields::kAddedDataFiles)),
@@ -105,14 +106,14 @@ TEST_F(SnapshotTest, ConstructionAndFieldAccess) {
 
 TEST_F(SnapshotTest, EqualityComparison) {
   // Test the == and != operators
-  Snapshot snapshot1(12345, {}, 1, 1615569200000, "s3://example/manifest_list.avro",
-                     summary1, {});
+  Snapshot snapshot1(12345, {}, 1, TimePointMsFromUnixMs(1615569200000).value(),
+                     "s3://example/manifest_list.avro", summary1, {});
 
-  Snapshot snapshot2(12345, {}, 1, 1615569200000, "s3://example/manifest_list.avro",
-                     summary2, {});
+  Snapshot snapshot2(12345, {}, 1, TimePointMsFromUnixMs(1615569200000).value(),
+                     "s3://example/manifest_list.avro", summary2, {});
 
-  Snapshot snapshot3(67890, {}, 1, 1615569200000, "s3://example/manifest_list.avro",
-                     summary3, {});
+  Snapshot snapshot3(67890, {}, 1, TimePointMsFromUnixMs(1615569200000).value(),
+                     "s3://example/manifest_list.avro", summary3, {});
 
   EXPECT_EQ(snapshot1, snapshot2);
   EXPECT_NE(snapshot1, snapshot3);

--- a/test/sort_field_test.cc
+++ b/test/sort_field_test.cc
@@ -24,7 +24,6 @@
 #include <gtest/gtest.h>
 
 #include "iceberg/transform.h"
-#include "iceberg/type.h"
 #include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
 namespace iceberg {

--- a/test/transform_test.cc
+++ b/test/transform_test.cc
@@ -27,6 +27,7 @@
 
 #include "iceberg/type.h"
 #include "iceberg/util/formatter.h"  // IWYU pragma: keep
+#include "matchers.h"
 
 namespace iceberg {
 
@@ -112,7 +113,7 @@ TEST(TransformFromStringTest, NegativeCases) {
   for (const auto& str : invalid_cases) {
     auto result = TransformFromString(str);
     EXPECT_FALSE(result.has_value()) << "Unexpected success for: " << str;
-    EXPECT_EQ(result.error().kind, ErrorKind::kInvalidArgument);
+    EXPECT_THAT(result, IsError(ErrorKind::kInvalidArgument));
   }
 }
 


### PR DESCRIPTION
reduce direct unexpected usage by using more Error wrappers defined in result.h