### PR TITLE
refactor: optimize Table accessors and TimePoint passing

### DIFF
--- a/src/iceberg/avro/avro_schema_util.cc
+++ b/src/iceberg/avro/avro_schema_util.cc
@@ -734,7 +734,7 @@ Result<FieldProjection> ProjectMap(const MapType& map_type,
   const auto& expected_key_field = map_type.key();
   const auto& expected_value_field = map_type.value();
 
-  FieldProjection result, key_projection, value_projection;
+  FieldProjection result;
   int32_t avro_key_id, avro_value_id;
   ::avro::NodePtr map_node;
 

--- a/src/iceberg/table.cc
+++ b/src/iceberg/table.cc
@@ -88,11 +88,11 @@ Table::sort_orders() const {
 
 const TableProperties& Table::properties() const { return metadata_->properties; }
 
-const std::string& Table::metadata_file_location() const { return metadata_location_; }
+std::string_view Table::metadata_file_location() const { return metadata_location_; }
 
-const std::string& Table::location() const { return metadata_->location; }
+std::string_view Table::location() const { return metadata_->location; }
 
-const TimePointMs& Table::last_updated_ms() const { return metadata_->last_updated_ms; }
+TimePointMs Table::last_updated_ms() const { return metadata_->last_updated_ms; }
 
 Result<std::shared_ptr<Snapshot>> Table::current_snapshot() const {
   return metadata_->Snapshot();

--- a/src/iceberg/table.h
+++ b/src/iceberg/table.h
@@ -86,15 +86,13 @@ class ICEBERG_EXPORT Table {
   const TableProperties& properties() const;
 
   /// \brief Return the table's metadata file location
-  const std::string& metadata_file_location() const;
+  std::string_view metadata_file_location() const;
 
   /// \brief Return the table's base location
-  const std::string& location() const;
+  std::string_view location() const;
 
-  /// \brief Get the time when this table was last updated
-  ///
-  /// \return the time when this table was last updated
-  const TimePointMs& last_updated_ms() const;
+  /// \brief Returns the time when this table was last updated
+  TimePointMs last_updated_ms() const;
 
   /// \brief Return the table's current snapshot, return NotFoundError if not found
   Result<std::shared_ptr<Snapshot>> current_snapshot() const;
@@ -132,6 +130,9 @@ class ICEBERG_EXPORT Table {
 
   /// \brief Returns a FileIO to read and write table data and metadata files
   const std::shared_ptr<FileIO>& io() const;
+
+  /// \brief Returns the current metadata for this table
+  const std::shared_ptr<TableMetadata>& metadata() const;
 
  private:
   const TableIdentifier identifier_;

--- a/src/iceberg/util/timepoint.cc
+++ b/src/iceberg/util/timepoint.cc
@@ -27,7 +27,7 @@ Result<TimePointMs> TimePointMsFromUnixMs(int64_t unix_ms) {
   return TimePointMs{std::chrono::milliseconds(unix_ms)};
 }
 
-int64_t UnixMsFromTimePointMs(const TimePointMs& time_point_ms) {
+int64_t UnixMsFromTimePointMs(TimePointMs time_point_ms) {
   return std::chrono::duration_cast<std::chrono::milliseconds>(
              time_point_ms.time_since_epoch())
       .count();
@@ -37,7 +37,7 @@ Result<TimePointNs> TimePointNsFromUnixNs(int64_t unix_ns) {
   return TimePointNs{std::chrono::nanoseconds(unix_ns)};
 }
 
-int64_t UnixNsFromTimePointNs(const TimePointNs& time_point_ns) {
+int64_t UnixNsFromTimePointNs(TimePointNs time_point_ns) {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
              time_point_ns.time_since_epoch())
       .count();

--- a/src/iceberg/util/timepoint.h
+++ b/src/iceberg/util/timepoint.h
@@ -38,12 +38,12 @@ using TimePointNs =
 ICEBERG_EXPORT Result<TimePointMs> TimePointMsFromUnixMs(int64_t unix_ms);
 
 /// \brief Returns a Unix timestamp in milliseconds from a TimePointMs
-ICEBERG_EXPORT int64_t UnixMsFromTimePointMs(const TimePointMs& time_point_ms);
+ICEBERG_EXPORT int64_t UnixMsFromTimePointMs(TimePointMs time_point_ms);
 
 /// \brief Returns a TimePointNs from a Unix timestamp in nanoseconds
 ICEBERG_EXPORT Result<TimePointNs> TimePointNsFromUnixNs(int64_t unix_ns);
 
 /// \brief Returns a Unix timestamp in nanoseconds from a TimePointNs
-ICEBERG_EXPORT int64_t UnixNsFromTimePointNs(const TimePointNs& time_point_ns);
+ICEBERG_EXPORT int64_t UnixNsFromTimePointNs(TimePointNs time_point_ns);
 
 }  // namespace iceberg


### PR DESCRIPTION
- Update `Table::location()` and `Table::metadata_file_location()` to return `std::string_view` instead of `const std::string&` to avoid unnecessary reference indirection.
- Change `TimePointMs` and `TimePointNs` arguments and return types to pass-by-value in `Table` and utility functions, as they are small types.
- Expose `Table::metadata()` accessor to allow access to the underlying table metadata.
- Clean up unused variable declarations in `avro_schema_util.cc`.