### PR TITLE
fix: make static_assert template-dependent in ByteSwap

### DIFF
--- a/src/iceberg/util/endian.h
+++ b/src/iceberg/util/endian.h
@@ -48,7 +48,8 @@ constexpr T ByteSwap(T value) {
     } else if constexpr (sizeof(T) == sizeof(uint64_t)) {
       return std::bit_cast<T>(std::byteswap(std::bit_cast<uint64_t>(value)));
     } else {
-      static_assert(false, "Unsupported floating-point size for endian conversion.");
+      static_assert(sizeof(T) == 0,
+                    "Unsupported floating-point size for endian conversion.");
     }
   }
 }


### PR DESCRIPTION
The static_assert(false, ...) in the ByteSwap function template was unconditionally evaluated at template definition time, which could cause compilation failures even when the else branch is never instantiated.                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                 