### PR TITLE
chore: add readability-isolate-declaration to .clang-tidy

### DIFF
--- a/src/iceberg/test/mock_catalog.h
+++ b/src/iceberg/test/mock_catalog.h
@@ -23,7 +23,6 @@
 #include <gtest/gtest.h>
 
 #include "iceberg/catalog.h"
-#include "iceberg/table.h"
 
 namespace iceberg {
 


### PR DESCRIPTION
Add this rule to avoid defining multiple variables on the same line.