### PR TITLE
refactor: suppress warnings

### DIFF
--- a/src/iceberg/catalog/memory/in_memory_catalog.cc
+++ b/src/iceberg/catalog/memory/in_memory_catalog.cc
@@ -384,23 +384,25 @@ Result<std::vector<TableIdentifier>> InMemoryCatalog::ListTables(
 }
 
 Result<std::unique_ptr<Table>> InMemoryCatalog::CreateTable(
-    const TableIdentifier& identifier, const Schema& schema, const PartitionSpec& spec,
-    const std::string& location,
-    const std::unordered_map<std::string, std::string>& properties) {
+    [[maybe_unused]] const TableIdentifier& identifier,
+    [[maybe_unused]] const Schema& schema, [[maybe_unused]] const PartitionSpec& spec,
+    [[maybe_unused]] const std::string& location,
+    [[maybe_unused]] const std::unordered_map<std::string, std::string>& properties) {
   return NotImplemented("create table");
 }
 
 Result<std::unique_ptr<Table>> InMemoryCatalog::UpdateTable(
-    const TableIdentifier& identifier,
-    const std::vector<std::unique_ptr<TableRequirement>>& requirements,
-    const std::vector<std::unique_ptr<TableUpdate>>& updates) {
+    [[maybe_unused]] const TableIdentifier& identifier,
+    [[maybe_unused]] const std::vector<std::unique_ptr<TableRequirement>>& requirements,
+    [[maybe_unused]] const std::vector<std::unique_ptr<TableUpdate>>& updates) {
   return NotImplemented("update table");
 }
 
 Result<std::shared_ptr<Transaction>> InMemoryCatalog::StageCreateTable(
-    const TableIdentifier& identifier, const Schema& schema, const PartitionSpec& spec,
-    const std::string& location,
-    const std::unordered_map<std::string, std::string>& properties) {
+    [[maybe_unused]] const TableIdentifier& identifier,
+    [[maybe_unused]] const Schema& schema, [[maybe_unused]] const PartitionSpec& spec,
+    [[maybe_unused]] const std::string& location,
+    [[maybe_unused]] const std::unordered_map<std::string, std::string>& properties) {
   return NotImplemented("stage create table");
 }
 
@@ -409,14 +411,15 @@ Result<bool> InMemoryCatalog::TableExists(const TableIdentifier& identifier) con
   return root_namespace_->TableExists(identifier);
 }
 
-Status InMemoryCatalog::DropTable(const TableIdentifier& identifier, bool purge) {
+Status InMemoryCatalog::DropTable(const TableIdentifier& identifier,
+                                  [[maybe_unused]] bool purge) {
   std::unique_lock lock(mutex_);
   // TODO(Guotao): Delete all metadata files if purge is true.
   return root_namespace_->UnregisterTable(identifier);
 }
 
-Status InMemoryCatalog::RenameTable(const TableIdentifier& from,
-                                    const TableIdentifier& to) {
+Status InMemoryCatalog::RenameTable([[maybe_unused]] const TableIdentifier& from,
+                                    [[maybe_unused]] const TableIdentifier& to) {
   std::unique_lock lock(mutex_);
   return NotImplemented("rename table");
 }
@@ -455,7 +458,8 @@ Result<std::shared_ptr<Table>> InMemoryCatalog::RegisterTable(
 }
 
 std::unique_ptr<Catalog::TableBuilder> InMemoryCatalog::BuildTable(
-    const TableIdentifier& identifier, const Schema& schema) const {
+    [[maybe_unused]] const TableIdentifier& identifier,
+    [[maybe_unused]] const Schema& schema) const {
   throw IcebergError("not implemented");
 }
 

--- a/src/iceberg/catalog/rest/types.h
+++ b/src/iceberg/catalog/rest/types.h
@@ -39,9 +39,9 @@ namespace iceberg::rest {
 
 /// \brief Server-provided configuration for the catalog.
 struct ICEBERG_REST_EXPORT CatalogConfig {
-  std::unordered_map<std::string, std::string> defaults;   // required
-  std::unordered_map<std::string, std::string> overrides;  // required
-  std::vector<std::string> endpoints;
+  std::unordered_map<std::string, std::string> defaults{};   // required
+  std::unordered_map<std::string, std::string> overrides{};  // required
+  std::vector<std::string> endpoints{};
 
   /// \brief Validates the CatalogConfig.
   Status Validate() const {
@@ -58,7 +58,7 @@ struct ICEBERG_REST_EXPORT ErrorModel {
   std::string message;  // required
   std::string type;     // required
   uint32_t code;        // required
-  std::vector<std::string> stack;
+  std::vector<std::string> stack{};
 
   /// \brief Validates the ErrorModel.
   Status Validate() const {
@@ -88,7 +88,7 @@ struct ICEBERG_REST_EXPORT ErrorResponse {
 /// \brief Request to create a namespace.
 struct ICEBERG_REST_EXPORT CreateNamespaceRequest {
   Namespace namespace_;  // required
-  std::unordered_map<std::string, std::string> properties;
+  std::unordered_map<std::string, std::string> properties{};
 
   /// \brief Validates the CreateNamespaceRequest.
   Status Validate() const { return {}; }
@@ -96,8 +96,8 @@ struct ICEBERG_REST_EXPORT CreateNamespaceRequest {
 
 /// \brief Update or delete namespace properties request.
 struct ICEBERG_REST_EXPORT UpdateNamespacePropertiesRequest {
-  std::vector<std::string> removals;
-  std::unordered_map<std::string, std::string> updates;
+  std::vector<std::string> removals{};
+  std::unordered_map<std::string, std::string> updates{};
 
   /// \brief Validates the UpdateNamespacePropertiesRequest.
   Status Validate() const {
@@ -171,7 +171,7 @@ using LoadTableResponse = LoadTableResult;
 /// \brief Response body for listing namespaces.
 struct ICEBERG_REST_EXPORT ListNamespacesResponse {
   PageToken next_page_token;
-  std::vector<Namespace> namespaces;
+  std::vector<Namespace> namespaces{};
 
   /// \brief Validates the ListNamespacesResponse.
   Status Validate() const { return {}; }
@@ -180,7 +180,7 @@ struct ICEBERG_REST_EXPORT ListNamespacesResponse {
 /// \brief Response body after creating a namespace.
 struct ICEBERG_REST_EXPORT CreateNamespaceResponse {
   Namespace namespace_;  // required
-  std::unordered_map<std::string, std::string> properties;
+  std::unordered_map<std::string, std::string> properties{};
 
   /// \brief Validates the CreateNamespaceResponse.
   Status Validate() const { return {}; }
@@ -189,7 +189,7 @@ struct ICEBERG_REST_EXPORT CreateNamespaceResponse {
 /// \brief Response body for loading namespace properties.
 struct ICEBERG_REST_EXPORT GetNamespaceResponse {
   Namespace namespace_;  // required
-  std::unordered_map<std::string, std::string> properties;
+  std::unordered_map<std::string, std::string> properties{};
 
   /// \brief Validates the GetNamespaceResponse.
   Status Validate() const { return {}; }
@@ -197,9 +197,9 @@ struct ICEBERG_REST_EXPORT GetNamespaceResponse {
 
 /// \brief Response body after updating namespace properties.
 struct ICEBERG_REST_EXPORT UpdateNamespacePropertiesResponse {
-  std::vector<std::string> updated;  // required
-  std::vector<std::string> removed;  // required
-  std::vector<std::string> missing;
+  std::vector<std::string> updated{};  // required
+  std::vector<std::string> removed{};  // required
+  std::vector<std::string> missing{};
 
   /// \brief Validates the UpdateNamespacePropertiesResponse.
   Status Validate() const { return {}; }
@@ -208,7 +208,7 @@ struct ICEBERG_REST_EXPORT UpdateNamespacePropertiesResponse {
 /// \brief Response body for listing tables in a namespace.
 struct ICEBERG_REST_EXPORT ListTablesResponse {
   PageToken next_page_token;
-  std::vector<TableIdentifier> identifiers;
+  std::vector<TableIdentifier> identifiers{};
 
   /// \brief Validates the ListTablesResponse.
   Status Validate() const { return {}; }

--- a/src/iceberg/expression/binder.cc
+++ b/src/iceberg/expression/binder.cc
@@ -84,11 +84,13 @@ Result<bool> IsBoundVisitor::Or(bool left_result, bool right_result) {
   return left_result && right_result;
 }
 
-Result<bool> IsBoundVisitor::Predicate(const std::shared_ptr<BoundPredicate>& pred) {
+Result<bool> IsBoundVisitor::Predicate(
+    [[maybe_unused]] const std::shared_ptr<BoundPredicate>& pred) {
   return true;
 }
 
-Result<bool> IsBoundVisitor::Predicate(const std::shared_ptr<UnboundPredicate>& pred) {
+Result<bool> IsBoundVisitor::Predicate(
+    [[maybe_unused]] const std::shared_ptr<UnboundPredicate>& pred) {
   return false;
 }
 

--- a/src/iceberg/expression/expression.h
+++ b/src/iceberg/expression/expression.h
@@ -75,7 +75,7 @@ class ICEBERG_EXPORT Expression : public util::Formattable {
   /// \brief Returns whether this expression will accept the same values as another.
   /// \param other another expression
   /// \return true if the expressions are equivalent
-  virtual bool Equals(const Expression& other) const {
+  virtual bool Equals([[maybe_unused]] const Expression& other) const {
     // only bound predicates can be equivalent
     return false;
   }

--- a/src/iceberg/expression/expression_visitor.h
+++ b/src/iceberg/expression/expression_visitor.h
@@ -99,13 +99,13 @@ class ICEBERG_EXPORT BoundVisitor : public ExpressionVisitor<R> {
 
   /// \brief Visit an IS_NAN unary predicate.
   /// \param term The bound term being tested
-  virtual Result<R> IsNaN(const std::shared_ptr<BoundTerm>& term) {
+  virtual Result<R> IsNaN([[maybe_unused]] const std::shared_ptr<BoundTerm>& term) {
     return NotSupported("IsNaN operation is not supported by this visitor");
   }
 
   /// \brief Visit a NOT_NAN unary predicate.
   /// \param term The bound term being tested
-  virtual Result<R> NotNaN(const std::shared_ptr<BoundTerm>& term) {
+  virtual Result<R> NotNaN([[maybe_unused]] const std::shared_ptr<BoundTerm>& term) {
     return NotSupported("NotNaN operation is not supported by this visitor");
   }
 

--- a/src/iceberg/expression/expressions.cc
+++ b/src/iceberg/expression/expressions.cc
@@ -372,7 +372,8 @@ std::shared_ptr<NamedReference> Expressions::Ref(std::string name) {
   return ref;
 }
 
-Literal Expressions::Lit(Literal::Value value, std::shared_ptr<PrimitiveType> type) {
+Literal Expressions::Lit([[maybe_unused]] Literal::Value value,
+                         [[maybe_unused]] std::shared_ptr<PrimitiveType> type) {
   throw ExpressionError("Literal creation is not implemented");
 }
 

--- a/src/iceberg/expression/literal.cc
+++ b/src/iceberg/expression/literal.cc
@@ -245,7 +245,7 @@ Result<Literal> LiteralCaster::CastFromBinary(
   switch (target_type->type_id()) {
     case TypeId::kFixed: {
       auto target_fixed_type = internal::checked_pointer_cast<FixedType>(target_type);
-      if (binary_val.size() == target_fixed_type->length()) {
+      if (binary_val.size() == static_cast<size_t>(target_fixed_type->length())) {
         return Literal::Fixed(std::move(binary_val));
       }
       return InvalidArgument("Failed to cast Binary with length {} to Fixed({})",
@@ -505,8 +505,8 @@ bool Literal::IsAboveMax() const { return std::holds_alternative<AboveMax>(value
 bool Literal::IsNull() const { return std::holds_alternative<std::monostate>(value_); }
 
 bool Literal::IsNaN() const {
-  return std::holds_alternative<float>(value_) && std::isnan(std::get<float>(value_)) ||
-         std::holds_alternative<double>(value_) && std::isnan(std::get<double>(value_));
+  return (std::holds_alternative<float>(value_) && std::isnan(std::get<float>(value_))) ||
+         (std::holds_alternative<double>(value_) && std::isnan(std::get<double>(value_)));
 }
 
 // LiteralCaster implementation

--- a/src/iceberg/file_io.h
+++ b/src/iceberg/file_io.h
@@ -49,8 +49,8 @@ class ICEBERG_EXPORT FileIO {
   /// the length to read, e.g. S3 `GetObject` has a Range parameter.
   /// \return The content of the file if the read succeeded, an error code if the read
   /// failed.
-  virtual Result<std::string> ReadFile(const std::string& file_location,
-                                       std::optional<size_t> length) {
+  virtual Result<std::string> ReadFile([[maybe_unused]] const std::string& file_location,
+                                       [[maybe_unused]] std::optional<size_t> length) {
     // We provide a default implementation to avoid Windows linker error LNK2019.
     return NotImplemented("ReadFile not implemented");
   }
@@ -62,7 +62,8 @@ class ICEBERG_EXPORT FileIO {
   /// \param overwrite If true, overwrite the file if it exists. If false, fail if the
   /// file exists.
   /// \return void if the write succeeded, an error code if the write failed.
-  virtual Status WriteFile(const std::string& file_location, std::string_view content) {
+  virtual Status WriteFile([[maybe_unused]] const std::string& file_location,
+                           [[maybe_unused]] std::string_view content) {
     return NotImplemented("WriteFile not implemented");
   }
 
@@ -70,7 +71,7 @@ class ICEBERG_EXPORT FileIO {
   ///
   /// \param file_location The location of the file to delete.
   /// \return void if the delete succeeded, an error code if the delete failed.
-  virtual Status DeleteFile(const std::string& file_location) {
+  virtual Status DeleteFile([[maybe_unused]] const std::string& file_location) {
     return NotImplemented("DeleteFile not implemented");
   }
 };

--- a/src/iceberg/file_reader.h
+++ b/src/iceberg/file_reader.h
@@ -87,23 +87,23 @@ class ReaderProperties : public ConfigBase<ReaderProperties> {
 /// \brief Options for creating a reader.
 struct ICEBERG_EXPORT ReaderOptions {
   /// \brief The path to the file to read.
-  std::string path;
+  std::string path{};
   /// \brief The total length of the file.
-  std::optional<size_t> length;
+  std::optional<size_t> length{};
   /// \brief The split to read.
-  std::optional<Split> split;
+  std::optional<Split> split{};
   /// \brief FileIO instance to open the file. Reader implementations should down cast it
   /// to the specific FileIO implementation. By default, the `iceberg-bundle` library uses
   /// `ArrowFileSystemFileIO` as the default implementation.
-  std::shared_ptr<class FileIO> io;
+  std::shared_ptr<class FileIO> io{};
   /// \brief The projection schema to read from the file. This field is required.
-  std::shared_ptr<class Schema> projection;
+  std::shared_ptr<class Schema> projection{};
   /// \brief The filter to apply to the data. Reader implementations may ignore this if
   /// the file format does not support filtering.
-  std::shared_ptr<class Expression> filter;
+  std::shared_ptr<class Expression> filter{};
   /// \brief Name mapping for schema evolution compatibility. Used when reading files
   /// that may have different field names than the current schema.
-  std::shared_ptr<class NameMapping> name_mapping;
+  std::shared_ptr<class NameMapping> name_mapping{};
   /// \brief Format-specific or implementation-specific properties.
   std::shared_ptr<ReaderProperties> properties = ReaderProperties::default_properties();
 };

--- a/src/iceberg/manifest_adapter.cc
+++ b/src/iceberg/manifest_adapter.cc
@@ -164,13 +164,14 @@ ManifestEntryAdapter::~ManifestEntryAdapter() {
 Status ManifestEntryAdapter::AppendPartitionValues(
     ArrowArray* array, const std::shared_ptr<StructType>& partition_type,
     const std::vector<Literal>& partition_values) {
-  if (array->n_children != partition_type->fields().size()) [[unlikely]] {
+  auto fields = partition_type->fields();
+  auto num_fields = static_cast<int64_t>(fields.size());
+  if (array->n_children != num_fields) [[unlikely]] {
     return InvalidArrowData("Arrow array of partition does not match partition type.");
   }
-  if (partition_values.size() != partition_type->fields().size()) [[unlikely]] {
+  if (partition_values.size() != fields.size()) [[unlikely]] {
     return InvalidArrowData("Literal list of partition does not match partition type.");
   }
-  auto fields = partition_type->fields();
 
   for (size_t i = 0; i < fields.size(); i++) {
     const auto& partition_value = partition_values[i];

--- a/src/iceberg/manifest_reader_internal.cc
+++ b/src/iceberg/manifest_reader_internal.cc
@@ -196,7 +196,7 @@ Result<std::vector<ManifestFile>> ParseManifestList(ArrowSchema* schema,
     return InvalidManifestList("Columns size not match between schema:{} and array:{}",
                                schema->n_children, array_in->n_children);
   }
-  if (iceberg_schema.fields().size() != array_in->n_children) {
+  if (iceberg_schema.fields().size() != static_cast<size_t>(array_in->n_children)) {
     return InvalidManifestList("Columns size not match between schema:{} and array:{}",
                                iceberg_schema.fields().size(), array_in->n_children);
   }
@@ -333,7 +333,8 @@ Status ParseDataFile(const std::shared_ptr<StructType>& data_file_schema,
   if (view_of_column->storage_type != ArrowType::NANOARROW_TYPE_STRUCT) {
     return InvalidManifest("DataFile field should be a struct.");
   }
-  if (view_of_column->n_children != data_file_schema->fields().size()) {
+  if (static_cast<size_t>(view_of_column->n_children) !=
+      data_file_schema->fields().size()) {
     return InvalidManifest("DataFile schema size:{} not match with ArrayArray columns:{}",
                            data_file_schema->fields().size(), view_of_column->n_children);
   }
@@ -459,7 +460,8 @@ Result<std::vector<ManifestEntry>> ParseManifestEntry(ArrowSchema* schema,
     return InvalidManifest("Columns size not match between schema:{} and array:{}",
                            schema->n_children, array_in->n_children);
   }
-  if (iceberg_schema.fields().size() != array_in->n_children) {
+  if (array_in->n_children < 0 ||
+      iceberg_schema.fields().size() != static_cast<size_t>(array_in->n_children)) {
     return InvalidManifest("Columns size not match between schema:{} and array:{}",
                            iceberg_schema.fields().size(), array_in->n_children);
   }

--- a/src/iceberg/name_mapping.cc
+++ b/src/iceberg/name_mapping.cc
@@ -303,7 +303,7 @@ class CreateMappingVisitor {
   }
 
   template <typename T>
-  Result<std::unique_ptr<MappedFields>> Visit(const T& type) const {
+  Result<std::unique_ptr<MappedFields>> Visit([[maybe_unused]] const T& type) const {
     return nullptr;
   }
 

--- a/src/iceberg/name_mapping.h
+++ b/src/iceberg/name_mapping.h
@@ -44,7 +44,7 @@ struct ICEBERG_EXPORT MappedField {
   std::optional<int32_t> field_id;
   /// \brief An optional list of field mappings for child field of structs, maps, and
   /// lists.
-  std::shared_ptr<class MappedFields> nested_mapping;
+  std::shared_ptr<class MappedFields> nested_mapping{};
 
   friend bool operator==(const MappedField& lhs, const MappedField& rhs);
 };

--- a/src/iceberg/schema.cc
+++ b/src/iceberg/schema.cc
@@ -100,8 +100,8 @@ class PositionPathVisitor {
   }
 
   // Non-struct types are not supported yet, but it is not an error.
-  Status Visit(const ListType& type) { return {}; }
-  Status Visit(const MapType& type) { return {}; }
+  Status Visit([[maybe_unused]] const ListType& type) { return {}; }
+  Status Visit([[maybe_unused]] const MapType& type) { return {}; }
 
   std::unordered_map<int32_t, std::vector<size_t>> Finish() {
     return std::move(position_path_);
@@ -214,7 +214,7 @@ IdToFieldVisitor::IdToFieldVisitor(
     std::unordered_map<int32_t, std::reference_wrapper<const SchemaField>>& id_to_field)
     : id_to_field_(id_to_field) {}
 
-Status IdToFieldVisitor::Visit(const PrimitiveType& type) { return {}; }
+Status IdToFieldVisitor::Visit([[maybe_unused]] const PrimitiveType& type) { return {}; }
 
 Status IdToFieldVisitor::Visit(const NestedType& type) {
   const auto& nested = internal::checked_cast<const NestedType&>(type);
@@ -300,8 +300,9 @@ Status NameToIdVisitor::Visit(const StructType& type, const std::string& path,
   return {};
 }
 
-Status NameToIdVisitor::Visit(const PrimitiveType& type, const std::string& path,
-                              const std::string& short_path) {
+Status NameToIdVisitor::Visit([[maybe_unused]] const PrimitiveType& type,
+                              [[maybe_unused]] const std::string& path,
+                              [[maybe_unused]] const std::string& short_path) {
   return {};
 }
 

--- a/src/iceberg/schema.h
+++ b/src/iceberg/schema.h
@@ -103,6 +103,7 @@ class ICEBERG_EXPORT Schema : public StructType {
   friend bool operator==(const Schema& lhs, const Schema& rhs) { return lhs.Equals(rhs); }
 
  private:
+  using Type::Equals;
   /// \brief Compare two schemas for equality.
   bool Equals(const Schema& other) const;
 

--- a/src/iceberg/snapshot.h
+++ b/src/iceberg/snapshot.h
@@ -225,21 +225,21 @@ struct ICEBERG_EXPORT Snapshot {
   static constexpr int64_t kInvalidSnapshotId = -1;
 
   /// A unique long ID.
-  int64_t snapshot_id;
+  int64_t snapshot_id{};
   /// The snapshot ID of the snapshot's parent. Omitted for any snapshot with no parent.
-  std::optional<int64_t> parent_snapshot_id;
+  std::optional<int64_t> parent_snapshot_id{};
   /// A monotonically increasing long that tracks the order of changes to a table.
-  int64_t sequence_number;
+  int64_t sequence_number{};
   /// A timestamp when the snapshot was created, used for garbage collection and table
   /// inspection.
-  TimePointMs timestamp_ms;
+  TimePointMs timestamp_ms{};
   /// The location of a manifest list for this snapshot that tracks manifest files with
   /// additional metadata.
-  std::string manifest_list;
+  std::string manifest_list{};
   /// A string map that summaries the snapshot changes, including operation.
-  std::unordered_map<std::string, std::string> summary;
+  std::unordered_map<std::string, std::string> summary{};
   /// ID of the table's current schema when the snapshot was created.
-  std::optional<int32_t> schema_id;
+  std::optional<int32_t> schema_id{};
 
   /// \brief Return the name of the DataOperations data operation that produced this
   /// snapshot.

--- a/src/iceberg/table_metadata.cc
+++ b/src/iceberg/table_metadata.cc
@@ -267,12 +267,12 @@ std::unique_ptr<TableMetadataBuilder> TableMetadataBuilder::BuildFrom(
 }
 
 TableMetadataBuilder& TableMetadataBuilder::SetMetadataLocation(
-    std::string_view metadata_location) {
+    [[maybe_unused]] std::string_view metadata_location) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::SetPreviousMetadataLocation(
-    std::string_view previous_metadata_location) {
+    [[maybe_unused]] std::string_view previous_metadata_location) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
@@ -309,87 +309,94 @@ TableMetadataBuilder& TableMetadataBuilder::AssignUUID(std::string_view uuid) {
 }
 
 TableMetadataBuilder& TableMetadataBuilder::UpgradeFormatVersion(
-    int8_t new_format_version) {
+    [[maybe_unused]] int8_t new_format_version) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::SetCurrentSchema(
-    std::shared_ptr<Schema> schema, int32_t new_last_column_id) {
+    [[maybe_unused]] std::shared_ptr<Schema> schema,
+    [[maybe_unused]] int32_t new_last_column_id) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-TableMetadataBuilder& TableMetadataBuilder::SetCurrentSchema(int32_t schema_id) {
+TableMetadataBuilder& TableMetadataBuilder::SetCurrentSchema(
+    [[maybe_unused]] int32_t schema_id) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-TableMetadataBuilder& TableMetadataBuilder::AddSchema(std::shared_ptr<Schema> schema) {
+TableMetadataBuilder& TableMetadataBuilder::AddSchema(
+    [[maybe_unused]] std::shared_ptr<Schema> schema) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::SetDefaultPartitionSpec(
-    std::shared_ptr<PartitionSpec> spec) {
+    [[maybe_unused]] std::shared_ptr<PartitionSpec> spec) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-TableMetadataBuilder& TableMetadataBuilder::SetDefaultPartitionSpec(int32_t spec_id) {
+TableMetadataBuilder& TableMetadataBuilder::SetDefaultPartitionSpec(
+    [[maybe_unused]] int32_t spec_id) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::AddPartitionSpec(
-    std::shared_ptr<PartitionSpec> spec) {
+    [[maybe_unused]] std::shared_ptr<PartitionSpec> spec) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::RemovePartitionSpecs(
-    const std::vector<int32_t>& spec_ids) {
+    [[maybe_unused]] const std::vector<int32_t>& spec_ids) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::RemoveSchemas(
-    const std::vector<int32_t>& schema_ids) {
+    [[maybe_unused]] const std::vector<int32_t>& schema_ids) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::SetDefaultSortOrder(
-    std::shared_ptr<SortOrder> order) {
+    [[maybe_unused]] std::shared_ptr<SortOrder> order) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-TableMetadataBuilder& TableMetadataBuilder::SetDefaultSortOrder(int32_t order_id) {
+TableMetadataBuilder& TableMetadataBuilder::SetDefaultSortOrder(
+    [[maybe_unused]] int32_t order_id) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::AddSortOrder(
-    std::shared_ptr<SortOrder> order) {
+    [[maybe_unused]] std::shared_ptr<SortOrder> order) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::AddSnapshot(
-    std::shared_ptr<Snapshot> snapshot) {
+    [[maybe_unused]] std::shared_ptr<Snapshot> snapshot) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-TableMetadataBuilder& TableMetadataBuilder::SetBranchSnapshot(int64_t snapshot_id,
-                                                              const std::string& branch) {
+TableMetadataBuilder& TableMetadataBuilder::SetBranchSnapshot(
+    [[maybe_unused]] int64_t snapshot_id, [[maybe_unused]] const std::string& branch) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-TableMetadataBuilder& TableMetadataBuilder::SetRef(const std::string& name,
-                                                   std::shared_ptr<SnapshotRef> ref) {
+TableMetadataBuilder& TableMetadataBuilder::SetRef(
+    [[maybe_unused]] const std::string& name,
+    [[maybe_unused]] std::shared_ptr<SnapshotRef> ref) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-TableMetadataBuilder& TableMetadataBuilder::RemoveRef(const std::string& name) {
+TableMetadataBuilder& TableMetadataBuilder::RemoveRef(
+    [[maybe_unused]] const std::string& name) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::RemoveSnapshots(
-    const std::vector<std::shared_ptr<Snapshot>>& snapshots_to_remove) {
+    [[maybe_unused]] const std::vector<std::shared_ptr<Snapshot>>& snapshots_to_remove) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::RemoveSnapshots(
-    const std::vector<int64_t>& snapshot_ids) {
+    [[maybe_unused]] const std::vector<int64_t>& snapshot_ids) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
@@ -398,44 +405,48 @@ TableMetadataBuilder& TableMetadataBuilder::suppressHistoricalSnapshots() {
 }
 
 TableMetadataBuilder& TableMetadataBuilder::SetStatistics(
-    const std::shared_ptr<StatisticsFile>& statistics_file) {
+    [[maybe_unused]] const std::shared_ptr<StatisticsFile>& statistics_file) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-TableMetadataBuilder& TableMetadataBuilder::RemoveStatistics(int64_t snapshot_id) {
+TableMetadataBuilder& TableMetadataBuilder::RemoveStatistics(
+    [[maybe_unused]] int64_t snapshot_id) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::SetPartitionStatistics(
-    const std::shared_ptr<PartitionStatisticsFile>& partition_statistics_file) {
+    [[maybe_unused]] const std::shared_ptr<PartitionStatisticsFile>&
+        partition_statistics_file) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::RemovePartitionStatistics(
-    int64_t snapshot_id) {
+    [[maybe_unused]] int64_t snapshot_id) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::SetProperties(
-    const std::unordered_map<std::string, std::string>& updated) {
+    [[maybe_unused]] const std::unordered_map<std::string, std::string>& updated) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::RemoveProperties(
-    const std::vector<std::string>& removed) {
+    [[maybe_unused]] const std::vector<std::string>& removed) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-TableMetadataBuilder& TableMetadataBuilder::SetLocation(std::string_view location) {
+TableMetadataBuilder& TableMetadataBuilder::SetLocation(
+    [[maybe_unused]] std::string_view location) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
 TableMetadataBuilder& TableMetadataBuilder::AddEncryptionKey(
-    std::shared_ptr<EncryptedKey> key) {
+    [[maybe_unused]] std::shared_ptr<EncryptedKey> key) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-TableMetadataBuilder& TableMetadataBuilder::RemoveEncryptionKey(std::string_view key_id) {
+TableMetadataBuilder& TableMetadataBuilder::RemoveEncryptionKey(
+    [[maybe_unused]] std::string_view key_id) {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 

--- a/src/iceberg/table_metadata.h
+++ b/src/iceberg/table_metadata.h
@@ -97,27 +97,27 @@ struct ICEBERG_EXPORT TableMetadata {
   /// The highest assigned partition field ID across all partition specs for the table
   int32_t last_partition_id;
   /// A string to string map of table properties
-  std::unordered_map<std::string, std::string> properties;
+  std::unordered_map<std::string, std::string> properties{};
   /// ID of the current table snapshot
   int64_t current_snapshot_id;
   /// A list of valid snapshots
-  std::vector<std::shared_ptr<iceberg::Snapshot>> snapshots;
+  std::vector<std::shared_ptr<iceberg::Snapshot>> snapshots{};
   /// A list of timestamp and snapshot ID pairs that encodes changes to the current
   /// snapshot for the table
-  std::vector<SnapshotLogEntry> snapshot_log;
+  std::vector<SnapshotLogEntry> snapshot_log{};
   /// A list of timestamp and metadata file location pairs that encodes changes to the
   /// previous metadata files for the table
-  std::vector<MetadataLogEntry> metadata_log;
+  std::vector<MetadataLogEntry> metadata_log{};
   /// A list of sort orders
   std::vector<std::shared_ptr<iceberg::SortOrder>> sort_orders;
   /// Default sort order id of the table
   int32_t default_sort_order_id;
   /// A map of snapshot references
-  std::unordered_map<std::string, std::shared_ptr<SnapshotRef>> refs;
+  std::unordered_map<std::string, std::shared_ptr<SnapshotRef>> refs{};
   /// A list of table statistics
-  std::vector<std::shared_ptr<struct StatisticsFile>> statistics;
+  std::vector<std::shared_ptr<struct StatisticsFile>> statistics{};
   /// A list of partition statistics
-  std::vector<std::shared_ptr<struct PartitionStatisticsFile>> partition_statistics;
+  std::vector<std::shared_ptr<struct PartitionStatisticsFile>> partition_statistics{};
   /// A `long` higher than all assigned row IDs
   int64_t next_row_id;
 

--- a/src/iceberg/table_requirements.cc
+++ b/src/iceberg/table_requirements.cc
@@ -34,19 +34,19 @@ Result<std::vector<std::unique_ptr<TableRequirement>>> TableUpdateContext::Build
 }
 
 Result<std::vector<std::unique_ptr<TableRequirement>>> TableRequirements::ForCreateTable(
-    const std::vector<std::unique_ptr<TableUpdate>>& table_updates) {
+    [[maybe_unused]] const std::vector<std::unique_ptr<TableUpdate>>& table_updates) {
   return NotImplemented("TableRequirements::ForCreateTable not implemented");
 }
 
 Result<std::vector<std::unique_ptr<TableRequirement>>> TableRequirements::ForReplaceTable(
-    const TableMetadata& base,
-    const std::vector<std::unique_ptr<TableUpdate>>& table_updates) {
+    [[maybe_unused]] const TableMetadata& base,
+    [[maybe_unused]] const std::vector<std::unique_ptr<TableUpdate>>& table_updates) {
   return NotImplemented("TableRequirements::ForReplaceTable not implemented");
 }
 
 Result<std::vector<std::unique_ptr<TableRequirement>>> TableRequirements::ForUpdateTable(
-    const TableMetadata& base,
-    const std::vector<std::unique_ptr<TableUpdate>>& table_updates) {
+    [[maybe_unused]] const TableMetadata& base,
+    [[maybe_unused]] const std::vector<std::unique_ptr<TableUpdate>>& table_updates) {
   return NotImplemented("TableRequirements::ForUpdateTable not implemented");
 }
 

--- a/src/iceberg/table_update.cc
+++ b/src/iceberg/table_update.cc
@@ -51,161 +51,178 @@ Status AssignUUID::GenerateRequirements(TableUpdateContext& context) const {
 
 // UpgradeFormatVersion
 
-void UpgradeFormatVersion::ApplyTo(TableMetadataBuilder& builder) const {
+void UpgradeFormatVersion::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status UpgradeFormatVersion::GenerateRequirements(TableUpdateContext& context) const {
+Status UpgradeFormatVersion::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("UpgradeFormatVersion::GenerateRequirements not implemented");
 }
 
 // AddSchema
 
-void AddSchema::ApplyTo(TableMetadataBuilder& builder) const {
+void AddSchema::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status AddSchema::GenerateRequirements(TableUpdateContext& context) const {
+Status AddSchema::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("AddTableSchema::GenerateRequirements not implemented");
 }
 
 // SetCurrentSchema
 
-void SetCurrentSchema::ApplyTo(TableMetadataBuilder& builder) const {
+void SetCurrentSchema::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status SetCurrentSchema::GenerateRequirements(TableUpdateContext& context) const {
+Status SetCurrentSchema::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("SetCurrentTableSchema::GenerateRequirements not implemented");
 }
 
 // AddPartitionSpec
 
-void AddPartitionSpec::ApplyTo(TableMetadataBuilder& builder) const {
+void AddPartitionSpec::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status AddPartitionSpec::GenerateRequirements(TableUpdateContext& context) const {
+Status AddPartitionSpec::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("AddTablePartitionSpec::GenerateRequirements not implemented");
 }
 
 // SetDefaultPartitionSpec
 
-void SetDefaultPartitionSpec::ApplyTo(TableMetadataBuilder& builder) const {
+void SetDefaultPartitionSpec::ApplyTo(
+    [[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status SetDefaultPartitionSpec::GenerateRequirements(TableUpdateContext& context) const {
+Status SetDefaultPartitionSpec::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented(
       "SetDefaultTablePartitionSpec::GenerateRequirements not implemented");
 }
 
 // RemovePartitionSpecs
 
-void RemovePartitionSpecs::ApplyTo(TableMetadataBuilder& builder) const {
+void RemovePartitionSpecs::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status RemovePartitionSpecs::GenerateRequirements(TableUpdateContext& context) const {
+Status RemovePartitionSpecs::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented(
       "RemoveTablePartitionSpecs::GenerateRequirements not implemented");
 }
 
 // RemoveSchemas
 
-void RemoveSchemas::ApplyTo(TableMetadataBuilder& builder) const {
+void RemoveSchemas::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status RemoveSchemas::GenerateRequirements(TableUpdateContext& context) const {
+Status RemoveSchemas::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("RemoveTableSchemas::GenerateRequirements not implemented");
 }
 
 // AddSortOrder
 
-void AddSortOrder::ApplyTo(TableMetadataBuilder& builder) const {
+void AddSortOrder::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status AddSortOrder::GenerateRequirements(TableUpdateContext& context) const {
+Status AddSortOrder::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("AddTableSortOrder::GenerateRequirements not implemented");
 }
 
 // SetDefaultSortOrder
 
-void SetDefaultSortOrder::ApplyTo(TableMetadataBuilder& builder) const {
+void SetDefaultSortOrder::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status SetDefaultSortOrder::GenerateRequirements(TableUpdateContext& context) const {
+Status SetDefaultSortOrder::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("SetDefaultTableSortOrder::GenerateRequirements not implemented");
 }
 
 // AddSnapshot
 
-void AddSnapshot::ApplyTo(TableMetadataBuilder& builder) const {
+void AddSnapshot::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status AddSnapshot::GenerateRequirements(TableUpdateContext& context) const {
+Status AddSnapshot::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("AddTableSnapshot::GenerateRequirements not implemented");
 }
 
 // RemoveSnapshots
 
-void RemoveSnapshots::ApplyTo(TableMetadataBuilder& builder) const {}
+void RemoveSnapshots::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {}
 
-Status RemoveSnapshots::GenerateRequirements(TableUpdateContext& context) const {
+Status RemoveSnapshots::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("RemoveTableSnapshots::GenerateRequirements not implemented");
 }
 
 // RemoveSnapshotRef
 
-void RemoveSnapshotRef::ApplyTo(TableMetadataBuilder& builder) const {
+void RemoveSnapshotRef::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status RemoveSnapshotRef::GenerateRequirements(TableUpdateContext& context) const {
+Status RemoveSnapshotRef::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("RemoveTableSnapshotRef::GenerateRequirements not implemented");
 }
 
 // SetSnapshotRef
 
-void SetSnapshotRef::ApplyTo(TableMetadataBuilder& builder) const {
+void SetSnapshotRef::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status SetSnapshotRef::GenerateRequirements(TableUpdateContext& context) const {
+Status SetSnapshotRef::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("SetTableSnapshotRef::GenerateRequirements not implemented");
 }
 
 // SetProperties
 
-void SetProperties::ApplyTo(TableMetadataBuilder& builder) const {
+void SetProperties::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status SetProperties::GenerateRequirements(TableUpdateContext& context) const {
+Status SetProperties::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("SetTableProperties::GenerateRequirements not implemented");
 }
 
 // RemoveProperties
 
-void RemoveProperties::ApplyTo(TableMetadataBuilder& builder) const {
+void RemoveProperties::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status RemoveProperties::GenerateRequirements(TableUpdateContext& context) const {
+Status RemoveProperties::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("RemoveTableProperties::GenerateRequirements not implemented");
 }
 
 // SetLocation
 
-void SetLocation::ApplyTo(TableMetadataBuilder& builder) const {
+void SetLocation::ApplyTo([[maybe_unused]] TableMetadataBuilder& builder) const {
   throw IcebergError(std::format("{} not implemented", __FUNCTION__));
 }
 
-Status SetLocation::GenerateRequirements(TableUpdateContext& context) const {
+Status SetLocation::GenerateRequirements(
+    [[maybe_unused]] TableUpdateContext& context) const {
   return NotImplemented("SetTableLocation::GenerateRequirements not implemented");
 }
 

--- a/src/iceberg/test/schema_test.cc
+++ b/src/iceberg/test/schema_test.cc
@@ -606,9 +606,9 @@ struct SelectTestParam {
   std::string test_name;
   std::function<std::unique_ptr<iceberg::Schema>()> create_schema;
   std::vector<std::string> select_fields;
-  std::function<std::unique_ptr<iceberg::Schema>()> expected_schema;
+  std::function<std::unique_ptr<iceberg::Schema>()> expected_schema{};
   bool should_succeed;
-  std::string expected_error_message;
+  std::string expected_error_message{};
   bool case_sensitive = true;
 };
 
@@ -749,7 +749,7 @@ struct ProjectTestParam {
   std::unordered_set<int32_t> selected_ids;
   std::function<std::unique_ptr<iceberg::Schema>()> expected_schema;
   bool should_succeed;
-  std::string expected_error_message;
+  std::string expected_error_message{};
 };
 
 class ProjectParamTest : public ::testing::TestWithParam<ProjectTestParam> {};

--- a/src/iceberg/test/schema_util_test.cc
+++ b/src/iceberg/test/schema_util_test.cc
@@ -82,14 +82,14 @@ std::shared_ptr<Type> CreateNestedStruct() {
   });
 }
 
-std::shared_ptr<Type> CreateListOfList() {
+[[maybe_unused]] std::shared_ptr<Type> CreateListOfList() {
   return std::make_shared<ListType>(SchemaField::MakeRequired(
       /*field_id=*/401, "element",
       std::make_shared<ListType>(SchemaField::MakeOptional(
           /*field_id=*/402, "element", iceberg::float64()))));
 }
 
-std::shared_ptr<Type> CreateMapOfList() {
+[[maybe_unused]] std::shared_ptr<Type> CreateMapOfList() {
   return std::make_shared<MapType>(
       SchemaField::MakeRequired(/*field_id=*/501, "key", iceberg::string()),
       SchemaField::MakeRequired(

--- a/src/iceberg/test/transform_test.cc
+++ b/src/iceberg/test/transform_test.cc
@@ -195,7 +195,7 @@ TEST(TransformResultTypeTest, NegativeCases) {
 struct TransformParam {
   std::string str;
   // The integer parameter associated with the transform.
-  int32_t param;
+  int32_t param = 0;
   std::shared_ptr<Type> source_type;
   Literal source;
   Literal expected;

--- a/src/iceberg/util/conversions.cc
+++ b/src/iceberg/util/conversions.cc
@@ -200,7 +200,7 @@ Result<Literal::Value> Conversions::FromBytes(const PrimitiveType& type,
       return Literal::Value{std::vector<uint8_t>(data.begin(), data.end())};
     case TypeId::kFixed: {
       const auto& fixed_type = static_cast<const FixedType&>(type);
-      if (data.size() != fixed_type.length()) {
+      if (data.size() != static_cast<size_t>(fixed_type.length())) {
         return InvalidArgument("Invalid data size for Fixed literal, got size: {}",
                                data.size());
       }

--- a/src/iceberg/util/truncate_util.cc
+++ b/src/iceberg/util/truncate_util.cc
@@ -66,7 +66,7 @@ Literal TruncateLiteralImpl<TypeId::kBinary>(const Literal& literal, int32_t wid
   // In contrast to strings, binary values do not have an assumed encoding and are
   // truncated to `width` bytes.
   const auto& data = std::get<std::vector<uint8_t>>(literal.value());
-  if (data.size() <= width) {
+  if (data.size() <= static_cast<size_t>(width)) {
     return literal;
   }
   return Literal::Binary(std::vector<uint8_t>(data.begin(), data.begin() + width));


### PR DESCRIPTION
Warnings have been suppressed according to the following patterns:
* Applied `[[maybe_unused]]`
* Explicitly initialize the member variables in struct.
* Unaligned type comparison between signed and unsigned. Converted unsigned to singed.
* Hiding virtual functions in the base class. Declare `using base::func`.