### PR TITLE
refactor: use std::ranges::to in ToUpper and ToLower

### DIFF
--- a/src/iceberg/util/string_util.h
+++ b/src/iceberg/util/string_util.h
@@ -30,19 +30,13 @@ namespace iceberg {
 class ICEBERG_EXPORT StringUtils {
  public:
   static std::string ToLower(std::string_view str) {
-    std::string input(str);
-    // TODO(xiao.dong) gcc 13.3 didn't support std::ranges::to
-    std::transform(input.begin(), input.end(), input.begin(),  // NOLINT
-                   [](char c) { return std::tolower(c); });    // NOLINT
-    return input;
+    return str | std::ranges::views::transform([](char c) { return std::tolower(c); }) |
+           std::ranges::to<std::string>();
   }
 
   static std::string ToUpper(std::string_view str) {
-    std::string input(str);
-    // TODO(xiao.dong) gcc 13.3 didn't support std::ranges::to
-    std::transform(input.begin(), input.end(), input.begin(),  // NOLINT
-                   [](char c) { return std::toupper(c); });    // NOLINT
-    return input;
+    return str | std::ranges::views::transform([](char c) { return std::toupper(c); }) |
+           std::ranges::to<std::string>();
   }
 
   static bool EqualsIgnoreCase(std::string_view lhs, std::string_view rhs) {


### PR DESCRIPTION
CI moved to gcc-14 and other code already uses std::ranges::to, so the TODO can be removed.