### PR TITLE
fix: correct clang-tidy HeaderFilterRegex to match Posix ERE

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,4 +39,4 @@ CheckOptions:
   - key:    readability-identifier-naming.ProtectedMemberSuffix
     value:  '_'
 
-HeaderFilterRegex: '(?!_deps)(src|test|example)'
+HeaderFilterRegex: 'src/iceberg|example'


### PR DESCRIPTION
`HeaderFilterRegex` is a whitelist to determine info of which header file will be reported by clang-tidy.

```
  --header-filter=<string>        - Regular expression matching the names of the
                                    headers to output diagnostics from. Diagnostics
                                    from the main file of each translation unit are
                                    always displayed.
                                    Can be used together with -line-filter.
                                    This option overrides the 'HeaderFilterRegex'
                                    option in .clang-tidy file, if any.
```

Previous config `HeaderFilterRegex: '(?!_deps)(src|test|example)'` can filter `build/_deps/nlohmann_json-src`, but it is an illegal syntax in clang-tidy's regex engine. It seems that clang-tidy doesn't support negative lookahead. Forgive me for using 'seems', I have only found too little information about clang-tidy's regex syntax. And in fact I still haven't figured out how it works. And there are also some bugs in clang-tidy, see https://github.com/llvm/llvm-project/issues/138302.

Clang-tidy 19 supports a new feature `ExcludeHeaderFilterRegex` but we use version 18 as default. So we can only find another way to filter `build/_deps/nlohmann_json-src`.