### PR TITLE
infra: notify on github workflow failure

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -55,4 +55,5 @@ notifications:
   commits:      commits@iceberg.apache.org
   issues:       issues@iceberg.apache.org
   pullrequests: issues@iceberg.apache.org
+  jobs:         ci-jobs@iceberg.apache.org
   jira_options: link label link label


### PR DESCRIPTION
Notify ci-jobs@iceberg.apache.org when Github Workflow fails

For more context, see https://lists.apache.org/thread/sx7hz7tcs39tcfgywdh97gvbrtpdftxl