### PR TITLE
feat: update ci macOS version from 15 to 26

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-15
+          - macos-26
           - ubuntu-24.04
           # - windows-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,8 +111,8 @@ jobs:
           - title: AMD64 Windows 2025
             runs-on: windows-2025
             meson-setup-args: --vsenv
-          - title: AArch64 macOS 15
-            runs-on: macos-15
+          - title: AArch64 macOS 26
+            runs-on: macos-26
     steps:
       - uses: actions/setup-python@v5
         with:

--- a/src/iceberg/table.h
+++ b/src/iceberg/table.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
Current code cann't be compiled in latest macOS. See https://github.com/HuaHuaY/iceberg-cpp/actions/runs/18551254106/job/52879022386