### PR TITLE
fix: use /v1/config endpoint for catalog config

### DIFF
--- a/src/iceberg/catalog/rest/resource_paths.cc
+++ b/src/iceberg/catalog/rest/resource_paths.cc
@@ -47,7 +47,7 @@ Status ResourcePaths::SetBaseUri(const std::string& base_uri) {
 }
 
 Result<std::string> ResourcePaths::Config() const {
-  return std::format("{}/v1/{}config", base_uri_, prefix_);
+  return std::format("{}/v1/config", base_uri_);
 }
 
 Result<std::string> ResourcePaths::OAuth2Tokens() const {

--- a/src/iceberg/catalog/rest/resource_paths.h
+++ b/src/iceberg/catalog/rest/resource_paths.h
@@ -47,7 +47,7 @@ class ICEBERG_REST_EXPORT ResourcePaths {
   /// \brief Set the base URI of the REST catalog server.
   Status SetBaseUri(const std::string& base_uri);
 
-  /// \brief Get the /v1/{prefix}/config endpoint path.
+  /// \brief Get the /v1/config endpoint path.
   Result<std::string> Config() const;
 
   /// \brief Get the /v1/{prefix}/oauth/tokens endpoint path.


### PR DESCRIPTION
base on the define in https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L65