### PR TITLE
infra: automatically delete head branches after merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,6 +37,9 @@ github:
         required_approving_review_count: 1
 
       required_linear_history: true
+  pull_requests:
+    # auto-delete head branches after being merged
+    del_branch_on_merge: true
   features:
     wiki: true
     issues: true


### PR DESCRIPTION
set `.asf.yaml` to automatically delete head branches after merge
https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#pull_requests

already set in other iceberg subprojects