### PR TITLE
refactor: remove explicit string conversion in PartitionType

### DIFF
--- a/src/iceberg/partition_spec.cc
+++ b/src/iceberg/partition_spec.cc
@@ -89,8 +89,7 @@ Result<std::unique_ptr<StructType>> PartitionSpec::PartitionType(
 
     // Create the partition field with the transform result type
     // Partition fields are always optional (can be null)
-    partition_fields.emplace_back(partition_field.field_id(),
-                                  std::string(partition_field.name()),
+    partition_fields.emplace_back(partition_field.field_id(), partition_field.name(),
                                   std::move(result_type),
                                   /*optional=*/true);
   }


### PR DESCRIPTION
Removed unnecessary explicit std::string() conversion when passing partition_field.name() to emplace_back. The SchemaField constructor accepts std::string, and the implicit conversion from string_view to std::string is cleaner and equally efficient.

This simplifies the code without changing behavior or performance.