### PR TITLE
rest: build resource paths from final config

### DIFF
--- a/src/iceberg/catalog/rest/resource_paths.cc
+++ b/src/iceberg/catalog/rest/resource_paths.cc
@@ -38,8 +38,8 @@ Result<std::unique_ptr<ResourcePaths>> ResourcePaths::Make(std::string base_uri,
 ResourcePaths::ResourcePaths(std::string base_uri, const std::string& prefix)
     : base_uri_(std::move(base_uri)), prefix_(prefix.empty() ? "" : (prefix + "/")) {}
 
-Result<std::string> ResourcePaths::Config(const std::string& base_uri) {
-  return std::format("{}/v1/config", base_uri);
+Result<std::string> ResourcePaths::Config() const {
+  return std::format("{}/v1/config", base_uri_);
 }
 
 Result<std::string> ResourcePaths::OAuth2Tokens() const {

--- a/src/iceberg/catalog/rest/resource_paths.h
+++ b/src/iceberg/catalog/rest/resource_paths.h
@@ -44,7 +44,7 @@ class ICEBERG_REST_EXPORT ResourcePaths {
                                                      const std::string& prefix);
 
   /// \brief Get the /v1/config endpoint path.
-  static Result<std::string> Config(const std::string& base_uri);
+  Result<std::string> Config() const;
 
   /// \brief Get the /v1/{prefix}/oauth/tokens endpoint path.
   Result<std::string> OAuth2Tokens() const;


### PR DESCRIPTION
Build ResourcePaths using final URI + prefix after fetching server config: ref:https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L233