### PR TITLE
refactor: default equality operators for statistic file structs

### DIFF
--- a/src/iceberg/statistics_file.h
+++ b/src/iceberg/statistics_file.h
@@ -45,11 +45,7 @@ struct ICEBERG_EXPORT BlobMetadata {
   std::unordered_map<std::string, std::string> properties;
 
   /// \brief Compare two BlobMetadatas for equality.
-  friend bool operator==(const BlobMetadata& lhs, const BlobMetadata& rhs) {
-    return lhs.type == rhs.type && lhs.source_snapshot_id == rhs.source_snapshot_id &&
-           lhs.source_snapshot_sequence_number == rhs.source_snapshot_sequence_number &&
-           lhs.fields == rhs.fields && lhs.properties == rhs.properties;
-  }
+  friend bool operator==(const BlobMetadata& lhs, const BlobMetadata& rhs) = default;
 };
 
 /// \brief Represents a statistics file in the Puffin format
@@ -66,12 +62,7 @@ struct ICEBERG_EXPORT StatisticsFile {
   std::vector<BlobMetadata> blob_metadata;
 
   /// \brief Compare two StatisticsFiles for equality.
-  friend bool operator==(const StatisticsFile& lhs, const StatisticsFile& rhs) {
-    return lhs.snapshot_id == rhs.snapshot_id && lhs.path == rhs.path &&
-           lhs.file_size_in_bytes == rhs.file_size_in_bytes &&
-           lhs.file_footer_size_in_bytes == rhs.file_footer_size_in_bytes &&
-           lhs.blob_metadata == rhs.blob_metadata;
-  }
+  friend bool operator==(const StatisticsFile& lhs, const StatisticsFile& rhs) = default;
 };
 
 /// \brief Represents a partition statistics file
@@ -86,10 +77,7 @@ struct ICEBERG_EXPORT PartitionStatisticsFile {
 
   /// \brief Compare two PartitionStatisticsFiles for equality.
   friend bool operator==(const PartitionStatisticsFile& lhs,
-                         const PartitionStatisticsFile& rhs) {
-    return lhs.snapshot_id == rhs.snapshot_id && lhs.path == rhs.path &&
-           lhs.file_size_in_bytes == rhs.file_size_in_bytes;
-  }
+                         const PartitionStatisticsFile& rhs) = default;
 };
 
 /// \brief Returns a string representation of a BlobMetadata


### PR DESCRIPTION
Elsewhere in the project, equality operators are defaulted e.g.

https://github.com/apache/iceberg-cpp/blob/9f13bac62617e5b457be894e9f17eb89c78a0adb/src/iceberg/manifest_list.h#L196

I think for consistency, the `src/iceberg/statistics_file.h` equality operators can be defaulted too, as they do memberwise comparisons using each type's `operator==`.

(I'm new to this project, so please take with a pinch of salt 😄)