### PR TITLE
chore: disable timeout in meson test cases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,7 @@ jobs:
   meson:
     name: Meson - ${{ matrix.title }}
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -137,4 +138,4 @@ jobs:
           meson compile -C builddir
       - name: Test Iceberg
         run: |
-          meson test -C builddir
+          meson test -C builddir --timeout-multiplier 0


### PR DESCRIPTION
The rest_integration_test can sometimes run longer that 30s, so disable meson test timeout[1] and rely on the GH actions job–level timeout.

[1] https://mesonbuild.com/Unit-tests.html#other-test-options