### PR TITLE
refactor: use std::make_unique instead of raw new in WriterProperties

### DIFF
--- a/src/iceberg/file_writer.cc
+++ b/src/iceberg/file_writer.cc
@@ -60,12 +60,12 @@ Result<std::unique_ptr<Writer>> WriterFactoryRegistry::Open(
 }
 
 std::unique_ptr<WriterProperties> WriterProperties::default_properties() {
-  return std::unique_ptr<WriterProperties>(new WriterProperties());
+  return std::make_unique<WriterProperties>();
 }
 
 std::unique_ptr<WriterProperties> WriterProperties::FromMap(
     const std::unordered_map<std::string, std::string>& properties) {
-  auto writer_properties = std::unique_ptr<WriterProperties>(new WriterProperties());
+  auto writer_properties = std::make_unique<WriterProperties>();
   writer_properties->configs_ = properties;
   return writer_properties;
 }


### PR DESCRIPTION
Replace raw new with std::make_unique for better exception safety and modern C++ best practices in WriterProperties::default_properties() and WriterProperties::FromMap().

Using std::make_unique provides:
- Better exception safety (no leak if constructor throws)
- More concise and readable code
- Consistent with modern C++ guidelines