### PR TITLE
feat: implement schema selection and projection methods

### DIFF
--- a/src/iceberg/schema.cc
+++ b/src/iceberg/schema.cc
@@ -257,4 +257,259 @@ void NameToIdVisitor::Finish() {
   }
 }
 
+class PruneColumnVisitor {
+ public:
+  explicit PruneColumnVisitor(const std::unordered_set<int32_t>& selected_ids,
+                              bool select_full_types = false);
+  Status Visit(const ListType& type);
+  Status Visit(const MapType& type);
+  Status Visit(const StructType& type);
+  Status Visit(const PrimitiveType& type);
+  std::shared_ptr<const Type> GetResult() const;
+  void SetResult(std::shared_ptr<const Type> result);
+  Status ProjectList(const SchemaField& element,
+                     std::shared_ptr<const Type> element_result);
+  Status ProjectMap(const SchemaField& key_field, const SchemaField& value_field,
+                    std::shared_ptr<const Type> value_result);
+
+ private:
+  const std::unordered_set<int32_t>& selected_ids_;
+  bool select_full_types_;
+  std::shared_ptr<const Type> result_;
+};
+
+Result<std::shared_ptr<const Schema>> Schema::select(
+    const std::vector<std::string>& names, bool case_sensitive) const {
+  return internalSelect(names, case_sensitive);
+}
+
+Result<std::shared_ptr<const Schema>> Schema::select(
+    const std::initializer_list<std::string>& names, bool case_sensitive) const {
+  return internalSelect(std::vector<std::string>(names), case_sensitive);
+}
+
+Result<std::shared_ptr<const Schema>> Schema::internalSelect(
+    const std::vector<std::string>& names, bool case_sensitive) const {
+  const std::string ALL_COLUMNS = "*";
+  if (std::ranges::find(names, ALL_COLUMNS) != names.end()) {
+    return shared_from_this();
+  }
+
+  std::unordered_set<int32_t> selected_ids;
+  for (const auto& name : names) {
+    ICEBERG_ASSIGN_OR_RAISE(auto result, FindFieldByName(name, case_sensitive));
+    if (result.has_value()) {
+      selected_ids.insert(result.value().get().field_id());
+    }
+  }
+
+  PruneColumnVisitor visitor(selected_ids, /*select_full_types=*/true);
+  ICEBERG_RETURN_UNEXPECTED(VisitTypeInline(*this, &visitor));
+
+  auto projected_type = visitor.GetResult();
+  if (!projected_type) {
+    return std::make_shared<Schema>(std::vector<SchemaField>{}, schema_id_);
+  }
+
+  if (projected_type->type_id() != TypeId::kStruct) {
+    return InvalidSchema("Projected type must be a struct type");
+  }
+
+  const auto& projected_struct =
+      internal::checked_cast<const StructType&>(*projected_type);
+
+  std::vector<SchemaField> fields_vec(projected_struct.fields().begin(),
+                                      projected_struct.fields().end());
+  return std::make_shared<Schema>(std::move(fields_vec), schema_id_);
+}
+
+Result<std::shared_ptr<const Schema>> Schema::project(
+    std::unordered_set<int32_t>& selected_ids) const {
+  PruneColumnVisitor visitor(selected_ids, /*select_full_types=*/false);
+  ICEBERG_RETURN_UNEXPECTED(VisitTypeInline(*this, &visitor));
+
+  auto projected_type = visitor.GetResult();
+  if (!projected_type) {
+    return std::make_shared<Schema>(std::vector<SchemaField>{}, schema_id_);
+  }
+
+  if (projected_type->type_id() != TypeId::kStruct) {
+    return InvalidSchema("Projected type must be a struct type");
+  }
+
+  const auto& projected_struct =
+      internal::checked_cast<const StructType&>(*projected_type);
+  std::vector<SchemaField> fields_vec(projected_struct.fields().begin(),
+                                      projected_struct.fields().end());
+  return std::make_shared<Schema>(std::move(fields_vec), schema_id_);
+}
+
+PruneColumnVisitor::PruneColumnVisitor(const std::unordered_set<int32_t>& selected_ids,
+                                       bool select_full_types)
+    : selected_ids_(selected_ids), select_full_types_(select_full_types) {}
+
+std::shared_ptr<const Type> PruneColumnVisitor::GetResult() const { return result_; }
+
+void PruneColumnVisitor::SetResult(std::shared_ptr<const Type> result) {
+  result_ = std::move(result);
+}
+
+Status PruneColumnVisitor::Visit(const StructType& type) {
+  std::vector<std::shared_ptr<const Type>> selected_types;
+  const auto& fields = type.fields();
+  for (const auto& field : fields) {
+    PruneColumnVisitor field_visitor(selected_ids_, select_full_types_);
+    ICEBERG_RETURN_UNEXPECTED(VisitTypeInline(*field.type(), &field_visitor));
+    auto result = field_visitor.GetResult();
+    if (selected_ids_.contains(field.field_id())) {
+      // select
+      if (select_full_types_) {
+        selected_types.emplace_back(field.type());
+      } else if (field.type()->type_id() == TypeId::kStruct) {
+        // project(kstruct)
+        if (!result) {
+          result = std::make_shared<StructType>(std::vector<SchemaField>{});
+        }
+        selected_types.emplace_back(std::move(result));
+      } else {
+        // project(list, map, primitive)
+        if (!field.type()->is_primitive()) {
+          return InvalidArgument(
+              "Cannot explicitly project List or Map types, {}:{} of type {} was "
+              "selected",
+              field.field_id(), field.name(), field.type()->ToString());
+        }
+        selected_types.emplace_back(field.type());
+      }
+    } else if (result) {
+      // project, select
+      selected_types.emplace_back(std::move(result));
+    } else {
+      // project, select
+      selected_types.emplace_back(nullptr);
+    }
+  }
+
+  bool same_types = true;
+  std::vector<SchemaField> selected_fields;
+  for (size_t i = 0; i < fields.size(); i++) {
+    if (fields[i].type() == selected_types[i]) {
+      selected_fields.emplace_back(fields[i]);
+    } else if (selected_types[i]) {
+      same_types = false;
+      selected_fields.emplace_back(fields[i].field_id(), std::string(fields[i].name()),
+                                   std::const_pointer_cast<Type>(selected_types[i]),
+                                   fields[i].optional(), std::string(fields[i].doc()));
+    }
+  }
+
+  if (!selected_fields.empty()) {
+    if (selected_fields.size() == fields.size() && same_types) {
+      result_ = std::make_shared<StructType>(type);
+    } else {
+      result_ = std::make_shared<StructType>(std::move(selected_fields));
+    }
+  }
+
+  return {};
+}
+
+Status PruneColumnVisitor::Visit(const ListType& type) {
+  const auto& element_field = type.fields()[0];
+
+  PruneColumnVisitor element_visitor(selected_ids_, select_full_types_);
+  ICEBERG_RETURN_UNEXPECTED(VisitTypeInline(*element_field.type(), &element_visitor));
+
+  auto element_result = element_visitor.GetResult();
+
+  if (selected_ids_.contains(element_field.field_id())) {
+    if (select_full_types_) {
+      result_ = std::make_shared<ListType>(element_field);
+    } else if (element_field.type()->type_id() == TypeId::kStruct) {
+      ICEBERG_RETURN_UNEXPECTED(ProjectList(element_field, element_result));
+    } else {
+      if (!element_field.type()->is_primitive()) {
+        return InvalidArgument(
+            "Cannot explicitly project List or Map types, List element {} of type {} was "
+            "selected",
+            element_field.field_id(), element_field.name());
+      }
+      result_ = std::make_shared<ListType>(element_field);
+    }
+  } else if (element_result) {
+    ICEBERG_RETURN_UNEXPECTED(ProjectList(element_field, element_result));
+  }
+
+  return {};
+}
+
+Status PruneColumnVisitor::Visit(const MapType& type) {
+  const auto& key_field = type.fields()[0];
+  const auto& value_field = type.fields()[1];
+
+  PruneColumnVisitor key_visitor(selected_ids_, select_full_types_);
+  ICEBERG_RETURN_UNEXPECTED(VisitTypeInline(*key_field.type(), &key_visitor));
+  auto key_result = key_visitor.GetResult();
+
+  PruneColumnVisitor value_visitor(selected_ids_, select_full_types_);
+  ICEBERG_RETURN_UNEXPECTED(VisitTypeInline(*value_field.type(), &value_visitor));
+  auto value_result = value_visitor.GetResult();
+
+  if (selected_ids_.contains(value_field.field_id())) {
+    if (select_full_types_) {
+      result_ = std::make_shared<MapType>(type);
+    } else if (value_field.type()->type_id() == TypeId::kStruct) {
+      ICEBERG_RETURN_UNEXPECTED(ProjectMap(key_field, value_field, value_result));
+    } else {
+      if (!value_field.type()->is_primitive()) {
+        return InvalidArgument(
+            "Cannot explicitly project List or Map types, Map value {} of type {} was "
+            "selected",
+            value_field.field_id(), type.ToString());
+      }
+      result_ = std::make_shared<MapType>(type);
+    }
+  } else if (value_result) {
+    ICEBERG_RETURN_UNEXPECTED(ProjectMap(key_field, value_field, value_result));
+  } else if (selected_ids_.contains(key_field.field_id())) {
+    result_ = std::make_shared<MapType>(type);
+  }
+
+  return {};
+}
+
+Status PruneColumnVisitor::Visit(const PrimitiveType& type) { return {}; }
+
+Status PruneColumnVisitor::ProjectList(const SchemaField& element_field,
+                                       std::shared_ptr<const Type> element_result) {
+  if (!element_result) {
+    return InvalidArgument("Cannot project a list when the element result is null");
+  }
+  if (element_field.type() == element_result) {
+    result_ = std::make_shared<ListType>(element_field);
+  } else {
+    result_ = std::make_shared<ListType>(element_field.field_id(),
+                                         std::const_pointer_cast<Type>(element_result),
+                                         element_field.optional());
+  }
+  return {};
+}
+
+Status PruneColumnVisitor::ProjectMap(const SchemaField& key_field,
+                                      const SchemaField& value_field,
+                                      std::shared_ptr<const Type> value_result) {
+  if (!value_result) {
+    return InvalidArgument("Attempted to project a map without a defined map value type");
+  }
+  if (value_field.type() == value_result) {
+    result_ = std::make_shared<MapType>(key_field, value_field);
+  } else {
+    result_ = std::make_shared<MapType>(
+        key_field,
+        SchemaField(value_field.field_id(), std::string(value_field.name()),
+                    std::const_pointer_cast<Type>(value_result), value_field.optional()));
+  }
+  return {};
+}
+
 }  // namespace iceberg

--- a/src/iceberg/schema.h
+++ b/src/iceberg/schema.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "iceberg/iceberg_export.h"
@@ -41,7 +42,8 @@ namespace iceberg {
 /// A schema is a list of typed columns, along with a unique integer ID.  A
 /// Table may have different schemas over its lifetime due to schema
 /// evolution.
-class ICEBERG_EXPORT Schema : public StructType {
+class ICEBERG_EXPORT Schema : public StructType,
+                              public std::enable_shared_from_this<Schema> {
  public:
   static constexpr int32_t kInitialSchemaId = 0;
 
@@ -52,9 +54,9 @@ class ICEBERG_EXPORT Schema : public StructType {
   ///
   /// A schema is identified by a unique ID for the purposes of schema
   /// evolution.
-  [[nodiscard]] std::optional<int32_t> schema_id() const;
+  std::optional<int32_t> schema_id() const;
 
-  [[nodiscard]] std::string ToString() const override;
+  std::string ToString() const override;
 
   /// \brief Find the SchemaField by field name.
   ///
@@ -65,18 +67,40 @@ class ICEBERG_EXPORT Schema : public StructType {
   /// canonical name 'm.value.x'
   /// FIXME: Currently only handles ASCII lowercase conversion; extend to support
   /// non-ASCII characters (e.g., using std::towlower or ICU)
-  [[nodiscard]] Result<std::optional<std::reference_wrapper<const SchemaField>>>
-  FindFieldByName(std::string_view name, bool case_sensitive = true) const;
+  Result<std::optional<std::reference_wrapper<const SchemaField>>> FindFieldByName(
+      std::string_view name, bool case_sensitive = true) const;
 
   /// \brief Find the SchemaField by field id.
-  [[nodiscard]] Result<std::optional<std::reference_wrapper<const SchemaField>>>
-  FindFieldById(int32_t field_id) const;
+  Result<std::optional<std::reference_wrapper<const SchemaField>>> FindFieldById(
+      int32_t field_id) const;
+
+  /// \brief Creates a projection schema for a subset of columns, selected by name.
+  Result<std::shared_ptr<const Schema>> select(const std::vector<std::string>& names,
+                                               bool case_sensitive = true) const;
+
+  /// \brief Creates a projection schema for a subset of columns, selected by name.
+  Result<std::shared_ptr<const Schema>> select(
+      const std::initializer_list<std::string>& names, bool case_sensitive = true) const;
+
+  /// \brief Creates a projection schema for a subset of columns, selected by name.
+  template <typename... Args>
+  Result<std::shared_ptr<const Schema>> select(Args&&... names,
+                                               bool case_sensitive = true) const {
+    static_assert((std::is_convertible_v<Args, std::string> && ...),
+                  "All arguments must be convertible to std::string");
+    return select({std::string(names)...}, case_sensitive);
+  }
+
+  Result<std::shared_ptr<const Schema>> project(std::unordered_set<int32_t>& ids) const;
 
   friend bool operator==(const Schema& lhs, const Schema& rhs) { return lhs.Equals(rhs); }
 
  private:
   /// \brief Compare two schemas for equality.
   [[nodiscard]] bool Equals(const Schema& other) const;
+
+  Result<std::shared_ptr<const Schema>> internalSelect(
+      const std::vector<std::string>& names, bool case_sensitive) const;
 
   // TODO(nullccxsy): Address potential concurrency issues in lazy initialization (e.g.,
   // use std::call_once)

--- a/test/schema_test.cc
+++ b/test/schema_test.cc
@@ -25,8 +25,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "iceberg/result.h"
 #include "iceberg/schema_field.h"
 #include "iceberg/util/formatter.h"  // IWYU pragma: keep
+#include "matchers.h"
 
 TEST(SchemaTest, Basics) {
   {
@@ -491,3 +493,792 @@ TEST(SchemaTest, NestedDuplicateFieldIdError) {
   EXPECT_THAT(result.error().message,
               ::testing::HasSubstr("Duplicate field id found: 1"));
 }
+
+struct SelectTestParam {
+  std::string test_name;
+  std::function<std::shared_ptr<iceberg::Schema>()> create_schema;
+  std::vector<std::string> select_fields;
+  std::function<std::shared_ptr<iceberg::Schema>()> expected_schema;
+  bool should_succeed;
+  std::string expected_error_message;
+  bool case_sensitive = true;
+};
+
+class SelectParamTest : public ::testing::TestWithParam<SelectTestParam> {};
+
+TEST_P(SelectParamTest, SelectFields) {
+  const auto& param = GetParam();
+  auto input_schema = param.create_schema();
+
+  auto result = input_schema->select(param.select_fields, param.case_sensitive);
+
+  if (param.should_succeed) {
+    ASSERT_TRUE(result.has_value()) << "Select should succeed for: " << param.test_name;
+
+    auto actual_schema = result.value();
+    auto expected_schema = param.expected_schema();
+    ASSERT_EQ(*actual_schema, *expected_schema)
+        << "Schema mismatch for: " << param.test_name;
+  } else {
+    ASSERT_FALSE(result.has_value()) << "Select should fail for: " << param.test_name;
+    ASSERT_THAT(result, iceberg::IsError(iceberg::ErrorKind::kInvalidArgument))
+        << "Should return InvalidArgument error for: " << param.test_name;
+
+    ASSERT_THAT(result, iceberg::HasErrorMessage(param.expected_error_message))
+        << "Error message mismatch for: " << param.test_name;
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SelectTestCases, SelectParamTest,
+    ::testing::Values(
+        SelectTestParam{.test_name = "SelectAllColumns",
+                        .create_schema =
+                            []() {
+                              auto field1 = std::make_unique<iceberg::SchemaField>(
+                                  1, "id", iceberg::int32(), false);
+                              auto field2 = std::make_unique<iceberg::SchemaField>(
+                                  2, "name", iceberg::string(), true);
+                              auto field3 = std::make_unique<iceberg::SchemaField>(
+                                  3, "age", iceberg::int32(), true);
+                              auto field4 = std::make_unique<iceberg::SchemaField>(
+                                  4, "email", iceberg::string(), true);
+                              return std::make_shared<iceberg::Schema>(
+                                  std::vector<iceberg::SchemaField>{*field1, *field2,
+                                                                    *field3, *field4},
+                                  100);
+                            },
+                        .select_fields = {"*"},
+                        .expected_schema =
+                            []() {
+                              auto field1 = std::make_unique<iceberg::SchemaField>(
+                                  1, "id", iceberg::int32(), false);
+                              auto field2 = std::make_unique<iceberg::SchemaField>(
+                                  2, "name", iceberg::string(), true);
+                              auto field3 = std::make_unique<iceberg::SchemaField>(
+                                  3, "age", iceberg::int32(), true);
+                              auto field4 = std::make_unique<iceberg::SchemaField>(
+                                  4, "email", iceberg::string(), true);
+                              return std::make_shared<iceberg::Schema>(
+                                  std::vector<iceberg::SchemaField>{*field1, *field2,
+                                                                    *field3, *field4},
+                                  100);
+                            },
+                        .should_succeed = true},
+
+        SelectTestParam{.test_name = "SelectSingleField",
+                        .create_schema =
+                            []() {
+                              auto field1 = std::make_unique<iceberg::SchemaField>(
+                                  1, "id", iceberg::int32(), false);
+                              auto field2 = std::make_unique<iceberg::SchemaField>(
+                                  2, "name", iceberg::string(), true);
+                              auto field3 = std::make_unique<iceberg::SchemaField>(
+                                  3, "age", iceberg::int32(), true);
+                              auto field4 = std::make_unique<iceberg::SchemaField>(
+                                  4, "email", iceberg::string(), true);
+                              return std::make_shared<iceberg::Schema>(
+                                  std::vector<iceberg::SchemaField>{*field1, *field2,
+                                                                    *field3, *field4},
+                                  100);
+                            },
+                        .select_fields = {"name"},
+                        .expected_schema =
+                            []() {
+                              auto field = std::make_unique<iceberg::SchemaField>(
+                                  2, "name", iceberg::string(), true);
+                              return std::make_shared<iceberg::Schema>(
+                                  std::vector<iceberg::SchemaField>{*field}, 100);
+                            },
+                        .should_succeed = true},
+
+        SelectTestParam{
+            .test_name = "SelectMultipleFields",
+            .create_schema =
+                []() {
+                  auto field1 = std::make_unique<iceberg::SchemaField>(
+                      1, "id", iceberg::int32(), false);
+                  auto field2 = std::make_unique<iceberg::SchemaField>(
+                      2, "name", iceberg::string(), true);
+                  auto field3 = std::make_unique<iceberg::SchemaField>(
+                      3, "age", iceberg::int32(), true);
+                  auto field4 = std::make_unique<iceberg::SchemaField>(
+                      4, "email", iceberg::string(), true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*field1, *field2, *field3,
+                                                        *field4},
+                      100);
+                },
+            .select_fields = {"id", "name", "age"},
+            .expected_schema =
+                []() {
+                  auto field1 = std::make_unique<iceberg::SchemaField>(
+                      1, "id", iceberg::int32(), false);
+                  auto field2 = std::make_unique<iceberg::SchemaField>(
+                      2, "name", iceberg::string(), true);
+                  auto field3 = std::make_unique<iceberg::SchemaField>(
+                      3, "age", iceberg::int32(), true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*field1, *field2, *field3}, 100);
+                },
+            .should_succeed = true},
+
+        SelectTestParam{.test_name = "SelectNonExistentField",
+                        .create_schema =
+                            []() {
+                              auto field1 = std::make_unique<iceberg::SchemaField>(
+                                  1, "id", iceberg::int32(), false);
+                              auto field2 = std::make_unique<iceberg::SchemaField>(
+                                  2, "name", iceberg::string(), true);
+                              auto field3 = std::make_unique<iceberg::SchemaField>(
+                                  3, "age", iceberg::int32(), true);
+                              auto field4 = std::make_unique<iceberg::SchemaField>(
+                                  4, "email", iceberg::string(), true);
+                              return std::make_shared<iceberg::Schema>(
+                                  std::vector<iceberg::SchemaField>{*field1, *field2,
+                                                                    *field3, *field4},
+                                  100);
+                            },
+                        .select_fields = {"nonexistent"},
+                        .expected_schema =
+                            []() {
+                              return std::make_shared<iceberg::Schema>(
+                                  std::vector<iceberg::SchemaField>{}, 100);
+                            },
+                        .should_succeed = true},
+
+        SelectTestParam{.test_name = "SelectCaseSensitive",
+                        .create_schema =
+                            []() {
+                              auto field1 = std::make_unique<iceberg::SchemaField>(
+                                  1, "id", iceberg::int32(), false);
+                              auto field2 = std::make_unique<iceberg::SchemaField>(
+                                  2, "name", iceberg::string(), true);
+                              auto field3 = std::make_unique<iceberg::SchemaField>(
+                                  3, "age", iceberg::int32(), true);
+                              auto field4 = std::make_unique<iceberg::SchemaField>(
+                                  4, "email", iceberg::string(), true);
+                              return std::make_shared<iceberg::Schema>(
+                                  std::vector<iceberg::SchemaField>{*field1, *field2,
+                                                                    *field3, *field4},
+                                  100);
+                            },
+                        .select_fields = {"Name"},  // case-sensitive
+                        .expected_schema =
+                            []() {
+                              return std::make_shared<iceberg::Schema>(
+                                  std::vector<iceberg::SchemaField>{}, 100);
+                            },
+                        .should_succeed = true},
+
+        SelectTestParam{.test_name = "SelectCaseInsensitive",
+                        .create_schema =
+                            []() {
+                              auto field1 = std::make_unique<iceberg::SchemaField>(
+                                  1, "id", iceberg::int32(), false);
+                              auto field2 = std::make_unique<iceberg::SchemaField>(
+                                  2, "name", iceberg::string(), true);
+                              auto field3 = std::make_unique<iceberg::SchemaField>(
+                                  3, "age", iceberg::int32(), true);
+                              auto field4 = std::make_unique<iceberg::SchemaField>(
+                                  4, "email", iceberg::string(), true);
+                              return std::make_shared<iceberg::Schema>(
+                                  std::vector<iceberg::SchemaField>{*field1, *field2,
+                                                                    *field3, *field4},
+                                  100);
+                            },
+                        .select_fields = {"Name"},  // case-insensitive
+                        .expected_schema =
+                            []() {
+                              auto field = std::make_unique<iceberg::SchemaField>(
+                                  2, "name", iceberg::string(), true);
+                              return std::make_shared<iceberg::Schema>(
+                                  std::vector<iceberg::SchemaField>{*field}, 100);
+                            },
+                        .should_succeed = true,
+                        .case_sensitive = false}));
+
+INSTANTIATE_TEST_SUITE_P(
+    SelectNestedTestCases, SelectParamTest,
+    ::testing::Values(
+        SelectTestParam{
+            .test_name = "SelectTopLevelFields",
+            .create_schema =
+                []() {
+                  auto nested_field1 = std::make_unique<iceberg::SchemaField>(
+                      1, "street", iceberg::string(), true);
+                  auto nested_field2 = std::make_unique<iceberg::SchemaField>(
+                      2, "city", iceberg::string(), true);
+                  auto nested_field3 = std::make_unique<iceberg::SchemaField>(
+                      3, "zip", iceberg::int32(), true);
+                  auto address_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*nested_field1, *nested_field2,
+                                                        *nested_field3});
+                  auto field1 = std::make_unique<iceberg::SchemaField>(
+                      4, "id", iceberg::int32(), false);
+                  auto field2 = std::make_unique<iceberg::SchemaField>(
+                      5, "name", iceberg::string(), true);
+                  auto field3 = std::make_unique<iceberg::SchemaField>(
+                      6, "address", address_type, true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*field1, *field2, *field3}, 200);
+                },
+            .select_fields = {"id", "name"},
+            .expected_schema =
+                []() {
+                  auto field1 = std::make_unique<iceberg::SchemaField>(
+                      4, "id", iceberg::int32(), false);
+                  auto field2 = std::make_unique<iceberg::SchemaField>(
+                      5, "name", iceberg::string(), true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*field1, *field2}, 200);
+                },
+            .should_succeed = true},
+
+        SelectTestParam{
+            .test_name = "SelectNestedField",
+            .create_schema =
+                []() {
+                  auto nested_field1 = std::make_unique<iceberg::SchemaField>(
+                      1, "street", iceberg::string(), true);
+                  auto nested_field2 = std::make_unique<iceberg::SchemaField>(
+                      2, "city", iceberg::string(), true);
+                  auto nested_field3 = std::make_unique<iceberg::SchemaField>(
+                      3, "zip", iceberg::int32(), true);
+                  auto address_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*nested_field1, *nested_field2,
+                                                        *nested_field3});
+                  auto field1 = std::make_unique<iceberg::SchemaField>(
+                      4, "id", iceberg::int32(), false);
+                  auto field2 = std::make_unique<iceberg::SchemaField>(
+                      5, "name", iceberg::string(), true);
+                  auto field3 = std::make_unique<iceberg::SchemaField>(
+                      6, "address", address_type, true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*field1, *field2, *field3}, 200);
+                },
+            .select_fields = {"address.street"},
+            .expected_schema =
+                []() {
+                  auto street_field = std::make_unique<iceberg::SchemaField>(
+                      1, "street", iceberg::string(), true);
+                  auto address_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*street_field});
+                  auto address_field = std::make_unique<iceberg::SchemaField>(
+                      6, "address", address_type, true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*address_field}, 200);
+                },
+            .should_succeed = true}));
+
+INSTANTIATE_TEST_SUITE_P(
+    SelectMultiLevelTestCases, SelectParamTest,
+    ::testing::Values(
+        SelectTestParam{
+            .test_name = "SelectTopLevelAndNestedFields",
+            .create_schema =
+                []() {
+                  // {id: int, user: {name: string, address: {street: string, city:
+                  // string}}}
+                  auto street_field = std::make_unique<iceberg::SchemaField>(
+                      1, "street", iceberg::string(), true);
+                  auto city_field = std::make_unique<iceberg::SchemaField>(
+                      2, "city", iceberg::string(), true);
+                  auto address_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*street_field, *city_field});
+                  auto address_field = std::make_unique<iceberg::SchemaField>(
+                      3, "address", address_type, true);
+
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      4, "name", iceberg::string(), true);
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field, *address_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(5, "user", user_type, true);
+
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      6, "id", iceberg::int32(), false);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *user_field}, 300);
+                },
+            .select_fields = {"id", "user.name", "user.address.street"},
+            .expected_schema =
+                []() {
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      6, "id", iceberg::int32(), false);
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      4, "name", iceberg::string(), true);
+                  auto street_field = std::make_unique<iceberg::SchemaField>(
+                      1, "street", iceberg::string(), true);
+                  auto address_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*street_field});
+                  auto address_field = std::make_unique<iceberg::SchemaField>(
+                      3, "address", address_type, true);
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field, *address_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(5, "user", user_type, true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *user_field}, 300);
+                },
+            .should_succeed = true},
+
+        SelectTestParam{
+            .test_name = "SelectNestedFieldsAtDifferentLevels",
+            .create_schema =
+                []() {
+                  // {id: int, user: {profile: {name: string, age: int}, settings: {theme:
+                  // string}}}
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      1, "name", iceberg::string(), true);
+                  auto age_field = std::make_unique<iceberg::SchemaField>(
+                      2, "age", iceberg::int32(), true);
+                  auto profile_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field, *age_field});
+                  auto profile_field = std::make_unique<iceberg::SchemaField>(
+                      3, "profile", profile_type, true);
+
+                  auto theme_field = std::make_unique<iceberg::SchemaField>(
+                      4, "theme", iceberg::string(), true);
+                  auto settings_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*theme_field});
+                  auto settings_field = std::make_unique<iceberg::SchemaField>(
+                      5, "settings", settings_type, true);
+
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*profile_field, *settings_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(6, "user", user_type, true);
+
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      7, "id", iceberg::int32(), false);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *user_field}, 400);
+                },
+            .select_fields = {"user.profile.name", "user.settings.theme"},
+            .expected_schema =
+                []() {
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      1, "name", iceberg::string(), true);
+                  auto profile_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field});
+                  auto profile_field = std::make_unique<iceberg::SchemaField>(
+                      3, "profile", profile_type, true);
+
+                  auto theme_field = std::make_unique<iceberg::SchemaField>(
+                      4, "theme", iceberg::string(), true);
+                  auto settings_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*theme_field});
+                  auto settings_field = std::make_unique<iceberg::SchemaField>(
+                      5, "settings", settings_type, true);
+
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*profile_field, *settings_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(6, "user", user_type, true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*user_field}, 400);
+                },
+            .should_succeed = true},
+
+        SelectTestParam{
+            .test_name = "SelectListAndNestedFields",
+            .create_schema =
+                []() {
+                  // {id: int, tags: list<string>, user: {name: string, age: int}}
+                  auto list_element = std::make_unique<iceberg::SchemaField>(
+                      1, "element", iceberg::string(), false);
+                  auto list_type = std::make_shared<iceberg::ListType>(*list_element);
+                  auto tags_field =
+                      std::make_unique<iceberg::SchemaField>(2, "tags", list_type, true);
+
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      3, "name", iceberg::string(), true);
+                  auto age_field = std::make_unique<iceberg::SchemaField>(
+                      4, "age", iceberg::int32(), true);
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field, *age_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(5, "user", user_type, true);
+
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      6, "id", iceberg::int32(), false);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *tags_field,
+                                                        *user_field},
+                      500);
+                },
+            .select_fields = {"id", "user.name"},
+            .expected_schema =
+                []() {
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      6, "id", iceberg::int32(), false);
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      3, "name", iceberg::string(), true);
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(5, "user", user_type, true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *user_field}, 500);
+                },
+            .should_succeed = true}));
+
+struct ProjectTestParam {
+  std::string test_name;
+  std::function<std::shared_ptr<iceberg::Schema>()> create_schema;
+  std::unordered_set<int32_t> selected_ids;
+  std::function<std::shared_ptr<iceberg::Schema>()> expected_schema;
+  bool should_succeed;
+  std::string expected_error_message;
+};
+
+class ProjectParamTest : public ::testing::TestWithParam<ProjectTestParam> {};
+
+TEST_P(ProjectParamTest, ProjectFields) {
+  const auto& param = GetParam();
+  auto input_schema = param.create_schema();
+  auto selected_ids = param.selected_ids;
+  auto result = input_schema->project(selected_ids);
+
+  if (param.should_succeed) {
+    ASSERT_TRUE(result.has_value()) << "Project should succeed for: " << param.test_name;
+
+    auto actual_schema = result.value();
+    auto expected_schema = param.expected_schema();
+    ASSERT_EQ(*actual_schema, *expected_schema)
+        << "Schema mismatch for: " << param.test_name;
+  } else {
+    ASSERT_FALSE(result.has_value()) << "Project should fail for: " << param.test_name;
+    ASSERT_THAT(result, iceberg::IsError(iceberg::ErrorKind::kInvalidArgument))
+        << "Should return InvalidArgument error for: " << param.test_name;
+
+    if (!param.expected_error_message.empty()) {
+      ASSERT_THAT(result, iceberg::HasErrorMessage(param.expected_error_message))
+          << "Error message mismatch for: " << param.test_name;
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectTestCases, ProjectParamTest,
+    ::testing::Values(
+        ProjectTestParam{
+            .test_name = "ProjectAllFields",
+            .create_schema =
+                []() {
+                  auto field1 = std::make_unique<iceberg::SchemaField>(
+                      1, "id", iceberg::int32(), false);
+                  auto field2 = std::make_unique<iceberg::SchemaField>(
+                      2, "name", iceberg::string(), true);
+                  auto field3 = std::make_unique<iceberg::SchemaField>(
+                      3, "age", iceberg::int32(), true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*field1, *field2, *field3}, 100);
+                },
+            .selected_ids = {1, 2, 3},
+            .expected_schema =
+                []() {
+                  auto field1 = std::make_unique<iceberg::SchemaField>(
+                      1, "id", iceberg::int32(), false);
+                  auto field2 = std::make_unique<iceberg::SchemaField>(
+                      2, "name", iceberg::string(), true);
+                  auto field3 = std::make_unique<iceberg::SchemaField>(
+                      3, "age", iceberg::int32(), true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*field1, *field2, *field3}, 100);
+                },
+            .should_succeed = true},
+
+        ProjectTestParam{
+            .test_name = "ProjectSingleField",
+            .create_schema =
+                []() {
+                  auto field1 = std::make_unique<iceberg::SchemaField>(
+                      1, "id", iceberg::int32(), false);
+                  auto field2 = std::make_unique<iceberg::SchemaField>(
+                      2, "name", iceberg::string(), true);
+                  auto field3 = std::make_unique<iceberg::SchemaField>(
+                      3, "age", iceberg::int32(), true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*field1, *field2, *field3}, 100);
+                },
+            .selected_ids = {2},
+            .expected_schema =
+                []() {
+                  auto field = std::make_unique<iceberg::SchemaField>(
+                      2, "name", iceberg::string(), true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*field}, 100);
+                },
+            .should_succeed = true},
+
+        ProjectTestParam{.test_name = "ProjectNonExistentFieldId",
+                         .create_schema =
+                             []() {
+                               auto field1 = std::make_unique<iceberg::SchemaField>(
+                                   1, "id", iceberg::int32(), false);
+                               auto field2 = std::make_unique<iceberg::SchemaField>(
+                                   2, "name", iceberg::string(), true);
+                               return std::make_shared<iceberg::Schema>(
+                                   std::vector<iceberg::SchemaField>{*field1, *field2},
+                                   100);
+                             },
+                         .selected_ids = {999},
+                         .expected_schema =
+                             []() {
+                               return std::make_shared<iceberg::Schema>(
+                                   std::vector<iceberg::SchemaField>{}, 100);
+                             },
+                         .should_succeed = true},
+
+        ProjectTestParam{.test_name = "ProjectEmptySelection",
+                         .create_schema =
+                             []() {
+                               auto field1 = std::make_unique<iceberg::SchemaField>(
+                                   1, "id", iceberg::int32(), false);
+                               auto field2 = std::make_unique<iceberg::SchemaField>(
+                                   2, "name", iceberg::string(), true);
+                               return std::make_shared<iceberg::Schema>(
+                                   std::vector<iceberg::SchemaField>{*field1, *field2},
+                                   100);
+                             },
+                         .selected_ids = {},
+                         .expected_schema =
+                             []() {
+                               return std::make_shared<iceberg::Schema>(
+                                   std::vector<iceberg::SchemaField>{}, 100);
+                             },
+                         .should_succeed = true}));
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectNestedTestCases, ProjectParamTest,
+    ::testing::Values(ProjectTestParam{
+        .test_name = "ProjectNestedStructField",
+        .create_schema =
+            []() {
+              auto nested_field1 = std::make_unique<iceberg::SchemaField>(
+                  1, "street", iceberg::string(), true);
+              auto nested_field2 = std::make_unique<iceberg::SchemaField>(
+                  2, "city", iceberg::string(), true);
+              auto address_type = std::make_shared<iceberg::StructType>(
+                  std::vector<iceberg::SchemaField>{*nested_field1, *nested_field2});
+              auto field1 = std::make_unique<iceberg::SchemaField>(
+                  3, "id", iceberg::int32(), false);
+              auto field2 = std::make_unique<iceberg::SchemaField>(4, "address",
+                                                                   address_type, true);
+              return std::make_shared<iceberg::Schema>(
+                  std::vector<iceberg::SchemaField>{*field1, *field2}, 200);
+            },
+        .selected_ids = {1},
+        .expected_schema =
+            []() {
+              auto street_field = std::make_unique<iceberg::SchemaField>(
+                  1, "street", iceberg::string(), true);
+              auto address_type = std::make_shared<iceberg::StructType>(
+                  std::vector<iceberg::SchemaField>{*street_field});
+              auto address_field = std::make_unique<iceberg::SchemaField>(
+                  4, "address", address_type, true);
+              return std::make_shared<iceberg::Schema>(
+                  std::vector<iceberg::SchemaField>{*address_field}, 200);
+            },
+        .should_succeed = true}));
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectMultiLevelTestCases, ProjectParamTest,
+    ::testing::Values(
+        ProjectTestParam{
+            .test_name = "ProjectTopLevelAndNestedFields",
+            .create_schema =
+                []() {
+                  // {id: int, user: {name: string, address: {street: string, city:
+                  // string}}}
+                  auto street_field = std::make_unique<iceberg::SchemaField>(
+                      1, "street", iceberg::string(), true);
+                  auto city_field = std::make_unique<iceberg::SchemaField>(
+                      2, "city", iceberg::string(), true);
+                  auto address_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*street_field, *city_field});
+                  auto address_field = std::make_unique<iceberg::SchemaField>(
+                      3, "address", address_type, true);
+
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      4, "name", iceberg::string(), true);
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field, *address_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(5, "user", user_type, true);
+
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      6, "id", iceberg::int32(), false);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *user_field}, 300);
+                },
+            .selected_ids = {6, 4, 1},
+            .expected_schema =
+                []() {
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      6, "id", iceberg::int32(), false);
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      4, "name", iceberg::string(), true);
+                  auto street_field = std::make_unique<iceberg::SchemaField>(
+                      1, "street", iceberg::string(), true);
+                  auto address_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*street_field});
+                  auto address_field = std::make_unique<iceberg::SchemaField>(
+                      3, "address", address_type, true);
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field, *address_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(5, "user", user_type, true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *user_field}, 300);
+                },
+            .should_succeed = true},
+
+        ProjectTestParam{
+            .test_name = "ProjectNestedFieldsAtDifferentLevels",
+            .create_schema =
+                []() {
+                  // {id: int, user: {profile: {name: string, age: int}, settings: {theme:
+                  // string}}}
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      1, "name", iceberg::string(), true);
+                  auto age_field = std::make_unique<iceberg::SchemaField>(
+                      2, "age", iceberg::int32(), true);
+                  auto profile_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field, *age_field});
+                  auto profile_field = std::make_unique<iceberg::SchemaField>(
+                      3, "profile", profile_type, true);
+
+                  auto theme_field = std::make_unique<iceberg::SchemaField>(
+                      4, "theme", iceberg::string(), true);
+                  auto settings_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*theme_field});
+                  auto settings_field = std::make_unique<iceberg::SchemaField>(
+                      5, "settings", settings_type, true);
+
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*profile_field, *settings_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(6, "user", user_type, true);
+
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      7, "id", iceberg::int32(), false);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *user_field}, 400);
+                },
+            .selected_ids = {1, 4},
+            .expected_schema =
+                []() {
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      1, "name", iceberg::string(), true);
+                  auto profile_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field});
+                  auto profile_field = std::make_unique<iceberg::SchemaField>(
+                      3, "profile", profile_type, true);
+
+                  auto theme_field = std::make_unique<iceberg::SchemaField>(
+                      4, "theme", iceberg::string(), true);
+                  auto settings_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*theme_field});
+                  auto settings_field = std::make_unique<iceberg::SchemaField>(
+                      5, "settings", settings_type, true);
+
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*profile_field, *settings_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(6, "user", user_type, true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*user_field}, 400);
+                },
+            .should_succeed = true},
+
+        ProjectTestParam{
+            .test_name = "ProjectListAndNestedFields",
+            .create_schema =
+                []() {
+                  //  {id: int, tags: list<string>, user: {name: string, age: int}}
+                  auto list_element = std::make_unique<iceberg::SchemaField>(
+                      1, "element", iceberg::string(), false);
+                  auto list_type = std::make_shared<iceberg::ListType>(*list_element);
+                  auto tags_field =
+                      std::make_unique<iceberg::SchemaField>(2, "tags", list_type, true);
+
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      3, "name", iceberg::string(), true);
+                  auto age_field = std::make_unique<iceberg::SchemaField>(
+                      4, "age", iceberg::int32(), true);
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field, *age_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(5, "user", user_type, true);
+
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      6, "id", iceberg::int32(), false);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *tags_field,
+                                                        *user_field},
+                      500);
+                },
+            .selected_ids = {6, 3},
+            .expected_schema =
+                []() {
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      6, "id", iceberg::int32(), false);
+                  auto name_field = std::make_unique<iceberg::SchemaField>(
+                      3, "name", iceberg::string(), true);
+                  auto user_type = std::make_shared<iceberg::StructType>(
+                      std::vector<iceberg::SchemaField>{*name_field});
+                  auto user_field =
+                      std::make_unique<iceberg::SchemaField>(5, "user", user_type, true);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *user_field}, 500);
+                },
+            .should_succeed = true}));
+
+INSTANTIATE_TEST_SUITE_P(
+    ProjectMapErrorTestCases, ProjectParamTest,
+    ::testing::Values(
+        ProjectTestParam{
+            .test_name = "ProjectMapTypeError",
+            .create_schema =
+                []() {
+                  auto map_key = std::make_unique<iceberg::SchemaField>(
+                      1, "key", iceberg::string(), false);
+                  auto map_value = std::make_unique<iceberg::SchemaField>(
+                      2, "value", iceberg::string(), false);
+                  auto map_type =
+                      std::make_shared<iceberg::MapType>(*map_key, *map_value);
+                  auto map_field = std::make_unique<iceberg::SchemaField>(
+                      3, "string_map", map_type, false);
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      4, "id", iceberg::int32(), false);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *map_field}, 100);
+                },
+            .selected_ids = {3},
+            .expected_schema = []() { return nullptr; },
+            .should_succeed = false,
+            .expected_error_message =
+                R"(Cannot explicitly project List or Map types, 3:string_map of type map<key (1): string (required): value (2): string (required)> was selected)"},
+
+        ProjectTestParam{
+            .test_name = "ProjectListTypeError",
+            .create_schema =
+                []() {
+                  auto list_element = std::make_unique<iceberg::SchemaField>(
+                      1, "element", iceberg::int32(), false);
+                  auto list_type = std::make_shared<iceberg::ListType>(*list_element);
+                  auto list_field = std::make_unique<iceberg::SchemaField>(
+                      2, "int_list", list_type, false);
+                  auto id_field = std::make_unique<iceberg::SchemaField>(
+                      3, "id", iceberg::int32(), false);
+                  return std::make_shared<iceberg::Schema>(
+                      std::vector<iceberg::SchemaField>{*id_field, *list_field}, 100);
+                },
+            .selected_ids = {2},
+            .expected_schema = []() { return nullptr; },
+            .should_succeed = false,
+            .expected_error_message =
+                R"(Cannot explicitly project List or Map types, 2:int_list of type list<element (1): int (required)> was selected)"}));


### PR DESCRIPTION
- Added select and project methods to the Schema class for creating projection schemas based on specified field names or IDs.
- Introduced PruneColumnVisitor to handle the logic for selecting and projecting fields, including support for nested structures.