### PR TITLE
fix: properly propagate errors in MetricsConfig validation

### DIFF
--- a/src/iceberg/metrics_config.cc
+++ b/src/iceberg/metrics_config.cc
@@ -36,8 +36,8 @@ Status MetricsConfig::VerifyReferencedColumns(
     }
     auto field_name =
         std::string_view(key).substr(TableProperties::kMetricModeColumnConfPrefix.size());
-    auto field = schema.FindFieldByName(field_name);
-    if (!field.has_value() || !field.value().has_value()) {
+    ICEBERG_ASSIGN_OR_RAISE(auto field, schema.FindFieldByName(field_name));
+    if (!field.has_value()) {
       return ValidationFailed(
           "Invalid metrics config, could not find column {} from table prop {} in "
           "schema {}",


### PR DESCRIPTION
 The previous code had a logic error when checking the result of  FindFieldByName(). It used:                                                                                                                                                                                                                        
    if (!field.has_value() || !field.value().has_value())                                                                                                                                                                                            
                                                                                                                                                                                                                                                     
  This was incorrect because:                                                                                                                                                                                                                        
  1. If FindFieldByName() returns an error (Result contains an error), field.has_value() would be false, but the error was not propagated                                                                                                                                                                              
  2. field.value() returns std::optional<std::reference_wrapper<...>>,  so the second check was redundant and confusing                                                                                                                                                                                                 
                                                                                                                                                                                                                                                     
  Fixed by using ICEBERG_ASSIGN_OR_RAISE to properly propagate any errors from FindFieldByName(), then checking if the returned optional  contains a value. This matches the pattern used throughout the rest of the codebase and ensures errors are properly handled.           