### PR TITLE
refactor: remove explicit operator!= using C++20 rewrite candidates

### DIFF
--- a/src/iceberg/partition_field.h
+++ b/src/iceberg/partition_field.h
@@ -62,10 +62,6 @@ class ICEBERG_EXPORT PartitionField : public util::Formattable {
     return lhs.Equals(rhs);
   }
 
-  friend bool operator!=(const PartitionField& lhs, const PartitionField& rhs) {
-    return !(lhs == rhs);
-  }
-
  private:
   /// \brief Compare two fields for equality.
   [[nodiscard]] bool Equals(const PartitionField& other) const;

--- a/src/iceberg/partition_spec.h
+++ b/src/iceberg/partition_spec.h
@@ -75,10 +75,6 @@ class ICEBERG_EXPORT PartitionSpec : public util::Formattable {
     return lhs.Equals(rhs);
   }
 
-  friend bool operator!=(const PartitionSpec& lhs, const PartitionSpec& rhs) {
-    return !(lhs == rhs);
-  }
-
  private:
   /// \brief Compare two partition specs for equality.
   [[nodiscard]] bool Equals(const PartitionSpec& other) const;

--- a/src/iceberg/schema.h
+++ b/src/iceberg/schema.h
@@ -56,8 +56,6 @@ class ICEBERG_EXPORT Schema : public StructType {
 
   friend bool operator==(const Schema& lhs, const Schema& rhs) { return lhs.Equals(rhs); }
 
-  friend bool operator!=(const Schema& lhs, const Schema& rhs) { return !(lhs == rhs); }
-
  private:
   /// \brief Compare two schemas for equality.
   [[nodiscard]] bool Equals(const Schema& other) const;

--- a/src/iceberg/schema_field.h
+++ b/src/iceberg/schema_field.h
@@ -76,10 +76,6 @@ class ICEBERG_EXPORT SchemaField : public iceberg::util::Formattable {
     return lhs.Equals(rhs);
   }
 
-  friend bool operator!=(const SchemaField& lhs, const SchemaField& rhs) {
-    return !(lhs == rhs);
-  }
-
  private:
   /// \brief Compare two fields for equality.
   [[nodiscard]] bool Equals(const SchemaField& other) const;

--- a/src/iceberg/snapshot.h
+++ b/src/iceberg/snapshot.h
@@ -80,9 +80,6 @@ struct ICEBERG_EXPORT SnapshotRef {
       return lhs.Equals(rhs);
     }
 
-    /// \brief Compare two branches for inequality.
-    friend bool operator!=(const Branch& lhs, const Branch& rhs) { return !(lhs == rhs); }
-
    private:
     /// \brief Compare two branches for equality.
     bool Equals(const Branch& other) const;
@@ -96,9 +93,6 @@ struct ICEBERG_EXPORT SnapshotRef {
 
     /// \brief Compare two tags for equality.
     friend bool operator==(const Tag& lhs, const Tag& rhs) { return lhs.Equals(rhs); }
-
-    /// \brief Compare two tags for inequality.
-    friend bool operator!=(const Tag& lhs, const Tag& rhs) { return !(lhs == rhs); }
 
    private:
     /// \brief Compare two tags for equality.
@@ -115,11 +109,6 @@ struct ICEBERG_EXPORT SnapshotRef {
   /// \brief Compare two snapshot refs for equality
   friend bool operator==(const SnapshotRef& lhs, const SnapshotRef& rhs) {
     return lhs.Equals(rhs);
-  }
-
-  /// \brief Compare two snapshot refs for inequality.
-  friend bool operator!=(const SnapshotRef& lhs, const SnapshotRef& rhs) {
-    return !(lhs == rhs);
   }
 
  private:
@@ -261,11 +250,6 @@ struct ICEBERG_EXPORT Snapshot {
   /// \brief Compare two snapshots for equality.
   friend bool operator==(const Snapshot& lhs, const Snapshot& rhs) {
     return lhs.Equals(rhs);
-  }
-
-  /// \brief Compare two snapshots for inequality.
-  friend bool operator!=(const Snapshot& lhs, const Snapshot& rhs) {
-    return !(lhs == rhs);
   }
 
  private:

--- a/src/iceberg/sort_field.h
+++ b/src/iceberg/sort_field.h
@@ -113,10 +113,6 @@ class ICEBERG_EXPORT SortField : public util::Formattable {
     return lhs.Equals(rhs);
   }
 
-  friend bool operator!=(const SortField& lhs, const SortField& rhs) {
-    return !(lhs == rhs);
-  }
-
  private:
   /// \brief Compare two fields for equality.
   [[nodiscard]] bool Equals(const SortField& other) const;

--- a/src/iceberg/sort_order.h
+++ b/src/iceberg/sort_order.h
@@ -55,10 +55,6 @@ class ICEBERG_EXPORT SortOrder : public util::Formattable {
     return lhs.Equals(rhs);
   }
 
-  friend bool operator!=(const SortOrder& lhs, const SortOrder& rhs) {
-    return !(lhs == rhs);
-  }
-
  private:
   /// \brief Compare two sort orders for equality.
   bool Equals(const SortOrder& other) const;

--- a/src/iceberg/statistics_file.h
+++ b/src/iceberg/statistics_file.h
@@ -50,11 +50,6 @@ struct ICEBERG_EXPORT BlobMetadata {
            lhs.source_snapshot_sequence_number == rhs.source_snapshot_sequence_number &&
            lhs.fields == rhs.fields && lhs.properties == rhs.properties;
   }
-
-  /// \brief Compare two BlobMetadatas for inequality.
-  friend bool operator!=(const BlobMetadata& lhs, const BlobMetadata& rhs) {
-    return !(lhs == rhs);
-  }
 };
 
 /// \brief Represents a statistics file in the Puffin format
@@ -77,11 +72,6 @@ struct ICEBERG_EXPORT StatisticsFile {
            lhs.file_footer_size_in_bytes == rhs.file_footer_size_in_bytes &&
            lhs.blob_metadata == rhs.blob_metadata;
   }
-
-  /// \brief Compare two StatisticsFiles for inequality.
-  friend bool operator!=(const StatisticsFile& lhs, const StatisticsFile& rhs) {
-    return !(lhs == rhs);
-  }
 };
 
 /// \brief Represents a partition statistics file
@@ -99,12 +89,6 @@ struct ICEBERG_EXPORT PartitionStatisticsFile {
                          const PartitionStatisticsFile& rhs) {
     return lhs.snapshot_id == rhs.snapshot_id && lhs.path == rhs.path &&
            lhs.file_size_in_bytes == rhs.file_size_in_bytes;
-  }
-
-  /// \brief Compare two PartitionStatisticsFiles for inequality.
-  friend bool operator!=(const PartitionStatisticsFile& lhs,
-                         const PartitionStatisticsFile& rhs) {
-    return !(lhs == rhs);
   }
 };
 

--- a/src/iceberg/table_metadata.h
+++ b/src/iceberg/table_metadata.h
@@ -44,10 +44,6 @@ struct ICEBERG_EXPORT SnapshotLogEntry {
   friend bool operator==(const SnapshotLogEntry& lhs, const SnapshotLogEntry& rhs) {
     return lhs.timestamp_ms == rhs.timestamp_ms && lhs.snapshot_id == rhs.snapshot_id;
   }
-
-  friend bool operator!=(const SnapshotLogEntry& lhs, const SnapshotLogEntry& rhs) {
-    return !(lhs == rhs);
-  }
 };
 
 /// \brief Represents a metadata log entry
@@ -59,10 +55,6 @@ struct ICEBERG_EXPORT MetadataLogEntry {
 
   friend bool operator==(const MetadataLogEntry& lhs, const MetadataLogEntry& rhs) {
     return lhs.timestamp_ms == rhs.timestamp_ms && lhs.metadata_file == rhs.metadata_file;
-  }
-
-  friend bool operator!=(const MetadataLogEntry& lhs, const MetadataLogEntry& rhs) {
-    return !(lhs == rhs);
   }
 };
 
@@ -137,10 +129,6 @@ struct ICEBERG_EXPORT TableMetadata {
   Result<std::shared_ptr<SortOrder>> SortOrder() const;
 
   friend bool operator==(const TableMetadata& lhs, const TableMetadata& rhs);
-
-  friend bool operator!=(const TableMetadata& lhs, const TableMetadata& rhs) {
-    return !(lhs == rhs);
-  }
 };
 
 /// \brief Returns a string representation of a SnapshotLogEntry

--- a/src/iceberg/transform.h
+++ b/src/iceberg/transform.h
@@ -135,11 +135,6 @@ class ICEBERG_EXPORT Transform : public util::Formattable {
     return lhs.Equals(rhs);
   }
 
-  /// \brief Inequality comparison.
-  friend bool operator!=(const Transform& lhs, const Transform& rhs) {
-    return !(lhs == rhs);
-  }
-
  private:
   /// \brief Constructs a Transform of the specified type (for non-parametric types).
   /// \param transform_type The transform type (e.g., identity, year, day).
@@ -186,10 +181,6 @@ class ICEBERG_EXPORT TransformFunction {
 
   friend bool operator==(const TransformFunction& lhs, const TransformFunction& rhs) {
     return lhs.Equals(rhs);
-  }
-
-  friend bool operator!=(const TransformFunction& lhs, const TransformFunction& rhs) {
-    return !(lhs == rhs);
   }
 
  private:

--- a/src/iceberg/type.cc
+++ b/src/iceberg/type.cc
@@ -42,6 +42,7 @@ StructType::StructType(std::vector<SchemaField> fields) : fields_(std::move(fiel
 }
 
 TypeId StructType::type_id() const { return kTypeId; }
+
 std::string StructType::ToString() const {
   std::string repr = "struct<\n";
   for (const auto& field : fields_) {
@@ -59,7 +60,7 @@ std::optional<std::reference_wrapper<const SchemaField>> StructType::GetFieldByI
 }
 std::optional<std::reference_wrapper<const SchemaField>> StructType::GetFieldByIndex(
     int32_t index) const {
-  if (index < 0 || index >= static_cast<int>(fields_.size())) {
+  if (index < 0 || index >= static_cast<int32_t>(fields_.size())) {
     return std::nullopt;
   }
   return fields_[index];

--- a/src/iceberg/type.h
+++ b/src/iceberg/type.h
@@ -55,9 +55,6 @@ class ICEBERG_EXPORT Type : public iceberg::util::Formattable {
   /// \brief Compare two types for equality.
   friend bool operator==(const Type& lhs, const Type& rhs) { return lhs.Equals(rhs); }
 
-  /// \brief Compare two types for inequality.
-  friend bool operator!=(const Type& lhs, const Type& rhs) { return !(lhs == rhs); }
-
  protected:
   /// \brief Compare two types for equality.
   [[nodiscard]] virtual bool Equals(const Type& other) const = 0;


### PR DESCRIPTION
C++20 supports rewrite candidates, see https://en.cppreference.com/w/cpp/language/overload_resolution.html#Call_to_an_overloaded_operator

> For `x != y`, all member, non-member, and built-in `operator==`s found are added to the set, unless there is a matching `operator!=`.