### PR TITLE
refactor: use std::make_unique instead of raw new in ReaderProperties

### DIFF
--- a/src/iceberg/file_reader.cc
+++ b/src/iceberg/file_reader.cc
@@ -60,12 +60,12 @@ Result<std::unique_ptr<Reader>> ReaderFactoryRegistry::Open(
 }
 
 std::unique_ptr<ReaderProperties> ReaderProperties::default_properties() {
-  return std::unique_ptr<ReaderProperties>(new ReaderProperties());
+  return std::make_unique<ReaderProperties>();
 }
 
 std::unique_ptr<ReaderProperties> ReaderProperties::FromMap(
     const std::unordered_map<std::string, std::string>& properties) {
-  auto reader_properties = std::unique_ptr<ReaderProperties>(new ReaderProperties());
+  auto reader_properties = std::make_unique<ReaderProperties>();
   reader_properties->configs_ = properties;
   return reader_properties;
 }


### PR DESCRIPTION
Replace raw new with std::make_unique for better exception safety and modern C++ best practices in ReaderProperties::default_properties() and ReaderProperties::FromMap().

Using std::make_unique provides:
- Better exception safety (no leak if constructor throws)
- More concise and readable code
- Consistent with modern C++ guidelines