### PR TITLE
feat: make avro and parquet reader writer more configurable

### DIFF
--- a/src/iceberg/avro/avro_reader.cc
+++ b/src/iceberg/avro/avro_reader.cc
@@ -82,7 +82,7 @@ class AvroReader::Impl {
       return InvalidArgument("Projected schema is required by Avro reader");
     }
 
-    batch_size_ = options.batch_size;
+    batch_size_ = options.properties->Get(ReaderProperties::kBatchSize);
     read_schema_ = options.projection;
 
     // Open the input stream and adapt to the avro interface.

--- a/src/iceberg/file_reader.cc
+++ b/src/iceberg/file_reader.cc
@@ -59,4 +59,15 @@ Result<std::unique_ptr<Reader>> ReaderFactoryRegistry::Open(
   return reader;
 }
 
+std::unique_ptr<ReaderProperties> ReaderProperties::default_properties() {
+  return std::make_unique<ReaderProperties>();
+}
+
+std::unique_ptr<ReaderProperties> ReaderProperties::FromMap(
+    const std::unordered_map<std::string, std::string>& properties) {
+  auto reader_properties = std::make_unique<ReaderProperties>();
+  reader_properties->configs_ = properties;
+  return reader_properties;
+}
+
 }  // namespace iceberg

--- a/src/iceberg/file_writer.cc
+++ b/src/iceberg/file_writer.cc
@@ -59,4 +59,15 @@ Result<std::unique_ptr<Writer>> WriterFactoryRegistry::Open(
   return writer;
 }
 
+std::unique_ptr<WriterProperties> WriterProperties::default_properties() {
+  return std::make_unique<WriterProperties>();
+}
+
+std::unique_ptr<WriterProperties> WriterProperties::FromMap(
+    const std::unordered_map<std::string, std::string>& properties) {
+  auto writer_properties = std::make_unique<WriterProperties>();
+  writer_properties->configs_ = properties;
+  return writer_properties;
+}
+
 }  // namespace iceberg

--- a/src/iceberg/manifest_reader.h
+++ b/src/iceberg/manifest_reader.h
@@ -36,7 +36,12 @@ namespace iceberg {
 class ICEBERG_EXPORT ManifestReader {
  public:
   virtual ~ManifestReader() = default;
+
+  /// \brief Read all manifest entries in the manifest file.
   virtual Result<std::vector<ManifestEntry>> Entries() const = 0;
+
+  /// \brief Get the metadata of the manifest file.
+  virtual Result<std::unordered_map<std::string, std::string>> Metadata() const = 0;
 
   /// \brief Creates a reader for a manifest file.
   /// \param manifest A ManifestFile object containing metadata about the manifest.
@@ -61,7 +66,12 @@ class ICEBERG_EXPORT ManifestReader {
 class ICEBERG_EXPORT ManifestListReader {
  public:
   virtual ~ManifestListReader() = default;
+
+  /// \brief Read all manifest files in the manifest list file.
   virtual Result<std::vector<ManifestFile>> Files() const = 0;
+
+  /// \brief Get the metadata of the manifest list file.
+  virtual Result<std::unordered_map<std::string, std::string>> Metadata() const = 0;
 
   /// \brief Creates a reader for the manifest list.
   /// \param manifest_list_location Path to the manifest list file.

--- a/src/iceberg/manifest_reader_internal.cc
+++ b/src/iceberg/manifest_reader_internal.cc
@@ -548,6 +548,11 @@ Result<std::vector<ManifestEntry>> ManifestReaderImpl::Entries() const {
   return manifest_entries;
 }
 
+Result<std::unordered_map<std::string, std::string>> ManifestReaderImpl::Metadata()
+    const {
+  return reader_->Metadata();
+}
+
 Result<std::vector<ManifestFile>> ManifestListReaderImpl::Files() const {
   std::vector<ManifestFile> manifest_files;
   ICEBERG_ASSIGN_OR_RAISE(auto arrow_schema, reader_->Schema());
@@ -567,6 +572,11 @@ Result<std::vector<ManifestFile>> ManifestListReaderImpl::Files() const {
     }
   }
   return manifest_files;
+}
+
+Result<std::unordered_map<std::string, std::string>> ManifestListReaderImpl::Metadata()
+    const {
+  return reader_->Metadata();
 }
 
 Result<ManifestFileField> ManifestFileFieldFromIndex(int32_t index) {

--- a/src/iceberg/manifest_reader_internal.h
+++ b/src/iceberg/manifest_reader_internal.h
@@ -40,6 +40,8 @@ class ManifestReaderImpl : public ManifestReader {
 
   Result<std::vector<ManifestEntry>> Entries() const override;
 
+  Result<std::unordered_map<std::string, std::string>> Metadata() const override;
+
  private:
   std::shared_ptr<Schema> schema_;
   std::unique_ptr<Reader> reader_;
@@ -54,6 +56,8 @@ class ManifestListReaderImpl : public ManifestListReader {
       : schema_(std::move(schema)), reader_(std::move(reader)) {}
 
   Result<std::vector<ManifestFile>> Files() const override;
+
+  Result<std::unordered_map<std::string, std::string>> Metadata() const override;
 
  private:
   std::shared_ptr<Schema> schema_;

--- a/src/iceberg/parquet/parquet_reader.cc
+++ b/src/iceberg/parquet/parquet_reader.cc
@@ -122,7 +122,8 @@ class ParquetReader::Impl {
     // Prepare reader properties
     ::parquet::ReaderProperties reader_properties(pool_);
     ::parquet::ArrowReaderProperties arrow_reader_properties;
-    arrow_reader_properties.set_batch_size(options.batch_size);
+    arrow_reader_properties.set_batch_size(
+        options.properties->Get(ReaderProperties::kBatchSize));
     arrow_reader_properties.set_arrow_extensions_enabled(true);
 
     // Open the Parquet file reader

--- a/src/iceberg/parquet/parquet_writer.cc
+++ b/src/iceberg/parquet/parquet_writer.cc
@@ -68,7 +68,8 @@ class ParquetWriter::Impl {
 
     ICEBERG_ASSIGN_OR_RAISE(output_stream_, OpenOutputStream(options));
     auto file_writer = ::parquet::ParquetFileWriter::Open(
-        output_stream_, std::move(schema_node), std::move(writer_properties));
+        output_stream_, std::move(schema_node), std::move(writer_properties),
+        std::make_shared<::arrow::KeyValueMetadata>(options.metadata));
     ICEBERG_ARROW_RETURN_NOT_OK(
         ::parquet::arrow::FileWriter::Make(pool_, std::move(file_writer), arrow_schema_,
                                            std::move(arrow_writer_properties), &writer_));

--- a/src/iceberg/type_fwd.h
+++ b/src/iceberg/type_fwd.h
@@ -139,6 +139,8 @@ class ManifestListWriter;
 class ManifestReader;
 class ManifestWriter;
 
+struct ReaderOptions;
+struct WriterOptions;
 class Reader;
 class Writer;
 


### PR DESCRIPTION
- Added WriterProperties and ReaderProperties with predefined keys
- Supported writing key-value metadata to file
- Allowed manifest writer to customize avro schema name

Fixes #306