### PR TITLE
feat: add in-memory FileIO backed by Arrow MockFileSystem

### DIFF
--- a/src/iceberg/arrow/arrow_fs_file_io.cc
+++ b/src/iceberg/arrow/arrow_fs_file_io.cc
@@ -17,11 +17,13 @@
  * under the License.
  */
 
-#include "iceberg/arrow/arrow_fs_file_io.h"
+#include <chrono>
 
 #include <arrow/filesystem/localfs.h>
+#include <arrow/filesystem/mockfs.h>
 
 #include "iceberg/arrow/arrow_error_transform_internal.h"
+#include "iceberg/arrow/arrow_fs_file_io_internal.h"
 
 namespace iceberg::arrow {
 
@@ -65,6 +67,15 @@ Status ArrowFileSystemFileIO::WriteFile(const std::string& file_location,
 Status ArrowFileSystemFileIO::DeleteFile(const std::string& file_location) {
   ICEBERG_ARROW_RETURN_NOT_OK(arrow_fs_->DeleteFile(file_location));
   return {};
+}
+
+std::unique_ptr<::arrow::fs::FileSystem> ArrowFileSystemFileIO::MakeMockFileIO() {
+  return std::make_unique<::arrow::fs::internal::MockFileSystem>(
+      std::chrono::system_clock::now());
+}
+
+std::unique_ptr<::arrow::fs::FileSystem> ArrowFileSystemFileIO::MakeLocalFileIO() {
+  return std::make_unique<::arrow::fs::LocalFileSystem>();
 }
 
 }  // namespace iceberg::arrow

--- a/src/iceberg/arrow/arrow_fs_file_io_internal.h
+++ b/src/iceberg/arrow/arrow_fs_file_io_internal.h
@@ -34,6 +34,12 @@ class ICEBERG_BUNDLE_EXPORT ArrowFileSystemFileIO : public FileIO {
   explicit ArrowFileSystemFileIO(std::shared_ptr<::arrow::fs::FileSystem> arrow_fs)
       : arrow_fs_(std::move(arrow_fs)) {}
 
+  /// \brief Make an in-memory FileIO backed by arrow::fs::internal::MockFileSystem.
+  static std::unique_ptr<::arrow::fs::FileSystem> MakeMockFileIO();
+
+  /// \brief Make a local FileIO backed by arrow::fs::LocalFileSystem.
+  static std::unique_ptr<::arrow::fs::FileSystem> MakeLocalFileIO();
+
   ~ArrowFileSystemFileIO() override = default;
 
   /// \brief Read the content of the file at the given location.

--- a/src/iceberg/avro/avro_reader.cc
+++ b/src/iceberg/avro/avro_reader.cc
@@ -31,7 +31,7 @@
 #include <avro/Generic.hh>
 #include <avro/GenericDatum.hh>
 
-#include "iceberg/arrow/arrow_fs_file_io.h"
+#include "iceberg/arrow/arrow_fs_file_io_internal.h"
 #include "iceberg/avro/avro_data_util_internal.h"
 #include "iceberg/avro/avro_schema_util_internal.h"
 #include "iceberg/avro/avro_stream_internal.h"

--- a/test/arrow_fs_file_io_test.cc
+++ b/test/arrow_fs_file_io_test.cc
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-#include "iceberg/arrow/arrow_fs_file_io.h"
-
 #include <arrow/filesystem/localfs.h>
 #include <gtest/gtest.h>
 
+#include "iceberg/arrow/arrow_fs_file_io_internal.h"
 #include "matchers.h"
 #include "temp_file_test_base.h"
 

--- a/test/avro_test.cc
+++ b/test/avro_test.cc
@@ -29,7 +29,7 @@
 #include <avro/GenericDatum.hh>
 #include <gtest/gtest.h>
 
-#include "iceberg/arrow/arrow_fs_file_io.h"
+#include "iceberg/arrow/arrow_fs_file_io_internal.h"
 #include "iceberg/avro/avro_reader.h"
 #include "iceberg/schema.h"
 #include "iceberg/type.h"

--- a/test/gzip_decompress_test.cc
+++ b/test/gzip_decompress_test.cc
@@ -23,7 +23,7 @@
 #include <arrow/util/compression.h>
 #include <gtest/gtest.h>
 
-#include "iceberg/arrow/arrow_fs_file_io.h"
+#include "iceberg/arrow/arrow_fs_file_io_internal.h"
 #include "iceberg/file_io.h"
 #include "iceberg/util/gzip_internal.h"
 #include "matchers.h"

--- a/test/manifest_list_reader_test.cc
+++ b/test/manifest_list_reader_test.cc
@@ -21,7 +21,7 @@
 #include <avro/GenericDatum.hh>
 #include <gtest/gtest.h>
 
-#include "iceberg/arrow/arrow_fs_file_io.h"
+#include "iceberg/arrow/arrow_fs_file_io_internal.h"
 #include "iceberg/avro/avro_reader.h"
 #include "iceberg/manifest_list.h"
 #include "iceberg/manifest_reader.h"

--- a/test/metadata_io_test.cc
+++ b/test/metadata_io_test.cc
@@ -24,7 +24,7 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
-#include "iceberg/arrow/arrow_fs_file_io.h"
+#include "iceberg/arrow/arrow_fs_file_io_internal.h"
 #include "iceberg/file_io.h"
 #include "iceberg/json_internal.h"
 #include "iceberg/schema.h"


### PR DESCRIPTION
Rename `arrow_fs_file_io.h` to `arrow_fs_file_io_internal.h` to avoid accidentally installing it.