### PR TITLE
fix: remove unreachable return statement in ListNamespaces

### DIFF
--- a/src/iceberg/catalog/rest/rest_catalog.cc
+++ b/src/iceberg/catalog/rest/rest_catalog.cc
@@ -152,7 +152,6 @@ Result<std::vector<Namespace>> RestCatalog::ListNamespaces(const Namespace& ns) 
     }
     next_token = list_response.next_page_token;
   }
-  return result;
 }
 
 Status RestCatalog::CreateNamespace(


### PR DESCRIPTION
The while(true) loop in RestCatalog::ListNamespaces only exits via the return statement at line 151 when next_page_token is empty. The return statement after the loop is unreachable dead code and should be removed.