### PR TITLE
feat: add spdlog dependency to implement logging

### DIFF
--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -283,6 +283,55 @@ function(resolve_nlohmann_json_dependency)
 endfunction()
 
 # ----------------------------------------------------------------------
+# spdlog
+
+function(resolve_spdlog_dependency)
+  prepare_fetchcontent()
+
+  find_package(Threads REQUIRED)
+
+  set(SPDLOG_USE_STD_FORMAT
+      ON
+      CACHE BOOL "" FORCE)
+  set(SPDLOG_BUILD_PIC
+      ON
+      CACHE BOOL "" FORCE)
+
+  fetchcontent_declare(spdlog
+                       ${FC_DECLARE_COMMON_OPTIONS}
+                       URL "https://github.com/gabime/spdlog/archive/refs/tags/v1.15.3.tar.gz"
+                           FIND_PACKAGE_ARGS
+                           NAMES
+                           spdlog
+                           CONFIG)
+  fetchcontent_makeavailable(spdlog)
+
+  if(spdlog_SOURCE_DIR)
+    set_target_properties(spdlog PROPERTIES OUTPUT_NAME "iceberg_vendored_spdlog"
+                                            POSITION_INDEPENDENT_CODE ON)
+    target_link_libraries(spdlog INTERFACE Threads::Threads)
+    install(TARGETS spdlog
+            EXPORT iceberg_targets
+            RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"
+            ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
+            LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
+    set(SPDLOG_VENDORED TRUE)
+  else()
+    set(SPDLOG_VENDORED FALSE)
+    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES spdlog)
+  endif()
+
+  list(APPEND ICEBERG_SYSTEM_DEPENDENCIES Threads)
+
+  set(ICEBERG_SYSTEM_DEPENDENCIES
+      ${ICEBERG_SYSTEM_DEPENDENCIES}
+      PARENT_SCOPE)
+  set(SPDLOG_VENDORED
+      ${SPDLOG_VENDORED}
+      PARENT_SCOPE)
+endfunction()
+
+# ----------------------------------------------------------------------
 # zlib
 
 function(resolve_zlib_dependency)
@@ -302,6 +351,7 @@ endfunction()
 resolve_zlib_dependency()
 resolve_nanoarrow_dependency()
 resolve_nlohmann_json_dependency()
+resolve_spdlog_dependency()
 
 if(ICEBERG_BUILD_BUNDLE)
   resolve_arrow_dependency()

--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -58,16 +58,24 @@ list(APPEND
      ICEBERG_STATIC_BUILD_INTERFACE_LIBS
      nanoarrow::nanoarrow
      nlohmann_json::nlohmann_json
+     spdlog::spdlog
      ZLIB::ZLIB)
 list(APPEND
      ICEBERG_SHARED_BUILD_INTERFACE_LIBS
      nanoarrow::nanoarrow
      nlohmann_json::nlohmann_json
+     spdlog::spdlog
      ZLIB::ZLIB)
-list(APPEND ICEBERG_STATIC_INSTALL_INTERFACE_LIBS "Iceberg::nanoarrow"
-     "Iceberg::nlohmann_json")
-list(APPEND ICEBERG_SHARED_INSTALL_INTERFACE_LIBS "Iceberg::nanoarrow"
-     "Iceberg::nlohmann_json")
+list(APPEND
+     ICEBERG_STATIC_INSTALL_INTERFACE_LIBS
+     "Iceberg::nanoarrow"
+     "Iceberg::nlohmann_json"
+     "$<IF:$<BOOL:${SPDLOG_VENDORED}>,Iceberg::spdlog,spdlog::spdlog>")
+list(APPEND
+     ICEBERG_SHARED_INSTALL_INTERFACE_LIBS
+     "Iceberg::nanoarrow"
+     "Iceberg::nlohmann_json"
+     "$<IF:$<BOOL:${SPDLOG_VENDORED}>,Iceberg::spdlog,spdlog::spdlog>")
 
 add_iceberg_lib(iceberg
                 SOURCES


### PR DESCRIPTION
Added `spdlog` as a third-party dependency to implement logger support. My plan is to add a logger interface so we don't expose `spdlog` symbols externally (just like what we did with `nanoarrow` and `nlohman-json`).
