### PR TITLE
refactor: use remove_cvref_t instead of decay_t to get exact type

### DIFF
--- a/src/iceberg/expression/literal.cc
+++ b/src/iceberg/expression/literal.cc
@@ -583,7 +583,7 @@ Result<Literal> LiteralCaster::CastTo(const Literal& literal,
 std::size_t LiteralValueHash::operator()(const Literal::Value& value) const noexcept {
   return std::visit(
       [](const auto& v) -> std::size_t {
-        using T = std::decay_t<decltype(v)>;
+        using T = std::remove_cvref_t<decltype(v)>;
 
         constexpr size_t kHashPrime = 0x9e3779b9;
 

--- a/src/iceberg/manifest/manifest_reader.cc
+++ b/src/iceberg/manifest/manifest_reader.cc
@@ -119,7 +119,7 @@ template <typename Container, typename Accessor, typename... Args>
   requires std::ranges::forward_range<Container>
 Status ParseIntegerField(const ArrowArrayView* array_view, Container& container,
                          Accessor accessor, Args&&... args) {
-  using T = unwrap_optional_t<std::decay_t<
+  using T = unwrap_optional_t<std::remove_cvref_t<
       std::invoke_result_t<Accessor&, std::ranges::range_reference_t<Container>>>>;
   return ParseField(
       [](const ArrowArrayView* view, int64_t row_idx) {
@@ -165,11 +165,11 @@ void ParseVectorField(Transfer transfer, const ArrowArrayView* view, int64_t len
 
 template <typename Container, typename Accessor>
   requires std::ranges::forward_range<Container> &&
-           std::ranges::range<std::decay_t<std::invoke_result_t<
+           std::ranges::range<std::remove_cvref_t<std::invoke_result_t<
                Accessor&, std::ranges::range_reference_t<Container>>>>
 void ParseIntegerVectorField(const ArrowArrayView* view, int64_t length,
                              Container& container, Accessor accessor) {
-  using T = unwrap_optional_t<std::ranges::range_value_t<std::decay_t<
+  using T = unwrap_optional_t<std::ranges::range_value_t<std::remove_cvref_t<
       std::invoke_result_t<Accessor&, std::ranges::range_reference_t<Container>>>>>;
   return ParseVectorField(
       [](const ArrowArrayView* v, int64_t offset) {

--- a/src/iceberg/snapshot.cc
+++ b/src/iceberg/snapshot.cc
@@ -39,7 +39,7 @@ bool SnapshotRef::Tag::Equals(const SnapshotRef::Tag& other) const {
 SnapshotRefType SnapshotRef::type() const noexcept {
   return std::visit(
       [&](const auto& retention) -> SnapshotRefType {
-        using T = std::decay_t<decltype(retention)>;
+        using T = std::remove_cvref_t<decltype(retention)>;
         if constexpr (std::is_same_v<T, Branch>) {
           return SnapshotRefType::kBranch;
         } else {

--- a/src/iceberg/test/matchers.h
+++ b/src/iceberg/test/matchers.h
@@ -140,7 +140,7 @@ class HasValueMatcher {
 template <typename MatcherT>
 auto HasValue(MatcherT&& matcher) {
   return ::testing::MakePolymorphicMatcher(
-      HasValueMatcher<std::decay_t<MatcherT>>(std::forward<MatcherT>(matcher)));
+      HasValueMatcher<std::remove_cvref_t<MatcherT>>(std::forward<MatcherT>(matcher)));
 }
 
 // Overload for the common case where we just want to check for presence of any value
@@ -200,15 +200,15 @@ class ResultMatcher {
 // Factory function for ResultMatcher for values
 template <typename MatcherT>
 auto ResultIs(MatcherT&& matcher) {
-  return ::testing::MakePolymorphicMatcher(
-      ResultMatcher<std::decay_t<MatcherT>>(true, std::forward<MatcherT>(matcher)));
+  return ::testing::MakePolymorphicMatcher(ResultMatcher<std::remove_cvref_t<MatcherT>>(
+      true, std::forward<MatcherT>(matcher)));
 }
 
 // Factory function for ResultMatcher for errors
 template <typename MatcherT>
 auto ErrorIs(MatcherT&& matcher) {
-  return ::testing::MakePolymorphicMatcher(
-      ResultMatcher<std::decay_t<MatcherT>>(false, std::forward<MatcherT>(matcher)));
+  return ::testing::MakePolymorphicMatcher(ResultMatcher<std::remove_cvref_t<MatcherT>>(
+      false, std::forward<MatcherT>(matcher)));
 }
 
 // Evaluate `rexpr` which should return a Result<T, Error>.

--- a/src/iceberg/test/visit_type_test.cc
+++ b/src/iceberg/test/visit_type_test.cc
@@ -228,7 +228,7 @@ TEST_P(TypeTest, VisitTypePrintToString) {
 
 TEST_P(TypeTest, VisitTypeReturnNestedTypeId) {
   auto visitor = [&](auto&& type) -> Result<TypeId> {
-    using Type = std::decay_t<decltype(type)>;
+    using Type = std::remove_cvref_t<decltype(type)>;
     // Check if the type is a nested type
     if constexpr (std::is_base_of_v<NestedType, Type>) {
       return type.type_id();


### PR DESCRIPTION
`decay_t` will turn `T[]` into `T*` and function into a function pointer. It is not as accurate as `remove_cvref_t` when obtaining the original type.

https://stackoverflow.com/questions/74257533/difference-between-stddecay-and-stdremove-cvref