### PR TITLE
feat: add version header generation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ project(Iceberg
         DESCRIPTION "Iceberg C++ Project"
         LANGUAGES CXX)
 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/iceberg/version.h.in"
+               "${CMAKE_BINARY_DIR}/src/iceberg/version.h")
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/src/iceberg/version.h.in
+++ b/src/iceberg/version.h.in
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#define ICEBERG_VERSION_MAJOR @PROJECT_VERSION_MAJOR@
+#define ICEBERG_VERSION_MINOR @PROJECT_VERSION_MINOR@
+#define ICEBERG_VERSION_PATCH @PROJECT_VERSION_PATCH@
+
+#define ICEBERG_VERSION_STRING "@PROJECT_VERSION@"
+
+#define ICEBERG_PROJECT_NAME "@PROJECT_NAME@"


### PR DESCRIPTION
Create compile-time version information from the project version.
I have tested that the added version macros are properly generated and functional.