### PR TITLE
chore: remove fetch-depth: 0 of checkout action

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -32,8 +32,6 @@ jobs:
     steps:
       - name: Checkout iceberg-cpp
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
       - name: Install dependencies
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,6 @@ jobs:
     steps:
       - name: Checkout iceberg-cpp
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
       - name: Install dependencies
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
@@ -66,8 +64,6 @@ jobs:
     steps:
       - name: Checkout iceberg-cpp
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
       - name: Build Iceberg
         shell: bash
         run: ci/scripts/build_iceberg.sh $(pwd)
@@ -83,8 +79,6 @@ jobs:
     steps:
       - name: Checkout iceberg-cpp
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
       - name: Install dependencies
         shell: cmd
         run: |
@@ -119,8 +113,6 @@ jobs:
           python-version: '3.x'
       - name: Checkout iceberg-cpp
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
       - name: Install build dependencies
         run: |
           python3 -m pip install --upgrade pip


### PR DESCRIPTION
The README[1] of actions/checkout says:

0 indicates all history for all branches and tags.

I think we don't need all history, so the default 1 should be fine.

[1] https://github.com/actions/checkout/blob/main/README.md?plain=1#L120