### PR TITLE
feat: add cpr dependency for rest catalog client

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -34,6 +34,9 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+      - name: Install dependencies
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
       - name: Run build
         run: |
           mkdir build && cd build

--- a/.github/workflows/sanitizer_test.yml
+++ b/.github/workflows/sanitizer_test.yml
@@ -42,6 +42,9 @@ jobs:
     steps:
       - name: Checkout iceberg-cpp
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install dependencies
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
       - name: Configure and Build with ASAN & UBSAN
         run: |
           mkdir build && cd build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+      - name: Install dependencies
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
       - name: Build Iceberg
         shell: bash
         run: ci/scripts/build_iceberg.sh $(pwd)
@@ -85,7 +88,7 @@ jobs:
       - name: Install dependencies
         shell: cmd
         run: |
-          vcpkg install zlib:x64-windows nlohmann-json:x64-windows nanoarrow:x64-windows roaring:x64-windows
+          vcpkg install zlib:x64-windows nlohmann-json:x64-windows nanoarrow:x64-windows roaring:x64-windows cpr:x64-windows
       - name: Build Iceberg
         shell: cmd
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(ICEBERG_BUILD_STATIC "Build static library" ON)
 option(ICEBERG_BUILD_SHARED "Build shared library" OFF)
 option(ICEBERG_BUILD_TESTS "Build tests" ON)
 option(ICEBERG_BUILD_BUNDLE "Build the battery included library" ON)
+option(ICEBERG_BUILD_REST "Build rest catalog client" ON)
 option(ICEBERG_ENABLE_ASAN "Enable Address Sanitizer" OFF)
 option(ICEBERG_ENABLE_UBSAN "Enable Undefined Behavior Sanitizer" OFF)
 

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -431,87 +431,31 @@ function(resolve_zlib_dependency)
 endfunction()
 
 # ----------------------------------------------------------------------
-# CURL
+# CURL (for cpr)
 
 function(resolve_curl_dependency)
   prepare_fetchcontent()
 
-  set(BUILD_CURL_EXE
-      OFF
-      CACHE BOOL "" FORCE)
-  set(BUILD_TESTING
-      OFF
-      CACHE BOOL "" FORCE)
-  set(CURL_ENABLE_EXPORT_TARGET
-      OFF
-      CACHE BOOL "" FORCE)
-  set(BUILD_SHARED_LIBS
-      OFF
-      CACHE BOOL "" FORCE)
-  set(CURL_STATICLIB
-      ON
-      CACHE BOOL "" FORCE)
-  set(HTTP_ONLY
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_LDAP
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_LDAPS
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_RTSP
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_FTP
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_FILE
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_TELNET
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_DICT
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_TFTP
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_GOPHER
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_POP3
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_IMAP
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_SMTP
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_DISABLE_SMB
-      ON
-      CACHE BOOL "" FORCE)
-  set(CURL_CA_BUNDLE
-      "auto"
-      CACHE STRING "" FORCE)
-  set(USE_LIBIDN2
-      OFF
-      CACHE BOOL "" FORCE)
+  set(BUILD_CURL_EXE OFF)
+  set(BUILD_SHARED_LIBS OFF)
+  set(BUILD_TESTING OFF)
+  set(CURL_CA_BUNDLE "auto")
+  set(CURL_ENABLE_EXPORT_TARGET OFF)
+  set(CURL_STATICLIB ON)
+  set(HTTP_ONLY ON)
+  set(USE_LIBIDN2 OFF)
 
-  fetchcontent_declare(CURL
+  fetchcontent_declare(curl
                        ${FC_DECLARE_COMMON_OPTIONS}
-                       GIT_REPOSITORY https://github.com/curl/curl.git
-                       GIT_TAG curl-8_11_0
-                       FIND_PACKAGE_ARGS
-                       NAMES
-                       CURL
-                       CONFIG)
+                       URL https://curl.se/download/curl-8.11.0.tar.gz FIND_PACKAGE_ARGS
+                           NAMES curl)
 
   fetchcontent_makeavailable(CURL)
 
   if(curl_SOURCE_DIR)
+    set(CURL_VERSION_STRING
+        "8.11.0"
+        PARENT_SCOPE)
     if(NOT TARGET CURL::libcurl)
       add_library(CURL::libcurl INTERFACE IMPORTED)
       target_link_libraries(CURL::libcurl INTERFACE libcurl_static)
@@ -529,6 +473,9 @@ function(resolve_curl_dependency)
             ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
             LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
     message(STATUS "Use vendored CURL")
+
+    # curl depends on the system installed OpenSSL
+    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES OpenSSL)
   else()
     set(CURL_VENDORED FALSE)
     list(APPEND ICEBERG_SYSTEM_DEPENDENCIES CURL)
@@ -544,52 +491,26 @@ function(resolve_curl_dependency)
 endfunction()
 
 # ----------------------------------------------------------------------
-# cpr
+# cpr (C++ Requests)
 
 function(resolve_cpr_dependency)
   prepare_fetchcontent()
 
-  set(CPR_BUILD_TESTS
-      OFF
-      CACHE BOOL "" FORCE)
-  set(CPR_BUILD_TESTS_SSL
-      OFF
-      CACHE BOOL "" FORCE)
-  set(CPR_ENABLE_SSL
-      ON
-      CACHE BOOL "" FORCE)
-  set(CPR_USE_SYSTEM_CURL
-      ON
-      CACHE BOOL "" FORCE)
-  set(CPR_CURL_NOSIGNAL
-      ON
-      CACHE BOOL "" FORCE)
-
-  set(CURL_VERSION_STRING
-      "8.11.0"
-      CACHE STRING "" FORCE)
-  set(CURL_LIB
-      "CURL::libcurl"
-      CACHE STRING "" FORCE)
+  set(CPR_BUILD_TESTS OFF)
+  set(CPR_BUILD_TESTS_SSL OFF)
+  set(CPR_ENABLE_SSL ON)
+  set(CPR_USE_SYSTEM_CURL ON)
+  set(CPR_CURL_NOSIGNAL ON)
 
   fetchcontent_declare(cpr
                        ${FC_DECLARE_COMMON_OPTIONS}
-                       GIT_REPOSITORY https://github.com/libcpr/cpr.git
-                       GIT_TAG 1.11.0
-                       FIND_PACKAGE_ARGS
-                       NAMES
-                       cpr
-                       CONFIG)
-
-  # Create a custom install command that does nothing
-  # function(install)
-  #   # Do nothing - effectively disables install
-  # endfunction()
+                       URL https://github.com/libcpr/cpr/archive/refs/tags/1.12.0.tar.gz
+                           FIND_PACKAGE_ARGS
+                           NAMES
+                           cpr
+                           CONFIG)
 
   fetchcontent_makeavailable(cpr)
-
-  # Restore the original install function
-  # unset(install)
 
   if(cpr_SOURCE_DIR)
     if(NOT TARGET cpr::cpr)
@@ -641,11 +562,13 @@ resolve_croaring_dependency()
 resolve_nlohmann_json_dependency()
 resolve_spdlog_dependency()
 
-resolve_curl_dependency()
-resolve_cpr_dependency()
-
 if(ICEBERG_BUILD_BUNDLE)
   resolve_arrow_dependency()
   resolve_avro_dependency()
   resolve_zstd_dependency()
+endif()
+
+if(ICEBERG_BUILD_REST)
+  resolve_curl_dependency()
+  resolve_cpr_dependency()
 endif()

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -431,81 +431,6 @@ function(resolve_zlib_dependency)
 endfunction()
 
 # ----------------------------------------------------------------------
-# CURL (for cpr)
-
-# function(resolve_curl_dependency)
-# prepare_fetchcontent()
-
-# find_package(CURL QUIET COMPONENTS HTTPS SSL)
-
-# if(CURL_FOUND)
-#   if(CURL_VERSION VERSION_LESS "7.61.0")
-#     message(STATUS "System CURL version ${CURL_VERSION} too old, will download")
-#     set(CURL_FOUND FALSE)
-#   else()
-#     message(STATUS "Found my system CURL ${CURL_VERSION}")
-#     list(APPEND ICEBERG_SYSTEM_DEPENDENCIES CURL)
-#     set(CURL_VENDORED FALSE)
-#   endif()
-# endif()
-
-# if(NOT CURL_FOUND)
-#   set(BUILD_CURL_EXE OFF)
-#   set(BUILD_SHARED_LIBS OFF)
-#   set(BUILD_TESTING OFF)
-#   set(CURL_CA_BUNDLE "auto")
-#   set(CURL_ENABLE_EXPORT_TARGET OFF)
-#   set(CURL_STATICLIB ON)
-#   set(HTTP_ONLY ON)
-#   set(USE_LIBIDN2 OFF)
-
-#   FetchContent_Declare(curl
-#     ${FC_DECLARE_COMMON_OPTIONS}
-#     URL https://curl.se/download/curl-8.11.0.tar.gz
-#   )
-#   set(CURL_VENDORED TRUE)
-#   FetchContent_MakeAvailable(curl)
-# endif()
-
-# if(curl_SOURCE_DIR)
-#   set(CURL_VERSION_STRING
-#       "8.11.0"
-#       PARENT_SCOPE)
-#   if(NOT TARGET CURL::libcurl)
-#     add_library(CURL::libcurl INTERFACE IMPORTED)
-#     target_link_libraries(CURL::libcurl INTERFACE libcurl_static)
-#     target_include_directories(CURL::libcurl INTERFACE ${curl_BINARY_DIR}/include
-#                                                        ${curl_SOURCE_DIR}/include)
-#   endif()
-
-#
-#   set_target_properties(libcurl_static PROPERTIES OUTPUT_NAME "iceberg_vendored_curl"
-#                                                   POSITION_INDEPENDENT_CODE ON)
-#   add_library(Iceberg::libcurl_static ALIAS libcurl_static)
-#   install(TARGETS libcurl_static
-#           EXPORT iceberg_targets
-#           RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"
-#           ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
-#           LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
-#   message(STATUS "Use vendored CURL")
-
-#   # curl depends on the system installed OpenSSL
-#   list(APPEND ICEBERG_SYSTEM_DEPENDENCIES OpenSSL)
-# else()
-#   set(CURL_VENDORED FALSE)
-#   list(APPEND ICEBERG_SYSTEM_DEPENDENCIES CURL)
-#   message(STATUS "Use system CURL")
-# endif()
-
-#   set(ICEBERG_SYSTEM_DEPENDENCIES
-#       ${ICEBERG_SYSTEM_DEPENDENCIES}
-#       PARENT_SCOPE)
-#   set(CURL_VENDORED
-#       ${CURL_VENDORED}
-#       PARENT_SCOPE)
-# endfunction()
-
-# ----------------------------------------------------------------------
 # cpr (C++ Requests)
 
 function(resolve_cpr_dependency)
@@ -527,7 +452,6 @@ function(resolve_cpr_dependency)
   fetchcontent_makeavailable(cpr)
 
   if(cpr_SOURCE_DIR)
-    message(STATUS "AAAAAaaaaaaaaaaaa")
     if(NOT TARGET cpr::cpr)
       add_library(cpr::cpr INTERFACE IMPORTED)
       target_link_libraries(cpr::cpr INTERFACE cpr)
@@ -545,12 +469,9 @@ function(resolve_cpr_dependency)
             ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
             LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
     list(APPEND ICEBERG_SYSTEM_DEPENDENCIES OpenSSL)
-
   else()
-    message(STATUS "BBBBbbbbbbbbbb")
     set(CPR_VENDORED FALSE)
     list(APPEND ICEBERG_SYSTEM_DEPENDENCIES cpr)
-    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES OpenSSL)
   endif()
 
   set(ICEBERG_SYSTEM_DEPENDENCIES
@@ -560,63 +481,6 @@ function(resolve_cpr_dependency)
       ${CPR_VENDORED}
       PARENT_SCOPE)
 endfunction()
-
-# function(resolve_cpr_dependency)
-#   prepare_fetchcontent()
-
-#   set(CPR_BUILD_TESTS OFF)
-#   set(CPR_BUILD_TESTS_SSL OFF)
-#   set(CPR_ENABLE_SSL ON)
-#   set(CPR_USE_SYSTEM_CURL ON)
-#   set(CPR_CURL_NOSIGNAL ON)
-
-#   if(CURL_VENDORED)
-#     message(STATUS "Use vendored CURL in cpr")
-#     set(CPR_USE_SYSTEM_CURL OFF)
-#   else()
-#     message(STATUS "Use system CURL in cpr")
-#     set(CPR_USE_SYSTEM_CURL ON)
-#   endif()
-
-#   fetchcontent_declare(cpr
-#                        ${FC_DECLARE_COMMON_OPTIONS}
-#                        URL https://github.com/libcpr/cpr/archive/refs/tags/1.12.0.tar.gz
-#                            FIND_PACKAGE_ARGS
-#                            NAMES
-#                            cpr
-#                            CONFIG)
-
-#   fetchcontent_makeavailable(cpr)
-
-#   if(cpr_SOURCE_DIR)
-#     if(NOT TARGET cpr::cpr)
-#       add_library(cpr::cpr INTERFACE IMPORTED)
-#       target_link_libraries(cpr::cpr INTERFACE cpr)
-#       target_include_directories(cpr::cpr INTERFACE ${cpr_BINARY_DIR}
-#                                                     ${cpr_SOURCE_DIR}/include)
-#     endif()
-
-#     set(CPR_VENDORED TRUE)
-#     set_target_properties(cpr PROPERTIES OUTPUT_NAME "iceberg_vendored_cpr"
-#                                          POSITION_INDEPENDENT_CODE ON)
-#     add_library(Iceberg::cpr ALIAS cpr)
-#     install(TARGETS cpr
-#             EXPORT iceberg_targets
-#             RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"
-#             ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
-#             LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
-#   else()
-#     set(CPR_VENDORED FALSE)
-#     list(APPEND ICEBERG_SYSTEM_DEPENDENCIES cpr)
-#   endif()
-
-#   set(ICEBERG_SYSTEM_DEPENDENCIES
-#       ${ICEBERG_SYSTEM_DEPENDENCIES}
-#       PARENT_SCOPE)
-#   set(CPR_VENDORED
-#       ${CPR_VENDORED}
-#       PARENT_SCOPE)
-# endfunction()
 
 # ----------------------------------------------------------------------
 # Zstd

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -433,62 +433,77 @@ endfunction()
 # ----------------------------------------------------------------------
 # CURL (for cpr)
 
-function(resolve_curl_dependency)
-  prepare_fetchcontent()
+# function(resolve_curl_dependency)
+# prepare_fetchcontent()
 
-  set(BUILD_CURL_EXE OFF)
-  set(BUILD_SHARED_LIBS OFF)
-  set(BUILD_TESTING OFF)
-  set(CURL_CA_BUNDLE "auto")
-  set(CURL_ENABLE_EXPORT_TARGET OFF)
-  set(CURL_STATICLIB ON)
-  set(HTTP_ONLY ON)
-  set(USE_LIBIDN2 OFF)
+# find_package(CURL QUIET COMPONENTS HTTPS SSL)
 
-  fetchcontent_declare(curl
-                       ${FC_DECLARE_COMMON_OPTIONS}
-                       URL https://curl.se/download/curl-8.11.0.tar.gz FIND_PACKAGE_ARGS
-                           NAMES curl)
+# if(CURL_FOUND)
+#   if(CURL_VERSION VERSION_LESS "7.61.0")
+#     message(STATUS "System CURL version ${CURL_VERSION} too old, will download")
+#     set(CURL_FOUND FALSE)
+#   else()
+#     message(STATUS "Found my system CURL ${CURL_VERSION}")
+#     list(APPEND ICEBERG_SYSTEM_DEPENDENCIES CURL)
+#     set(CURL_VENDORED FALSE)
+#   endif()
+# endif()
 
-  fetchcontent_makeavailable(CURL)
+# if(NOT CURL_FOUND)
+#   set(BUILD_CURL_EXE OFF)
+#   set(BUILD_SHARED_LIBS OFF)
+#   set(BUILD_TESTING OFF)
+#   set(CURL_CA_BUNDLE "auto")
+#   set(CURL_ENABLE_EXPORT_TARGET OFF)
+#   set(CURL_STATICLIB ON)
+#   set(HTTP_ONLY ON)
+#   set(USE_LIBIDN2 OFF)
 
-  if(curl_SOURCE_DIR)
-    set(CURL_VERSION_STRING
-        "8.11.0"
-        PARENT_SCOPE)
-    if(NOT TARGET CURL::libcurl)
-      add_library(CURL::libcurl INTERFACE IMPORTED)
-      target_link_libraries(CURL::libcurl INTERFACE libcurl_static)
-      target_include_directories(CURL::libcurl INTERFACE ${curl_BINARY_DIR}/include
-                                                         ${curl_SOURCE_DIR}/include)
-    endif()
+#   FetchContent_Declare(curl
+#     ${FC_DECLARE_COMMON_OPTIONS}
+#     URL https://curl.se/download/curl-8.11.0.tar.gz
+#   )
+#   set(CURL_VENDORED TRUE)
+#   FetchContent_MakeAvailable(curl)
+# endif()
 
-    set(CURL_VENDORED TRUE)
-    set_target_properties(libcurl_static PROPERTIES OUTPUT_NAME "iceberg_vendored_curl"
-                                                    POSITION_INDEPENDENT_CODE ON)
-    add_library(Iceberg::libcurl_static ALIAS libcurl_static)
-    install(TARGETS libcurl_static
-            EXPORT iceberg_targets
-            RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"
-            ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
-            LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
-    message(STATUS "Use vendored CURL")
+# if(curl_SOURCE_DIR)
+#   set(CURL_VERSION_STRING
+#       "8.11.0"
+#       PARENT_SCOPE)
+#   if(NOT TARGET CURL::libcurl)
+#     add_library(CURL::libcurl INTERFACE IMPORTED)
+#     target_link_libraries(CURL::libcurl INTERFACE libcurl_static)
+#     target_include_directories(CURL::libcurl INTERFACE ${curl_BINARY_DIR}/include
+#                                                        ${curl_SOURCE_DIR}/include)
+#   endif()
 
-    # curl depends on the system installed OpenSSL
-    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES OpenSSL)
-  else()
-    set(CURL_VENDORED FALSE)
-    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES CURL)
-    message(STATUS "Use system CURL")
-  endif()
+#
+#   set_target_properties(libcurl_static PROPERTIES OUTPUT_NAME "iceberg_vendored_curl"
+#                                                   POSITION_INDEPENDENT_CODE ON)
+#   add_library(Iceberg::libcurl_static ALIAS libcurl_static)
+#   install(TARGETS libcurl_static
+#           EXPORT iceberg_targets
+#           RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"
+#           ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
+#           LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
+#   message(STATUS "Use vendored CURL")
 
-  set(ICEBERG_SYSTEM_DEPENDENCIES
-      ${ICEBERG_SYSTEM_DEPENDENCIES}
-      PARENT_SCOPE)
-  set(CURL_VENDORED
-      ${CURL_VENDORED}
-      PARENT_SCOPE)
-endfunction()
+#   # curl depends on the system installed OpenSSL
+#   list(APPEND ICEBERG_SYSTEM_DEPENDENCIES OpenSSL)
+# else()
+#   set(CURL_VENDORED FALSE)
+#   list(APPEND ICEBERG_SYSTEM_DEPENDENCIES CURL)
+#   message(STATUS "Use system CURL")
+# endif()
+
+#   set(ICEBERG_SYSTEM_DEPENDENCIES
+#       ${ICEBERG_SYSTEM_DEPENDENCIES}
+#       PARENT_SCOPE)
+#   set(CURL_VENDORED
+#       ${CURL_VENDORED}
+#       PARENT_SCOPE)
+# endfunction()
 
 # ----------------------------------------------------------------------
 # cpr (C++ Requests)
@@ -497,10 +512,9 @@ function(resolve_cpr_dependency)
   prepare_fetchcontent()
 
   set(CPR_BUILD_TESTS OFF)
-  set(CPR_BUILD_TESTS_SSL OFF)
+  set(CPR_ENABLE_CURL_HTTP_ONLY ON)
   set(CPR_ENABLE_SSL ON)
   set(CPR_USE_SYSTEM_CURL ON)
-  set(CPR_CURL_NOSIGNAL ON)
 
   fetchcontent_declare(cpr
                        ${FC_DECLARE_COMMON_OPTIONS}
@@ -532,6 +546,7 @@ function(resolve_cpr_dependency)
   else()
     set(CPR_VENDORED FALSE)
     list(APPEND ICEBERG_SYSTEM_DEPENDENCIES cpr)
+    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES OpenSSL)
   endif()
 
   set(ICEBERG_SYSTEM_DEPENDENCIES
@@ -541,6 +556,63 @@ function(resolve_cpr_dependency)
       ${CPR_VENDORED}
       PARENT_SCOPE)
 endfunction()
+
+# function(resolve_cpr_dependency)
+#   prepare_fetchcontent()
+
+#   set(CPR_BUILD_TESTS OFF)
+#   set(CPR_BUILD_TESTS_SSL OFF)
+#   set(CPR_ENABLE_SSL ON)
+#   set(CPR_USE_SYSTEM_CURL ON)
+#   set(CPR_CURL_NOSIGNAL ON)
+
+#   if(CURL_VENDORED)
+#     message(STATUS "Use vendored CURL in cpr")
+#     set(CPR_USE_SYSTEM_CURL OFF)
+#   else()
+#     message(STATUS "Use system CURL in cpr")
+#     set(CPR_USE_SYSTEM_CURL ON)
+#   endif()
+
+#   fetchcontent_declare(cpr
+#                        ${FC_DECLARE_COMMON_OPTIONS}
+#                        URL https://github.com/libcpr/cpr/archive/refs/tags/1.12.0.tar.gz
+#                            FIND_PACKAGE_ARGS
+#                            NAMES
+#                            cpr
+#                            CONFIG)
+
+#   fetchcontent_makeavailable(cpr)
+
+#   if(cpr_SOURCE_DIR)
+#     if(NOT TARGET cpr::cpr)
+#       add_library(cpr::cpr INTERFACE IMPORTED)
+#       target_link_libraries(cpr::cpr INTERFACE cpr)
+#       target_include_directories(cpr::cpr INTERFACE ${cpr_BINARY_DIR}
+#                                                     ${cpr_SOURCE_DIR}/include)
+#     endif()
+
+#     set(CPR_VENDORED TRUE)
+#     set_target_properties(cpr PROPERTIES OUTPUT_NAME "iceberg_vendored_cpr"
+#                                          POSITION_INDEPENDENT_CODE ON)
+#     add_library(Iceberg::cpr ALIAS cpr)
+#     install(TARGETS cpr
+#             EXPORT iceberg_targets
+#             RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"
+#             ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
+#             LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
+#   else()
+#     set(CPR_VENDORED FALSE)
+#     list(APPEND ICEBERG_SYSTEM_DEPENDENCIES cpr)
+#   endif()
+
+#   set(ICEBERG_SYSTEM_DEPENDENCIES
+#       ${ICEBERG_SYSTEM_DEPENDENCIES}
+#       PARENT_SCOPE)
+#   set(CPR_VENDORED
+#       ${CPR_VENDORED}
+#       PARENT_SCOPE)
+# endfunction()
 
 # ----------------------------------------------------------------------
 # Zstd
@@ -569,6 +641,5 @@ if(ICEBERG_BUILD_BUNDLE)
 endif()
 
 if(ICEBERG_BUILD_REST)
-  resolve_curl_dependency()
   resolve_cpr_dependency()
 endif()

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -527,6 +527,7 @@ function(resolve_cpr_dependency)
   fetchcontent_makeavailable(cpr)
 
   if(cpr_SOURCE_DIR)
+    message(STATUS "AAAAAaaaaaaaaaaaa")
     if(NOT TARGET cpr::cpr)
       add_library(cpr::cpr INTERFACE IMPORTED)
       target_link_libraries(cpr::cpr INTERFACE cpr)
@@ -543,7 +544,10 @@ function(resolve_cpr_dependency)
             RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"
             ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
             LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
+    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES OpenSSL)
+
   else()
+    message(STATUS "BBBBbbbbbbbbbb")
     set(CPR_VENDORED FALSE)
     list(APPEND ICEBERG_SYSTEM_DEPENDENCIES cpr)
     list(APPEND ICEBERG_SYSTEM_DEPENDENCIES OpenSSL)

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -431,6 +431,197 @@ function(resolve_zlib_dependency)
 endfunction()
 
 # ----------------------------------------------------------------------
+# CURL
+
+function(resolve_curl_dependency)
+  prepare_fetchcontent()
+
+  set(BUILD_CURL_EXE
+      OFF
+      CACHE BOOL "" FORCE)
+  set(BUILD_TESTING
+      OFF
+      CACHE BOOL "" FORCE)
+  set(CURL_ENABLE_EXPORT_TARGET
+      OFF
+      CACHE BOOL "" FORCE)
+  set(BUILD_SHARED_LIBS
+      OFF
+      CACHE BOOL "" FORCE)
+  set(CURL_STATICLIB
+      ON
+      CACHE BOOL "" FORCE)
+  set(HTTP_ONLY
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_LDAP
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_LDAPS
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_RTSP
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_FTP
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_FILE
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_TELNET
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_DICT
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_TFTP
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_GOPHER
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_POP3
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_IMAP
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_SMTP
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_DISABLE_SMB
+      ON
+      CACHE BOOL "" FORCE)
+  set(CURL_CA_BUNDLE
+      "auto"
+      CACHE STRING "" FORCE)
+  set(USE_LIBIDN2
+      OFF
+      CACHE BOOL "" FORCE)
+
+  fetchcontent_declare(CURL
+                       ${FC_DECLARE_COMMON_OPTIONS}
+                       GIT_REPOSITORY https://github.com/curl/curl.git
+                       GIT_TAG curl-8_11_0
+                       FIND_PACKAGE_ARGS
+                       NAMES
+                       CURL
+                       CONFIG)
+
+  fetchcontent_makeavailable(CURL)
+
+  if(curl_SOURCE_DIR)
+    if(NOT TARGET CURL::libcurl)
+      add_library(CURL::libcurl INTERFACE IMPORTED)
+      target_link_libraries(CURL::libcurl INTERFACE libcurl_static)
+      target_include_directories(CURL::libcurl INTERFACE ${curl_BINARY_DIR}/include
+                                                         ${curl_SOURCE_DIR}/include)
+    endif()
+
+    set(CURL_VENDORED TRUE)
+    set_target_properties(libcurl_static PROPERTIES OUTPUT_NAME "iceberg_vendored_curl"
+                                                    POSITION_INDEPENDENT_CODE ON)
+    add_library(Iceberg::libcurl_static ALIAS libcurl_static)
+    install(TARGETS libcurl_static
+            EXPORT iceberg_targets
+            RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"
+            ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
+            LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
+    message(STATUS "Use vendored CURL")
+  else()
+    set(CURL_VENDORED FALSE)
+    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES CURL)
+    message(STATUS "Use system CURL")
+  endif()
+
+  set(ICEBERG_SYSTEM_DEPENDENCIES
+      ${ICEBERG_SYSTEM_DEPENDENCIES}
+      PARENT_SCOPE)
+  set(CURL_VENDORED
+      ${CURL_VENDORED}
+      PARENT_SCOPE)
+endfunction()
+
+# ----------------------------------------------------------------------
+# cpr
+
+function(resolve_cpr_dependency)
+  prepare_fetchcontent()
+
+  set(CPR_BUILD_TESTS
+      OFF
+      CACHE BOOL "" FORCE)
+  set(CPR_BUILD_TESTS_SSL
+      OFF
+      CACHE BOOL "" FORCE)
+  set(CPR_ENABLE_SSL
+      ON
+      CACHE BOOL "" FORCE)
+  set(CPR_USE_SYSTEM_CURL
+      ON
+      CACHE BOOL "" FORCE)
+  set(CPR_CURL_NOSIGNAL
+      ON
+      CACHE BOOL "" FORCE)
+
+  set(CURL_VERSION_STRING
+      "8.11.0"
+      CACHE STRING "" FORCE)
+  set(CURL_LIB
+      "CURL::libcurl"
+      CACHE STRING "" FORCE)
+
+  fetchcontent_declare(cpr
+                       ${FC_DECLARE_COMMON_OPTIONS}
+                       GIT_REPOSITORY https://github.com/libcpr/cpr.git
+                       GIT_TAG 1.11.0
+                       FIND_PACKAGE_ARGS
+                       NAMES
+                       cpr
+                       CONFIG)
+
+  # Create a custom install command that does nothing
+  # function(install)
+  #   # Do nothing - effectively disables install
+  # endfunction()
+
+  fetchcontent_makeavailable(cpr)
+
+  # Restore the original install function
+  # unset(install)
+
+  if(cpr_SOURCE_DIR)
+    if(NOT TARGET cpr::cpr)
+      add_library(cpr::cpr INTERFACE IMPORTED)
+      target_link_libraries(cpr::cpr INTERFACE cpr)
+      target_include_directories(cpr::cpr INTERFACE ${cpr_BINARY_DIR}
+                                                    ${cpr_SOURCE_DIR}/include)
+    endif()
+
+    set(CPR_VENDORED TRUE)
+    set_target_properties(cpr PROPERTIES OUTPUT_NAME "iceberg_vendored_cpr"
+                                         POSITION_INDEPENDENT_CODE ON)
+    add_library(Iceberg::cpr ALIAS cpr)
+    install(TARGETS cpr
+            EXPORT iceberg_targets
+            RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"
+            ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
+            LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
+  else()
+    set(CPR_VENDORED FALSE)
+    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES cpr)
+  endif()
+
+  set(ICEBERG_SYSTEM_DEPENDENCIES
+      ${ICEBERG_SYSTEM_DEPENDENCIES}
+      PARENT_SCOPE)
+  set(CPR_VENDORED
+      ${CPR_VENDORED}
+      PARENT_SCOPE)
+endfunction()
+
+# ----------------------------------------------------------------------
 # Zstd
 
 function(resolve_zstd_dependency)
@@ -449,6 +640,9 @@ resolve_nanoarrow_dependency()
 resolve_croaring_dependency()
 resolve_nlohmann_json_dependency()
 resolve_spdlog_dependency()
+
+resolve_curl_dependency()
+resolve_cpr_dependency()
 
 if(ICEBERG_BUILD_BUNDLE)
   resolve_arrow_dependency()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -26,4 +26,5 @@ find_package(Iceberg CONFIG REQUIRED)
 
 add_executable(demo_example demo_example.cc)
 
-target_link_libraries(demo_example PRIVATE Iceberg::iceberg_bundle_static)
+target_link_libraries(demo_example PRIVATE Iceberg::iceberg_bundle_static
+                                           Iceberg::iceberg_rest_static)

--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -133,8 +133,6 @@ if(ICEBERG_BUILD_BUNDLE)
   list(APPEND
        ICEBERG_BUNDLE_STATIC_BUILD_INTERFACE_LIBS
        "$<IF:$<TARGET_EXISTS:iceberg_static>,iceberg_static,iceberg_shared>"
-       "$<IF:$<TARGET_EXISTS:CURL::libcurl>,CURL::libcurl,CURL::libcurl>"
-       "$<IF:$<TARGET_EXISTS:cpr::cpr>,cpr::cpr,cpr::cpr>"
        "$<IF:$<TARGET_EXISTS:Arrow::arrow_static>,Arrow::arrow_static,Arrow::arrow_shared>"
        "$<IF:$<TARGET_EXISTS:Parquet::parquet_static>,Parquet::parquet_static,Parquet::parquet_shared>"
        "$<IF:$<TARGET_EXISTS:avro-cpp::avrocpp_static>,avro-cpp::avrocpp_static,avro-cpp::avrocpp_shared>"
@@ -142,8 +140,6 @@ if(ICEBERG_BUILD_BUNDLE)
   list(APPEND
        ICEBERG_BUNDLE_SHARED_BUILD_INTERFACE_LIBS
        "$<IF:$<TARGET_EXISTS:iceberg_shared>,iceberg_shared,iceberg_static>"
-       "$<IF:$<TARGET_EXISTS:CURL::libcurl>,CURL::libcurl,CURL::libcurl>"
-       "$<IF:$<TARGET_EXISTS:cpr::cpr>,cpr::cpr,cpr::cpr>"
        "$<IF:$<TARGET_EXISTS:Arrow::arrow_shared>,Arrow::arrow_shared,Arrow::arrow_static>"
        "$<IF:$<TARGET_EXISTS:Parquet::parquet_shared>,Parquet::parquet_shared,Parquet::parquet_static>"
        "$<IF:$<TARGET_EXISTS:avro-cpp::avrocpp_shared>,avro-cpp::avrocpp_shared,avro-cpp::avrocpp_static>"
@@ -152,8 +148,6 @@ if(ICEBERG_BUILD_BUNDLE)
   list(APPEND
        ICEBERG_BUNDLE_STATIC_INSTALL_INTERFACE_LIBS
        "$<IF:$<TARGET_EXISTS:Iceberg::iceberg_static>,Iceberg::iceberg_static,Iceberg::iceberg_shared>"
-       "$<IF:$<BOOL:${CURL_VENDORED}>,Iceberg::libcurl_static,$<IF:$<TARGET_EXISTS:CURL::libcurl>,CURL::libcurl,CURL::libcurl>>"
-       "$<IF:$<BOOL:${CPR_VENDORED}>,Iceberg::cpr,$<IF:$<TARGET_EXISTS:cpr::cpr>,cpr::cpr,cpr::cpr>>"
        "$<IF:$<BOOL:${ARROW_VENDORED}>,Iceberg::arrow_static,$<IF:$<TARGET_EXISTS:Arrow::arrow_static>,Arrow::arrow_static,Arrow::arrow_shared>>"
        "$<IF:$<BOOL:${ARROW_VENDORED}>,Iceberg::parquet_static,$<IF:$<TARGET_EXISTS:Parquet::parquet_static>,Parquet::parquet_static,Parquet::parquet_shared>>"
        "$<IF:$<BOOL:${AVRO_VENDORED}>,Iceberg::avrocpp_s,$<IF:$<TARGET_EXISTS:avro-cpp::avrocpp_static>,avro-cpp::avrocpp_static,avro-cpp::avrocpp_shared>>"
@@ -161,8 +155,6 @@ if(ICEBERG_BUILD_BUNDLE)
   list(APPEND
        ICEBERG_BUNDLE_SHARED_INSTALL_INTERFACE_LIBS
        "$<IF:$<TARGET_EXISTS:Iceberg::iceberg_shared>,Iceberg::iceberg_shared,Iceberg::iceberg_static>"
-       "$<IF:$<BOOL:${CURL_VENDORED}>,Iceberg::libcurl_static,$<IF:$<TARGET_EXISTS:CURL::libcurl>,CURL::libcurl,CURL::libcurl>>"
-       "$<IF:$<BOOL:${CPR_VENDORED}>,Iceberg::cpr,$<IF:$<TARGET_EXISTS:cpr::cpr>,cpr::cpr,cpr::cpr>>"
        "$<IF:$<BOOL:${ARROW_VENDORED}>,Iceberg::arrow_static,$<IF:$<TARGET_EXISTS:Arrow::arrow_shared>,Arrow::arrow_shared,Arrow::arrow_static>>"
        "$<IF:$<BOOL:${ARROW_VENDORED}>,Iceberg::parquet_static,$<IF:$<TARGET_EXISTS:Parquet::parquet_shared>,Parquet::parquet_shared,Parquet::parquet_static>>"
        "$<IF:$<BOOL:${AVRO_VENDORED}>,Iceberg::avrocpp_s,$<IF:$<TARGET_EXISTS:avro-cpp::avrocpp_shared>,avro-cpp::avrocpp_shared,avro-cpp::avrocpp_static>>"

--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -133,6 +133,8 @@ if(ICEBERG_BUILD_BUNDLE)
   list(APPEND
        ICEBERG_BUNDLE_STATIC_BUILD_INTERFACE_LIBS
        "$<IF:$<TARGET_EXISTS:iceberg_static>,iceberg_static,iceberg_shared>"
+       "$<IF:$<TARGET_EXISTS:CURL::libcurl>,CURL::libcurl,CURL::libcurl>"
+       "$<IF:$<TARGET_EXISTS:cpr::cpr>,cpr::cpr,cpr::cpr>"
        "$<IF:$<TARGET_EXISTS:Arrow::arrow_static>,Arrow::arrow_static,Arrow::arrow_shared>"
        "$<IF:$<TARGET_EXISTS:Parquet::parquet_static>,Parquet::parquet_static,Parquet::parquet_shared>"
        "$<IF:$<TARGET_EXISTS:avro-cpp::avrocpp_static>,avro-cpp::avrocpp_static,avro-cpp::avrocpp_shared>"
@@ -140,6 +142,8 @@ if(ICEBERG_BUILD_BUNDLE)
   list(APPEND
        ICEBERG_BUNDLE_SHARED_BUILD_INTERFACE_LIBS
        "$<IF:$<TARGET_EXISTS:iceberg_shared>,iceberg_shared,iceberg_static>"
+       "$<IF:$<TARGET_EXISTS:CURL::libcurl>,CURL::libcurl,CURL::libcurl>"
+       "$<IF:$<TARGET_EXISTS:cpr::cpr>,cpr::cpr,cpr::cpr>"
        "$<IF:$<TARGET_EXISTS:Arrow::arrow_shared>,Arrow::arrow_shared,Arrow::arrow_static>"
        "$<IF:$<TARGET_EXISTS:Parquet::parquet_shared>,Parquet::parquet_shared,Parquet::parquet_static>"
        "$<IF:$<TARGET_EXISTS:avro-cpp::avrocpp_shared>,avro-cpp::avrocpp_shared,avro-cpp::avrocpp_static>"
@@ -148,6 +152,8 @@ if(ICEBERG_BUILD_BUNDLE)
   list(APPEND
        ICEBERG_BUNDLE_STATIC_INSTALL_INTERFACE_LIBS
        "$<IF:$<TARGET_EXISTS:Iceberg::iceberg_static>,Iceberg::iceberg_static,Iceberg::iceberg_shared>"
+       "$<IF:$<BOOL:${CURL_VENDORED}>,Iceberg::libcurl_static,$<IF:$<TARGET_EXISTS:CURL::libcurl>,CURL::libcurl,CURL::libcurl>>"
+       "$<IF:$<BOOL:${CPR_VENDORED}>,Iceberg::cpr,$<IF:$<TARGET_EXISTS:cpr::cpr>,cpr::cpr,cpr::cpr>>"
        "$<IF:$<BOOL:${ARROW_VENDORED}>,Iceberg::arrow_static,$<IF:$<TARGET_EXISTS:Arrow::arrow_static>,Arrow::arrow_static,Arrow::arrow_shared>>"
        "$<IF:$<BOOL:${ARROW_VENDORED}>,Iceberg::parquet_static,$<IF:$<TARGET_EXISTS:Parquet::parquet_static>,Parquet::parquet_static,Parquet::parquet_shared>>"
        "$<IF:$<BOOL:${AVRO_VENDORED}>,Iceberg::avrocpp_s,$<IF:$<TARGET_EXISTS:avro-cpp::avrocpp_static>,avro-cpp::avrocpp_static,avro-cpp::avrocpp_shared>>"
@@ -155,6 +161,8 @@ if(ICEBERG_BUILD_BUNDLE)
   list(APPEND
        ICEBERG_BUNDLE_SHARED_INSTALL_INTERFACE_LIBS
        "$<IF:$<TARGET_EXISTS:Iceberg::iceberg_shared>,Iceberg::iceberg_shared,Iceberg::iceberg_static>"
+       "$<IF:$<BOOL:${CURL_VENDORED}>,Iceberg::libcurl_static,$<IF:$<TARGET_EXISTS:CURL::libcurl>,CURL::libcurl,CURL::libcurl>>"
+       "$<IF:$<BOOL:${CPR_VENDORED}>,Iceberg::cpr,$<IF:$<TARGET_EXISTS:cpr::cpr>,cpr::cpr,cpr::cpr>>"
        "$<IF:$<BOOL:${ARROW_VENDORED}>,Iceberg::arrow_static,$<IF:$<TARGET_EXISTS:Arrow::arrow_shared>,Arrow::arrow_shared,Arrow::arrow_static>>"
        "$<IF:$<BOOL:${ARROW_VENDORED}>,Iceberg::parquet_static,$<IF:$<TARGET_EXISTS:Parquet::parquet_shared>,Parquet::parquet_shared,Parquet::parquet_static>>"
        "$<IF:$<BOOL:${AVRO_VENDORED}>,Iceberg::avrocpp_s,$<IF:$<TARGET_EXISTS:avro-cpp::avrocpp_shared>,avro-cpp::avrocpp_shared,avro-cpp::avrocpp_static>>"

--- a/src/iceberg/IcebergConfig.cmake.in
+++ b/src/iceberg/IcebergConfig.cmake.in
@@ -26,6 +26,8 @@
 #   Iceberg::iceberg_static
 #   Iceberg::iceberg_bundle_shared
 #   Iceberg::iceberg_bundle_static
+#   Iceberg::iceberg_rest_shared
+#   Iceberg::iceberg_rest_static
 
 @PACKAGE_INIT@
 
@@ -77,6 +79,10 @@ endif()
 
 if(NOT TARGET roaring::roaring-headers-cpp)
   add_library(roaring::roaring-headers-cpp INTERFACE IMPORTED)
+endif()
+
+if(NOT TARGET CURL::libcurl)
+  add_library(CURL::libcurl INTERFACE IMPORTED)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/IcebergTargets.cmake")

--- a/src/iceberg/catalog/CMakeLists.txt
+++ b/src/iceberg/catalog/CMakeLists.txt
@@ -16,3 +16,7 @@
 # under the License.
 
 iceberg_install_all_headers(iceberg/catalog)
+
+if(ICEBERG_BUILD_REST)
+  add_subdirectory(rest)
+endif()

--- a/src/iceberg/catalog/rest/CMakeLists.txt
+++ b/src/iceberg/catalog/rest/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(ICEBERG_REST_SOURCES rest_catalog.cc)
+
+set(ICEBERG_REST_STATIC_BUILD_INTERFACE_LIBS)
+set(ICEBERG_REST_SHARED_BUILD_INTERFACE_LIBS)
+set(ICEBERG_REST_STATIC_INSTALL_INTERFACE_LIBS)
+set(ICEBERG_REST_SHARED_INSTALL_INTERFACE_LIBS)
+
+list(APPEND ICEBERG_REST_STATIC_BUILD_INTERFACE_LIBS
+     "$<IF:$<TARGET_EXISTS:iceberg_static>,iceberg_static,iceberg_shared>" cpr::cpr)
+list(APPEND ICEBERG_REST_SHARED_BUILD_INTERFACE_LIBS
+     "$<IF:$<TARGET_EXISTS:iceberg_shared>,iceberg_shared,iceberg_static>" cpr::cpr)
+list(APPEND
+     ICEBERG_REST_STATIC_INSTALL_INTERFACE_LIBS
+     "$<IF:$<TARGET_EXISTS:Iceberg::iceberg_static>,Iceberg::iceberg_static,Iceberg::iceberg_shared>"
+     "$<IF:$<BOOL:${CPR_VENDORED}>,Iceberg::cpr,cpr::cpr>")
+list(APPEND
+     ICEBERG_REST_SHARED_INSTALL_INTERFACE_LIBS
+     "$<IF:$<TARGET_EXISTS:Iceberg::iceberg_shared>,Iceberg::iceberg_shared,Iceberg::iceberg_static>"
+     "$<IF:$<BOOL:${CPR_VENDORED}>,Iceberg::cpr,cpr::cpr>")
+
+add_iceberg_lib(iceberg_rest
+                SOURCES
+                ${ICEBERG_REST_SOURCES}
+                SHARED_LINK_LIBS
+                ${ICEBERG_REST_SHARED_BUILD_INTERFACE_LIBS}
+                STATIC_LINK_LIBS
+                ${ICEBERG_REST_STATIC_BUILD_INTERFACE_LIBS}
+                STATIC_INSTALL_INTERFACE_LIBS
+                ${ICEBERG_REST_STATIC_INSTALL_INTERFACE_LIBS}
+                SHARED_INSTALL_INTERFACE_LIBS
+                ${ICEBERG_REST_SHARED_INSTALL_INTERFACE_LIBS})
+
+iceberg_install_all_headers(iceberg/catalog/rest)

--- a/src/iceberg/catalog/rest/rest_catalog.cc
+++ b/src/iceberg/catalog/rest/rest_catalog.cc
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/catalog/rest/rest_catalog.h"
+
+#include <utility>
+
+#include <cpr/cpr.h>
+
+namespace iceberg::catalog::rest {
+
+RestCatalog::RestCatalog(const std::string& base_url) : base_url_(std::move(base_url)) {}
+
+cpr::Response RestCatalog::GetConfig() {
+  cpr::Url url = cpr::Url{base_url_ + "/v1/config"};
+  cpr::Response r = cpr::Get(url);
+  return r;
+}
+
+cpr::Response RestCatalog::ListNamespaces() {
+  cpr::Url url = cpr::Url{base_url_ + "/v1/namespaces"};
+  cpr::Response r = cpr::Get(url);
+  return r;
+}
+
+}  // namespace iceberg::catalog::rest

--- a/src/iceberg/catalog/rest/rest_catalog.h
+++ b/src/iceberg/catalog/rest/rest_catalog.h
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <string>
+
+#include <cpr/cpr.h>
+
+#include "iceberg/catalog/rest/iceberg_rest_export.h"
+
+namespace iceberg::catalog::rest {
+
+class ICEBERG_REST_EXPORT RestCatalog {
+ public:
+  explicit RestCatalog(const std::string& base_url);
+  ~RestCatalog() = default;
+
+  cpr::Response GetConfig();
+
+  cpr::Response ListNamespaces();
+
+ private:
+  std::string base_url_;
+};
+
+}  // namespace iceberg::catalog::rest


### PR DESCRIPTION
Add cpr and curl dependency for REST catalog. This is related to #232 .

The current code in the REST package is just a demo example to verify the feasibility of cpr, which will be replaced in future commits. The actual content will be added in subsequent PRs so that we can keep the size of each PR reasonable.
