### PR TITLE
For iceberg v1 PartitionSpec's PartitionField id can be optional

### DIFF
--- a/src/iceberg/json_internal.cc
+++ b/src/iceberg/json_internal.cc
@@ -1053,7 +1053,7 @@ Status ParsePartitionSpecs(const nlohmann::json& json, int8_t format_version,
     int32_t next_partition_field_id = PartitionSpec::kLegacyPartitionDataIdStart;
     std::vector<PartitionField> fields;
     for (const auto& entry_json : partition_spec_json) {
-      ICEBERG_ASSIGN_OR_RAISE(auto field, PartitionFieldFromJson(entry_json));
+      ICEBERG_ASSIGN_OR_RAISE(auto field, PartitionFieldFromJson(entry_json, true));
       int32_t field_id = field->field_id();
       if (field_id == SchemaField::kInvalidFieldId) {
         // If the field ID is not set, we need to assign a new one


### PR DESCRIPTION
Just looks like forget to use `allow_field_id_missing` in `PartitionFieldFromJson(const nlohmann::json& json, bool allow_field_id_missing)`

In v1 iceberg, we should allow field_id is missing.