### PR TITLE
fix: wrong header inclusion

### DIFF
--- a/test/in_memory_catalog_test.cc
+++ b/test/in_memory_catalog_test.cc
@@ -25,7 +25,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "iceberg/arrow/arrow_fs_file_io.h"
+#include "iceberg/arrow/arrow_fs_file_io_internal.h"
 #include "iceberg/table.h"
 #include "iceberg/table_metadata.h"
 #include "matchers.h"

--- a/test/manifest_reader_test.cc
+++ b/test/manifest_reader_test.cc
@@ -22,7 +22,7 @@
 #include <arrow/filesystem/localfs.h>
 #include <gtest/gtest.h>
 
-#include "iceberg/arrow/arrow_fs_file_io.h"
+#include "iceberg/arrow/arrow_fs_file_io_internal.h"
 #include "iceberg/avro/avro_reader.h"
 #include "iceberg/avro/avro_register.h"
 #include "iceberg/avro/avro_schema_util_internal.h"


### PR DESCRIPTION
PR #148 renames arrow_fs_file_io.h to arrow_fs_file_io_internal.h, Since CI does not re-run after a PR is merged, conflicts arose with other PR changes, thus the CI failure on main branch.