### PR TITLE
feat: Add error collection pattern to PendingUpdate

### DIFF
--- a/src/iceberg/table_metadata.h
+++ b/src/iceberg/table_metadata.h
@@ -30,6 +30,7 @@
 
 #include "iceberg/iceberg_export.h"
 #include "iceberg/type_fwd.h"
+#include "iceberg/util/error_collector.h"
 #include "iceberg/util/lazy.h"
 #include "iceberg/util/timepoint.h"
 
@@ -193,7 +194,7 @@ ICEBERG_EXPORT std::string ToString(const MetadataLogEntry& entry);
 /// If a modification violates Iceberg table constraints (e.g., setting a current
 /// schema ID that does not exist), an error will be recorded and returned when
 /// Build() is called.
-class ICEBERG_EXPORT TableMetadataBuilder {
+class ICEBERG_EXPORT TableMetadataBuilder : public ErrorCollector {
  public:
   /// \brief Create a builder for a new table
   ///
@@ -353,7 +354,7 @@ class ICEBERG_EXPORT TableMetadataBuilder {
   /// RemoveSnapshot changes are created. A snapshot is historical if no ref directly
   /// references its ID.
   /// \return Reference to this builder for method chaining
-  TableMetadataBuilder& suppressHistoricalSnapshots();
+  TableMetadataBuilder& SuppressHistoricalSnapshots();
 
   /// \brief Set table statistics
   ///

--- a/src/iceberg/util/meson.build
+++ b/src/iceberg/util/meson.build
@@ -23,6 +23,7 @@ install_headers(
         'conversions.h',
         'decimal.h',
         'endian.h',
+        'error_collector.h',
         'formattable.h',
         'formatter.h',
         'int128.h',


### PR DESCRIPTION
Implement error vector collection pattern in PendingUpdateTyped to allow builder methods to accumulate validation errors instead of failing fast. This enables users to see all validation issues at once rather than fixing them one by one.

Changes:
- Add protected error collection methods (AddError, CheckErrors, HasErrors, ClearErrors) to PendingUpdateTyped base class
- Add std::vector<Error> errors_ member to collect validation errors
- Update PendingUpdate documentation with usage examples
- Add 6 comprehensive unit tests demonstrating error collection

Pattern follows TableMetadataBuilder implementation.

All tests pass (11/11).