### PR TITLE
fix: add identifier-field-ids JSON serialization/deserialization

### DIFF
--- a/src/iceberg/test/metadata_serde_test.cc
+++ b/src/iceberg/test/metadata_serde_test.cc
@@ -143,7 +143,8 @@ TEST(MetadataSerdeTest, DeserializeV2Valid) {
       std::vector<SchemaField>{SchemaField::MakeRequired(1, "x", int64()),
                                SchemaField::MakeRequired(2, "y", int64()),
                                SchemaField::MakeRequired(3, "z", int64())},
-      /*schema_id=*/1);
+      /*schema_id=*/1,
+      /*identifier_field_ids=*/std::vector<int32_t>{1, 2});
 
   auto expected_spec_result = PartitionSpec::Make(
       /*spec_id=*/0,


### PR DESCRIPTION
- Add serialization of identifier-field-ids in ToJson(Schema)
- Add deserialization of identifier-field-ids in SchemaFromJson()
- Add comprehensive test coverage for:
  * Schema with single identifier field
  * Schema without identifier fields
  * Schema with multiple identifier fields
  * Round-trip serialization/deserialization

Fixes the TODO in json_internal.cc for identifier-field-ids support.
