### PR TITLE
refactor: use lock_guard instead of unique_lock when available

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -38,5 +38,7 @@ CheckOptions:
     value:  '_'
   - key:    readability-identifier-naming.ProtectedMemberSuffix
     value:  '_'
+  - key:    modernize-use-scoped-lock.WarnOnSingleLocks
+    value:  'false'
 
 HeaderFilterRegex: 'src/iceberg|example'

--- a/src/iceberg/catalog/rest/http_client.cc
+++ b/src/iceberg/catalog/rest/http_client.cc
@@ -139,7 +139,7 @@ Result<HttpResponse> HttpClient::Get(
     const ErrorHandler& error_handler) {
   cpr::Response response;
   {
-    std::scoped_lock<std::mutex> lock(session_mutex_);
+    std::lock_guard guard(session_mutex_);
     PrepareSession(path, headers, params);
     response = session_->Get();
   }
@@ -156,7 +156,7 @@ Result<HttpResponse> HttpClient::Post(
     const ErrorHandler& error_handler) {
   cpr::Response response;
   {
-    std::scoped_lock<std::mutex> lock(session_mutex_);
+    std::lock_guard guard(session_mutex_);
     PrepareSession(path, headers);
     session_->SetBody(cpr::Body{body});
     response = session_->Post();
@@ -176,7 +176,7 @@ Result<HttpResponse> HttpClient::PostForm(
   cpr::Response response;
 
   {
-    std::scoped_lock<std::mutex> lock(session_mutex_);
+    std::lock_guard guard(session_mutex_);
 
     // Override default Content-Type (application/json) with form-urlencoded
     auto form_headers = headers;
@@ -204,7 +204,7 @@ Result<HttpResponse> HttpClient::Head(
     const ErrorHandler& error_handler) {
   cpr::Response response;
   {
-    std::scoped_lock<std::mutex> lock(session_mutex_);
+    std::lock_guard guard(session_mutex_);
     PrepareSession(path, headers);
     response = session_->Head();
   }
@@ -220,7 +220,7 @@ Result<HttpResponse> HttpClient::Delete(
     const ErrorHandler& error_handler) {
   cpr::Response response;
   {
-    std::scoped_lock<std::mutex> lock(session_mutex_);
+    std::lock_guard guard(session_mutex_);
     PrepareSession(path, headers);
     response = session_->Delete();
   }

--- a/src/iceberg/table_metadata.h
+++ b/src/iceberg/table_metadata.h
@@ -419,7 +419,7 @@ class ICEBERG_EXPORT TableMetadataBuilder : public ErrorCollector {
   Result<std::unique_ptr<TableMetadata>> Build();
 
   /// \brief Destructor
-  ~TableMetadataBuilder();
+  ~TableMetadataBuilder() override;
 
   // Delete copy operations (use BuildFrom to create a new builder)
   TableMetadataBuilder(const TableMetadataBuilder&) = delete;


### PR DESCRIPTION
Follow the answer in stackoverflow https://stackoverflow.com/a/60172828/11568166
1. `lock_guard` if you need to lock exactly 1 mutex for an entire scope.
2. `scoped_lock` if you need to lock a number of mutexes that is not exactly 1.
3. `unique_lock` if you need to unlock within the scope of the block (which includes use with a condition_variable).

So let clang-tidy only report `modernize-use-scoped-lock` warning when there are multiple `lock_guard`.