### PR TITLE
style: Improve BuildTable signature readability

### DIFF
--- a/src/iceberg/catalog.h
+++ b/src/iceberg/catalog.h
@@ -176,15 +176,6 @@ class ICEBERG_EXPORT Catalog {
   virtual Result<std::shared_ptr<Table>> RegisterTable(
       const TableIdentifier& identifier, const std::string& metadata_file_location) = 0;
 
-  /// \brief Instantiate a builder to either create a table or start a create/replace
-  /// transaction
-  ///
-  /// \param identifier a table identifier
-  /// \param schema a schema
-  /// \return the builder to create a table or start a create/replace transaction
-  virtual std::unique_ptr<class TableBuilder> BuildTable(
-      const TableIdentifier& identifier, const Schema& schema) const = 0;
-
   /// \brief A builder used to create valid tables or start create/replace transactions
   class TableBuilder {
    public:
@@ -233,6 +224,16 @@ class ICEBERG_EXPORT Catalog {
     /// \return the Transaction to create the table
     virtual std::unique_ptr<Transaction> StageCreate() = 0;
   };
+
+  /// \brief Instantiate a builder to either create a table or start a create/replace
+  /// transaction
+  ///
+  /// \param identifier a table identifier
+  /// \param schema a schema
+  /// \return the builder to create a table or start a create/replace transaction
+  virtual std::unique_ptr<class TableBuilder> BuildTable(
+    const TableIdentifier& identifier, const Schema& schema) const = 0;
+
 };
 
 }  // namespace iceberg

--- a/src/iceberg/catalog/in_memory_catalog.cc
+++ b/src/iceberg/catalog/in_memory_catalog.cc
@@ -441,7 +441,7 @@ Result<std::shared_ptr<Table>> InMemoryCatalog::RegisterTable(
   return LoadTable(identifier);
 }
 
-std::unique_ptr<TableBuilder> InMemoryCatalog::BuildTable(
+std::unique_ptr<iceberg::Catalog::TableBuilder> InMemoryCatalog::BuildTable(
     const TableIdentifier& identifier, const Schema& schema) const {
   throw IcebergError("not implemented");
 }

--- a/src/iceberg/catalog/in_memory_catalog.h
+++ b/src/iceberg/catalog/in_memory_catalog.h
@@ -90,7 +90,7 @@ class ICEBERG_EXPORT InMemoryCatalog
       const TableIdentifier& identifier,
       const std::string& metadata_file_location) override;
 
-  std::unique_ptr<iceberg::TableBuilder> BuildTable(const TableIdentifier& identifier,
+  std::unique_ptr<iceberg::Catalog::TableBuilder> BuildTable(const TableIdentifier& identifier,
                                                     const Schema& schema) const override;
 
  private:


### PR DESCRIPTION
Removes the confusing inline class TableBuilder forward declaration from the BuildTable method.
Replaces it with a standard forward declaration at the namespace level for better clarity.