### PR TITLE
chore: some warning worth fixing

### DIFF
--- a/src/iceberg/manifest_adapter.cc
+++ b/src/iceberg/manifest_adapter.cc
@@ -167,7 +167,7 @@ Status ManifestEntryAdapter::AppendPartitionValues(
   }
   auto fields = partition_type->fields();
 
-  for (int32_t i = 0; i < fields.size(); i++) {
+  for (size_t i = 0; i < fields.size(); i++) {
     const auto& partition_value = partition_values[i];
     const auto& partition_field = fields[i];
     auto child_array = array->children[i];
@@ -243,7 +243,7 @@ Status ManifestEntryAdapter::AppendDataFile(
     ArrowArray* array, const std::shared_ptr<StructType>& data_file_type,
     const DataFile& file) {
   auto fields = data_file_type->fields();
-  for (int32_t i = 0; i < fields.size(); i++) {
+  for (size_t i = 0; i < fields.size(); i++) {
     const auto& field = fields[i];
     auto child_array = array->children[i];
 
@@ -382,7 +382,7 @@ Result<std::optional<int64_t>> ManifestEntryAdapter::GetContentSizeInBytes(
 
 Status ManifestEntryAdapter::AppendInternal(const ManifestEntry& entry) {
   const auto& fields = manifest_schema_->fields();
-  for (int32_t i = 0; i < fields.size(); i++) {
+  for (size_t i = 0; i < fields.size(); i++) {
     const auto& field = fields[i];
     auto array = array_.children[i];
 
@@ -555,7 +555,7 @@ Result<std::optional<int64_t>> ManifestFileAdapter::GetFirstRowId(
 
 Status ManifestFileAdapter::AppendInternal(const ManifestFile& file) {
   const auto& fields = manifest_list_schema_->fields();
-  for (int32_t i = 0; i < fields.size(); i++) {
+  for (size_t i = 0; i < fields.size(); i++) {
     const auto& field = fields[i];
     auto array = array_.children[i];
     switch (field.field_id()) {

--- a/src/iceberg/manifest_reader_internal.cc
+++ b/src/iceberg/manifest_reader_internal.cc
@@ -476,7 +476,7 @@ Result<std::vector<ManifestEntry>> ParseManifestEntry(ArrowSchema* schema,
 
   std::vector<ManifestEntry> manifest_entries;
   manifest_entries.resize(array_in->length);
-  for (size_t i = 0; i < array_in->length; i++) {
+  for (int64_t i = 0; i < array_in->length; i++) {
     manifest_entries[i].data_file = std::make_shared<DataFile>();
   }
 

--- a/src/iceberg/schema.cc
+++ b/src/iceberg/schema.cc
@@ -166,8 +166,8 @@ Status IdToFieldVisitor::Visit(const NestedType& type) {
 NameToIdVisitor::NameToIdVisitor(
     std::unordered_map<std::string, int32_t, StringHash, std::equal_to<>>& name_to_id,
     bool case_sensitive, std::function<std::string(std::string_view)> quoting_func)
-    : name_to_id_(name_to_id),
-      case_sensitive_(case_sensitive),
+    : case_sensitive_(case_sensitive),
+      name_to_id_(name_to_id),
       quoting_func_(std::move(quoting_func)) {}
 
 Status NameToIdVisitor::Visit(const ListType& type, const std::string& path,

--- a/src/iceberg/util/murmurhash3_internal.cc
+++ b/src/iceberg/util/murmurhash3_internal.cc
@@ -120,8 +120,10 @@ void MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* out) {
   switch (len & 3) {
     case 3:
       k1 ^= tail[2] << 16;
+      [[fallthrough]];
     case 2:
       k1 ^= tail[1] << 8;
+      [[fallthrough]];
     case 1:
       k1 ^= tail[0];
       k1 *= c1;
@@ -217,47 +219,61 @@ void MurmurHash3_x86_128(const void* key, const int len, uint32_t seed, void* ou
   switch (len & 15) {
     case 15:
       k4 ^= tail[14] << 16;
+      [[fallthrough]];
     case 14:
       k4 ^= tail[13] << 8;
+      [[fallthrough]];
     case 13:
       k4 ^= tail[12] << 0;
       k4 *= c4;
       k4 = ROTL32(k4, 18);
       k4 *= c1;
       h4 ^= k4;
+      [[fallthrough]];
 
     case 12:
       k3 ^= tail[11] << 24;
+      [[fallthrough]];
     case 11:
       k3 ^= tail[10] << 16;
+      [[fallthrough]];
     case 10:
       k3 ^= tail[9] << 8;
+      [[fallthrough]];
     case 9:
       k3 ^= tail[8] << 0;
       k3 *= c3;
       k3 = ROTL32(k3, 17);
       k3 *= c4;
       h3 ^= k3;
+      [[fallthrough]];
 
     case 8:
       k2 ^= tail[7] << 24;
+      [[fallthrough]];
     case 7:
       k2 ^= tail[6] << 16;
+      [[fallthrough]];
     case 6:
       k2 ^= tail[5] << 8;
+      [[fallthrough]];
     case 5:
       k2 ^= tail[4] << 0;
       k2 *= c2;
       k2 = ROTL32(k2, 16);
       k2 *= c3;
       h2 ^= k2;
+      [[fallthrough]];
 
     case 4:
       k1 ^= tail[3] << 24;
+      [[fallthrough]];
     case 3:
       k1 ^= tail[2] << 16;
+      [[fallthrough]];
     case 2:
       k1 ^= tail[1] << 8;
+      [[fallthrough]];
     case 1:
       k1 ^= tail[0] << 0;
       k1 *= c1;
@@ -350,37 +366,51 @@ void MurmurHash3_x64_128(const void* key, const int len, const uint32_t seed, vo
   switch (len & 15) {
     case 15:
       k2 ^= ((uint64_t)tail[14]) << 48;
+      [[fallthrough]];
     case 14:
       k2 ^= ((uint64_t)tail[13]) << 40;
+      [[fallthrough]];
     case 13:
       k2 ^= ((uint64_t)tail[12]) << 32;
+      [[fallthrough]];
     case 12:
       k2 ^= ((uint64_t)tail[11]) << 24;
+      [[fallthrough]];
     case 11:
       k2 ^= ((uint64_t)tail[10]) << 16;
+      [[fallthrough]];
     case 10:
       k2 ^= ((uint64_t)tail[9]) << 8;
+      [[fallthrough]];
     case 9:
       k2 ^= ((uint64_t)tail[8]) << 0;
       k2 *= c2;
       k2 = ROTL64(k2, 33);
       k2 *= c1;
       h2 ^= k2;
+      [[fallthrough]];
 
     case 8:
       k1 ^= ((uint64_t)tail[7]) << 56;
+      [[fallthrough]];
     case 7:
       k1 ^= ((uint64_t)tail[6]) << 48;
+      [[fallthrough]];
     case 6:
       k1 ^= ((uint64_t)tail[5]) << 40;
+      [[fallthrough]];
     case 5:
       k1 ^= ((uint64_t)tail[4]) << 32;
+      [[fallthrough]];
     case 4:
       k1 ^= ((uint64_t)tail[3]) << 24;
+      [[fallthrough]];
     case 3:
       k1 ^= ((uint64_t)tail[2]) << 16;
+      [[fallthrough]];
     case 2:
       k1 ^= ((uint64_t)tail[1]) << 8;
+      [[fallthrough]];
     case 1:
       k1 ^= ((uint64_t)tail[0]) << 0;
       k1 *= c1;

--- a/src/iceberg/util/truncate_util.h
+++ b/src/iceberg/util/truncate_util.h
@@ -58,7 +58,7 @@ class ICEBERG_EXPORT TruncateUtils {
       source.resize(safe_point);
     }
 
-    return std::move(source);
+    return source;
   }
 
   /// \brief Truncate an integer v, either int32_t or int64_t, to v - (v % W).


### PR DESCRIPTION
Meson build has warning_level=2, which enables -Wall -Wextra compiler flags. Some of the warning seems worth fixing.

This PR resolves some of the following warnings:

-Wredundant-move
-Wimplicit-fallthrough
-Wreorder
-Wsign-compare