### PR TITLE
fix: result.h cpplint failed after upgraded to gcc14

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -58,7 +58,7 @@ jobs:
           ignore: 'build|cmake_modules|ci'
           database: build
           # need '-fno-builtin-std-forward_like', see https://github.com/llvm/llvm-project/issues/101614
-          extra-args: '-I$PWD/src -I$PWD/build/src -fno-builtin-std-forward_like'
+          extra-args: '-I$PWD/src -I$PWD/build/src -fno-builtin-std-forward_like -D__cpp_concepts=202002L'
       - name: Fail fast?!
         if: steps.linter.outputs.checks-failed != 0
         run: |

--- a/src/iceberg/result.h
+++ b/src/iceberg/result.h
@@ -43,7 +43,6 @@ enum class ErrorKind {
   kInvalidManifest,
   kInvalidManifestList,
   kInvalidSchema,
-  kInvalidStatistics,
   kIOError,
   kJsonParseError,
   kNamespaceNotEmpty,
@@ -105,7 +104,6 @@ DEFINE_ERROR_FUNCTION(InvalidExpression)
 DEFINE_ERROR_FUNCTION(InvalidManifest)
 DEFINE_ERROR_FUNCTION(InvalidManifestList)
 DEFINE_ERROR_FUNCTION(InvalidSchema)
-DEFINE_ERROR_FUNCTION(InvalidStatistics)
 DEFINE_ERROR_FUNCTION(IOError)
 DEFINE_ERROR_FUNCTION(JsonParseError)
 DEFINE_ERROR_FUNCTION(NamespaceNotEmpty)


### PR DESCRIPTION
fix result.h cpplint fail after upgraded to gcc14