### PR TITLE
fix(transaction): move flag assignment after auto-commit

### DIFF
--- a/src/iceberg/transaction.cc
+++ b/src/iceberg/transaction.cc
@@ -70,8 +70,6 @@ Status Transaction::Apply(std::vector<std::unique_ptr<TableUpdate>> updates) {
   if (auto_commit_) {
     auto result = Commit();
     if (!result.has_value()) {
-      // Commit failed, revert the flag
-      last_update_committed_ = false;
       return std::unexpected(result.error());
     }
   }


### PR DESCRIPTION
Move last_update_committed_ assignment to after auto-commit attempt.

If Commit() fails, ICEBERG_RETURN_UNEXPECTED returns early and the flag remains false, preventing the transaction from incorrectly reporting the update as committed when it actually failed.