### PR TITLE
chore: remove stale path in licenserc.yaml

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -29,7 +29,6 @@ header:
     - 'LICENSE'
     - 'NOTICE'
     - 'requirements.txt'
-    - 'src/iceberg/expected.h'
     - 'src/iceberg/util/murmurhash3_internal.*'
     - 'src/iceberg/test/resources/**'
 


### PR DESCRIPTION
we no longer self-maintain expected.h, better to remove