### PR TITLE
refactor: remove unused `StringUtils::EqualsIgnoreCase` function

### DIFF
--- a/src/iceberg/util/string_util.h
+++ b/src/iceberg/util/string_util.h
@@ -44,11 +44,6 @@ class ICEBERG_EXPORT StringUtils {
                    [](char c) { return std::toupper(c); });    // NOLINT
     return input;
   }
-
-  static bool EqualsIgnoreCase(const std::string& lhs, const std::string& rhs) {
-    return std::ranges::equal(
-        lhs, rhs, [](char lc, char rc) { return std::tolower(lc) == std::tolower(rc); });
-  }
 };
 
 /// \brief Transparent hash function that supports std::string_view as lookup key


### PR DESCRIPTION
Nit - removing unused helper function recently introduced in https://github.com/apache/iceberg-cpp/pull/257