### PR TITLE
feat: add ReachableFileCleanup to expire snapshots

### DIFF
--- a/src/iceberg/table_metadata.cc
+++ b/src/iceberg/table_metadata.cc
@@ -1440,11 +1440,8 @@ Status TableMetadataBuilder::Impl::RemoveSnapshots(
     if (ids_to_remove.contains(snapshot_id)) {
       snapshots_by_id_.erase(snapshot_id);
       snapshot_ids_to_remove.push_back(snapshot_id);
-      // TODO(shangxinli): Remove statistics metadata entries when a snapshot is expired.
-      // Until this is wired in, physical stats-file deletion is deferred in
-      // ReachableFileCleanup::CleanFiles to keep metadata and physical files in sync.
-      // ICEBERG_RETURN_UNEXPECTED(RemoveStatistics(snapshot_id));
-      // ICEBERG_RETURN_UNEXPECTED(RemovePartitionStatistics(snapshot_id));
+      ICEBERG_RETURN_UNEXPECTED(RemoveStatistics(snapshot_id));
+      ICEBERG_RETURN_UNEXPECTED(RemovePartitionStatistics(snapshot_id));
     } else {
       retained_snapshots.push_back(std::move(snapshot));
     }

--- a/src/iceberg/table_metadata.cc
+++ b/src/iceberg/table_metadata.cc
@@ -1440,7 +1440,7 @@ Status TableMetadataBuilder::Impl::RemoveSnapshots(
     if (ids_to_remove.contains(snapshot_id)) {
       snapshots_by_id_.erase(snapshot_id);
       snapshot_ids_to_remove.push_back(snapshot_id);
-      // TODO: Remove statistics metadata entries when a snapshot is expired.
+      // TODO(shangxinli): Remove statistics metadata entries when a snapshot is expired.
       // Until this is wired in, physical stats-file deletion is deferred in
       // ReachableFileCleanup::CleanFiles to keep metadata and physical files in sync.
       // ICEBERG_RETURN_UNEXPECTED(RemoveStatistics(snapshot_id));

--- a/src/iceberg/table_metadata.cc
+++ b/src/iceberg/table_metadata.cc
@@ -1440,7 +1440,9 @@ Status TableMetadataBuilder::Impl::RemoveSnapshots(
     if (ids_to_remove.contains(snapshot_id)) {
       snapshots_by_id_.erase(snapshot_id);
       snapshot_ids_to_remove.push_back(snapshot_id);
-      // FIXME: implement statistics removal and uncomment below
+      // TODO: Remove statistics metadata entries when a snapshot is expired.
+      // Until this is wired in, physical stats-file deletion is deferred in
+      // ReachableFileCleanup::CleanFiles to keep metadata and physical files in sync.
       // ICEBERG_RETURN_UNEXPECTED(RemoveStatistics(snapshot_id));
       // ICEBERG_RETURN_UNEXPECTED(RemovePartitionStatistics(snapshot_id));
     } else {

--- a/src/iceberg/test/expire_snapshots_test.cc
+++ b/src/iceberg/test/expire_snapshots_test.cc
@@ -19,6 +19,9 @@
 
 #include "iceberg/update/expire_snapshots.h"
 
+#include <string>
+#include <vector>
+
 #include "iceberg/test/matchers.h"
 #include "iceberg/test/update_test_base.h"
 
@@ -63,6 +66,90 @@ TEST_F(ExpireSnapshotsTest, ExpireOlderThan) {
     ICEBERG_UNWRAP_OR_FAIL(auto result, update->Apply());
     EXPECT_EQ(result.snapshot_ids_to_remove.size(), test_case.expected_num_expired);
   }
+}
+
+TEST_F(ExpireSnapshotsTest, DeleteWithCustomFunction) {
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  // Apply first so apply_result_ is cached
+  ICEBERG_UNWRAP_OR_FAIL(auto result, update->Apply());
+  EXPECT_EQ(result.snapshot_ids_to_remove.size(), 1);
+
+  // Call Finalize directly to simulate successful commit
+  // Note: Finalize tries to read manifests from the expired snapshot's manifest list,
+  // which will fail on mock FS since "s3://a/b/1.avro" doesn't contain real avro data.
+  // The error is returned from Finalize but in the real commit flow it's ignored.
+  auto finalize_status = update->Finalize(std::nullopt);
+  // Finalize may fail because manifest list files don't exist on mock FS,
+  // but it should not crash
+  if (finalize_status.has_value()) {
+    // If it succeeded (e.g., if manifest reading was skipped), verify deletions
+    EXPECT_FALSE(deleted_files.empty());
+  }
+}
+
+TEST_F(ExpireSnapshotsTest, CleanupLevelNoneSkipsFileDeletion) {
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->CleanupLevel(CleanupLevel::kNone);
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  ICEBERG_UNWRAP_OR_FAIL(auto result, update->Apply());
+  EXPECT_EQ(result.snapshot_ids_to_remove.size(), 1);
+
+  // With kNone cleanup level, Finalize should skip all file deletion
+  auto finalize_status = update->Finalize(std::nullopt);
+  EXPECT_THAT(finalize_status, IsOk());
+  EXPECT_TRUE(deleted_files.empty());
+}
+
+TEST_F(ExpireSnapshotsTest, FinalizeSkippedOnCommitError) {
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  ICEBERG_UNWRAP_OR_FAIL(auto result, update->Apply());
+  EXPECT_EQ(result.snapshot_ids_to_remove.size(), 1);
+
+  // Simulate a commit failure - Finalize should not delete any files
+  auto finalize_status = update->Finalize(
+      Error{.kind = ErrorKind::kCommitFailed, .message = "simulated failure"});
+  EXPECT_THAT(finalize_status, IsOk());
+  EXPECT_TRUE(deleted_files.empty());
+}
+
+TEST_F(ExpireSnapshotsTest, FinalizeSkippedWhenNoSnapshotsExpired) {
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->RetainLast(2);
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  ICEBERG_UNWRAP_OR_FAIL(auto result, update->Apply());
+  EXPECT_TRUE(result.snapshot_ids_to_remove.empty());
+
+  // No snapshots expired, so Finalize should not delete any files
+  auto finalize_status = update->Finalize(std::nullopt);
+  EXPECT_THAT(finalize_status, IsOk());
+  EXPECT_TRUE(deleted_files.empty());
+}
+
+TEST_F(ExpireSnapshotsTest, CommitWithCleanupLevelNone) {
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->CleanupLevel(CleanupLevel::kNone);
+
+  // Commit should succeed - Finalize is called internally but skips cleanup
+  EXPECT_THAT(update->Commit(), IsOk());
+
+  // Verify snapshot was removed from metadata
+  auto metadata = ReloadMetadata();
+  EXPECT_EQ(metadata->snapshots.size(), 1);
+  EXPECT_EQ(metadata->snapshots.at(0)->snapshot_id, 3055729675574597004);
 }
 
 }  // namespace iceberg

--- a/src/iceberg/test/expire_snapshots_test.cc
+++ b/src/iceberg/test/expire_snapshots_test.cc
@@ -19,15 +19,190 @@
 
 #include "iceberg/update/expire_snapshots.h"
 
+#include <optional>
 #include <string>
 #include <vector>
 
+#include <gmock/gmock.h>
+
+#include "iceberg/avro/avro_register.h"
+#include "iceberg/manifest/manifest_entry.h"
+#include "iceberg/manifest/manifest_writer.h"
+#include "iceberg/statistics_file.h"
+#include "iceberg/table_metadata.h"
 #include "iceberg/test/matchers.h"
 #include "iceberg/test/update_test_base.h"
 
 namespace iceberg {
 
 class ExpireSnapshotsTest : public UpdateTestBase {};
+
+class ExpireSnapshotsCleanupTest : public UpdateTestBase {
+ protected:
+  static constexpr int64_t kExpiredSnapshotId = 3051729675574597004;
+  static constexpr int64_t kCurrentSnapshotId = 3055729675574597004;
+  static constexpr int64_t kExpiredSequenceNumber = 0;
+  static constexpr int64_t kCurrentSequenceNumber = 1;
+
+  void SetUp() override {
+    UpdateTestBase::SetUp();
+    avro::RegisterAll();
+  }
+
+  ManifestEntry MakeEntry(ManifestStatus status, int64_t snapshot_id,
+                          int64_t sequence_number, std::shared_ptr<DataFile> file) const {
+    return ManifestEntry{
+        .status = status,
+        .snapshot_id = snapshot_id,
+        .sequence_number = sequence_number,
+        .file_sequence_number = sequence_number,
+        .data_file = std::move(file),
+    };
+  }
+
+  std::shared_ptr<DataFile> MakeDataFile(const std::string& path) const {
+    return std::make_shared<DataFile>(DataFile{
+        .file_path = path,
+        .file_format = FileFormatType::kParquet,
+        .partition = PartitionValues({Literal::Long(1)}),
+        .record_count = 1,
+        .file_size_in_bytes = 10,
+        .sort_order_id = 0,
+    });
+  }
+
+  std::shared_ptr<DataFile> MakePositionDeleteFile(const std::string& path) const {
+    return std::make_shared<DataFile>(DataFile{
+        .content = DataFile::Content::kPositionDeletes,
+        .file_path = path,
+        .file_format = FileFormatType::kParquet,
+        .partition = PartitionValues({Literal::Long(1)}),
+        .record_count = 1,
+        .file_size_in_bytes = 10,
+    });
+  }
+
+  std::shared_ptr<StatisticsFile> MakeStatisticsFile(int64_t snapshot_id,
+                                                     const std::string& path) const {
+    auto statistics_file = std::make_shared<StatisticsFile>();
+    statistics_file->snapshot_id = snapshot_id;
+    statistics_file->path = path;
+    statistics_file->file_size_in_bytes = 10;
+    statistics_file->file_footer_size_in_bytes = 2;
+    return statistics_file;
+  }
+
+  std::shared_ptr<PartitionStatisticsFile> MakePartitionStatisticsFile(
+      int64_t snapshot_id, const std::string& path) const {
+    auto statistics_file = std::make_shared<PartitionStatisticsFile>();
+    statistics_file->snapshot_id = snapshot_id;
+    statistics_file->path = path;
+    statistics_file->file_size_in_bytes = 10;
+    return statistics_file;
+  }
+
+  std::shared_ptr<Schema> CurrentSchema() {
+    auto metadata = ReloadMetadata();
+    auto schema_result = metadata->Schema();
+    EXPECT_THAT(schema_result, IsOk());
+    return schema_result.value();
+  }
+
+  std::shared_ptr<PartitionSpec> DefaultSpec() {
+    auto metadata = ReloadMetadata();
+    auto spec_result = metadata->PartitionSpecById(metadata->default_spec_id);
+    EXPECT_THAT(spec_result, IsOk());
+    return spec_result.value();
+  }
+
+  int8_t FormatVersion() { return ReloadMetadata()->format_version; }
+
+  ManifestFile WriteDataManifest(const std::string& path, int64_t snapshot_id,
+                                 std::vector<ManifestEntry> entries) {
+    auto writer_result = ManifestWriter::MakeWriter(
+        FormatVersion(), snapshot_id, path, file_io_, DefaultSpec(), CurrentSchema(),
+        ManifestContent::kData, /*first_row_id=*/std::nullopt);
+    EXPECT_THAT(writer_result, IsOk());
+    auto writer = std::move(writer_result.value());
+
+    for (const auto& entry : entries) {
+      EXPECT_THAT(writer->WriteEntry(entry), IsOk());
+    }
+
+    EXPECT_THAT(writer->Close(), IsOk());
+    auto manifest_result = writer->ToManifestFile();
+    EXPECT_THAT(manifest_result, IsOk());
+    return manifest_result.value();
+  }
+
+  ManifestFile WriteDeleteManifest(const std::string& path, int64_t snapshot_id,
+                                   std::vector<ManifestEntry> entries) {
+    auto writer_result = ManifestWriter::MakeWriter(
+        FormatVersion(), snapshot_id, path, file_io_, DefaultSpec(), CurrentSchema(),
+        ManifestContent::kDeletes, /*first_row_id=*/std::nullopt);
+    EXPECT_THAT(writer_result, IsOk());
+    auto writer = std::move(writer_result.value());
+
+    for (const auto& entry : entries) {
+      EXPECT_THAT(writer->WriteEntry(entry), IsOk());
+    }
+
+    EXPECT_THAT(writer->Close(), IsOk());
+    auto manifest_result = writer->ToManifestFile();
+    EXPECT_THAT(manifest_result, IsOk());
+    return manifest_result.value();
+  }
+
+  std::string WriteManifestList(const std::string& path, int64_t snapshot_id,
+                                int64_t parent_snapshot_id, int64_t sequence_number,
+                                const std::vector<ManifestFile>& manifests) {
+    auto writer_result = ManifestListWriter::MakeWriter(
+        FormatVersion(), snapshot_id, parent_snapshot_id, path, file_io_,
+        /*sequence_number=*/std::optional<int64_t>(sequence_number),
+        /*first_row_id=*/std::nullopt);
+    EXPECT_THAT(writer_result, IsOk());
+    auto writer = std::move(writer_result.value());
+    EXPECT_THAT(writer->AddAll(manifests), IsOk());
+    EXPECT_THAT(writer->Close(), IsOk());
+    return path;
+  }
+
+  void RewriteTableWithManifestLists(const std::string& expired_manifest_list,
+                                     const std::string& current_manifest_list) {
+    auto metadata = ReloadMetadata();
+    ASSERT_EQ(metadata->snapshots.size(), 2);
+    metadata->snapshots.at(0)->manifest_list = expired_manifest_list;
+    metadata->snapshots.at(1)->manifest_list = current_manifest_list;
+
+    RewriteTable(std::move(metadata));
+  }
+
+  void RewriteTable(std::shared_ptr<TableMetadata> metadata) {
+    ASSERT_NE(metadata, nullptr);
+
+    const auto metadata_location =
+        table_location_ + "/metadata/00002-custom.metadata.json";
+    ASSERT_THAT(catalog_->DropTable(table_ident_, /*purge=*/false), IsOk());
+    ASSERT_THAT(TableMetadataUtil::Write(*file_io_, metadata_location, *metadata),
+                IsOk());
+    ICEBERG_UNWRAP_OR_FAIL(table_,
+                           catalog_->RegisterTable(table_ident_, metadata_location));
+  }
+
+  void RewriteTableWithManifestListsAndStatistics(
+      const std::string& expired_manifest_list, const std::string& current_manifest_list,
+      std::vector<std::shared_ptr<StatisticsFile>> statistics,
+      std::vector<std::shared_ptr<PartitionStatisticsFile>> partition_statistics) {
+    auto metadata = ReloadMetadata();
+    ASSERT_EQ(metadata->snapshots.size(), 2);
+    metadata->snapshots.at(0)->manifest_list = expired_manifest_list;
+    metadata->snapshots.at(1)->manifest_list = current_manifest_list;
+    metadata->statistics = std::move(statistics);
+    metadata->partition_statistics = std::move(partition_statistics);
+
+    RewriteTable(std::move(metadata));
+  }
+};
 
 TEST_F(ExpireSnapshotsTest, DefaultExpireByAge) {
   ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
@@ -68,7 +243,7 @@ TEST_F(ExpireSnapshotsTest, ExpireOlderThan) {
   }
 }
 
-TEST_F(ExpireSnapshotsTest, DeleteWithCustomFunction) {
+TEST_F(ExpireSnapshotsTest, FinalizeRequiresCommittedMetadata) {
   std::vector<std::string> deleted_files;
   ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
   update->DeleteWith(
@@ -78,20 +253,15 @@ TEST_F(ExpireSnapshotsTest, DeleteWithCustomFunction) {
   ICEBERG_UNWRAP_OR_FAIL(auto result, update->Apply());
   EXPECT_EQ(result.snapshot_ids_to_remove.size(), 1);
 
-  // Call Finalize directly to simulate successful commit
-  // Note: Finalize tries to read manifests from the expired snapshot's manifest list,
-  // which will fail on mock FS since "s3://a/b/1.avro" doesn't contain real avro data.
-  // The error is returned from Finalize but in the real commit flow it's ignored.
-  auto finalize_status = update->Finalize(std::nullopt);
-  // Finalize may fail because manifest list files don't exist on mock FS,
-  // but it should not crash
-  if (finalize_status.has_value()) {
-    // If it succeeded (e.g., if manifest reading was skipped), verify deletions
-    EXPECT_FALSE(deleted_files.empty());
-  }
+  // A successful finalize now requires the committed metadata from the catalog.
+  auto finalize_status = update->Finalize(static_cast<const TableMetadata*>(nullptr));
+  EXPECT_THAT(finalize_status, IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(finalize_status,
+              HasErrorMessage("Missing committed table metadata for cleanup"));
+  EXPECT_TRUE(deleted_files.empty());
 }
 
-TEST_F(ExpireSnapshotsTest, CleanupLevelNoneSkipsFileDeletion) {
+TEST_F(ExpireSnapshotsTest, CleanupNoneSkipsDeletion) {
   std::vector<std::string> deleted_files;
   ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
   update->CleanupLevel(CleanupLevel::kNone);
@@ -102,7 +272,7 @@ TEST_F(ExpireSnapshotsTest, CleanupLevelNoneSkipsFileDeletion) {
   EXPECT_EQ(result.snapshot_ids_to_remove.size(), 1);
 
   // With kNone cleanup level, Finalize should skip all file deletion
-  auto finalize_status = update->Finalize(std::nullopt);
+  auto finalize_status = update->Finalize(static_cast<const TableMetadata*>(nullptr));
   EXPECT_THAT(finalize_status, IsOk());
   EXPECT_TRUE(deleted_files.empty());
 }
@@ -117,13 +287,13 @@ TEST_F(ExpireSnapshotsTest, FinalizeSkippedOnCommitError) {
   EXPECT_EQ(result.snapshot_ids_to_remove.size(), 1);
 
   // Simulate a commit failure - Finalize should not delete any files
-  auto finalize_status = update->Finalize(
-      Error{.kind = ErrorKind::kCommitFailed, .message = "simulated failure"});
+  auto finalize_status = update->Finalize(Result<const TableMetadata*>(std::unexpected(
+      Error{.kind = ErrorKind::kCommitFailed, .message = "simulated failure"})));
   EXPECT_THAT(finalize_status, IsOk());
   EXPECT_TRUE(deleted_files.empty());
 }
 
-TEST_F(ExpireSnapshotsTest, FinalizeSkippedWhenNoSnapshotsExpired) {
+TEST_F(ExpireSnapshotsTest, FinalizeSkipsWhenNothingExpired) {
   std::vector<std::string> deleted_files;
   ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
   update->RetainLast(2);
@@ -134,12 +304,12 @@ TEST_F(ExpireSnapshotsTest, FinalizeSkippedWhenNoSnapshotsExpired) {
   EXPECT_TRUE(result.snapshot_ids_to_remove.empty());
 
   // No snapshots expired, so Finalize should not delete any files
-  auto finalize_status = update->Finalize(std::nullopt);
+  auto finalize_status = update->Finalize(static_cast<const TableMetadata*>(nullptr));
   EXPECT_THAT(finalize_status, IsOk());
   EXPECT_TRUE(deleted_files.empty());
 }
 
-TEST_F(ExpireSnapshotsTest, CommitWithCleanupLevelNone) {
+TEST_F(ExpireSnapshotsTest, CommitWithCleanupNone) {
   ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
   update->CleanupLevel(CleanupLevel::kNone);
 
@@ -150,6 +320,257 @@ TEST_F(ExpireSnapshotsTest, CommitWithCleanupLevelNone) {
   auto metadata = ReloadMetadata();
   EXPECT_EQ(metadata->snapshots.size(), 1);
   EXPECT_EQ(metadata->snapshots.at(0)->snapshot_id, 3055729675574597004);
+}
+
+TEST_F(ExpireSnapshotsCleanupTest, IgnoresExpiredDeleteManifestReadFailures) {
+  const auto expired_data_file_path = table_location_ + "/data/expired-data.parquet";
+  const auto expired_delete_file_path = table_location_ + "/data/expired-delete.parquet";
+  const auto expired_data_manifest_path = table_location_ + "/metadata/expired-data.avro";
+  const auto expired_delete_manifest_path =
+      table_location_ + "/metadata/expired-delete.avro";
+  const auto expired_manifest_list_path =
+      table_location_ + "/metadata/expired-manifest-list.avro";
+  const auto current_manifest_list_path =
+      table_location_ + "/metadata/current-manifest-list.avro";
+
+  auto expired_data_manifest = WriteDataManifest(
+      expired_data_manifest_path, kExpiredSnapshotId,
+      {MakeEntry(ManifestStatus::kAdded, kExpiredSnapshotId, kExpiredSequenceNumber,
+                 MakeDataFile(expired_data_file_path))});
+  auto expired_delete_manifest = WriteDeleteManifest(
+      expired_delete_manifest_path, kExpiredSnapshotId,
+      {MakeEntry(ManifestStatus::kAdded, kExpiredSnapshotId, kExpiredSequenceNumber,
+                 MakePositionDeleteFile(expired_delete_file_path))});
+  WriteManifestList(expired_manifest_list_path, kExpiredSnapshotId,
+                    /*parent_snapshot_id=*/0, kExpiredSequenceNumber,
+                    {expired_data_manifest, expired_delete_manifest});
+  WriteManifestList(current_manifest_list_path, kCurrentSnapshotId, kExpiredSnapshotId,
+                    kCurrentSequenceNumber, {});
+  RewriteTableWithManifestLists(expired_manifest_list_path, current_manifest_list_path);
+
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  EXPECT_THAT(update->Commit(), IsOk());
+  EXPECT_THAT(deleted_files, testing::UnorderedElementsAre(expired_data_file_path,
+                                                           expired_data_manifest_path,
+                                                           expired_delete_manifest_path,
+                                                           expired_manifest_list_path));
+}
+
+TEST_F(ExpireSnapshotsCleanupTest, DeletesExpiredFiles) {
+  const auto expired_data_file_path = table_location_ + "/data/expired-data.parquet";
+  const auto expired_delete_file_path = table_location_ + "/data/expired-delete.parquet";
+  const auto expired_data_manifest_path = table_location_ + "/metadata/expired-data.avro";
+  const auto expired_delete_manifest_path =
+      table_location_ + "/metadata/expired-delete.avro";
+  const auto expired_manifest_list_path =
+      table_location_ + "/metadata/expired-manifest-list.avro";
+  const auto current_manifest_list_path =
+      table_location_ + "/metadata/current-manifest-list.avro";
+
+  auto expired_data_manifest = WriteDataManifest(
+      expired_data_manifest_path, kExpiredSnapshotId,
+      {MakeEntry(ManifestStatus::kAdded, kExpiredSnapshotId, kExpiredSequenceNumber,
+                 MakeDataFile(expired_data_file_path))});
+  auto expired_delete_manifest = WriteDeleteManifest(
+      expired_delete_manifest_path, kExpiredSnapshotId,
+      {MakeEntry(ManifestStatus::kAdded, kExpiredSnapshotId, kExpiredSequenceNumber,
+                 MakePositionDeleteFile(expired_delete_file_path))});
+  WriteManifestList(expired_manifest_list_path, kExpiredSnapshotId,
+                    /*parent_snapshot_id=*/0, kExpiredSequenceNumber,
+                    {expired_data_manifest, expired_delete_manifest});
+  WriteManifestList(current_manifest_list_path, kCurrentSnapshotId, kExpiredSnapshotId,
+                    kCurrentSequenceNumber, {});
+  RewriteTableWithManifestLists(expired_manifest_list_path, current_manifest_list_path);
+
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  EXPECT_THAT(update->Commit(), IsOk());
+  EXPECT_THAT(deleted_files, testing::UnorderedElementsAre(expired_data_file_path,
+                                                           expired_data_manifest_path,
+                                                           expired_delete_manifest_path,
+                                                           expired_manifest_list_path));
+}
+
+TEST_F(ExpireSnapshotsCleanupTest, MetadataOnlySkipsDataDeletion) {
+  const auto expired_data_file_path = table_location_ + "/data/expired-data.parquet";
+  const auto expired_delete_manifest_path =
+      table_location_ + "/metadata/expired-delete.avro";
+  const auto expired_data_manifest_path = table_location_ + "/metadata/expired-data.avro";
+  const auto expired_manifest_list_path =
+      table_location_ + "/metadata/expired-manifest-list.avro";
+  const auto current_manifest_list_path =
+      table_location_ + "/metadata/current-manifest-list.avro";
+
+  auto expired_data_manifest = WriteDataManifest(
+      expired_data_manifest_path, kExpiredSnapshotId,
+      {MakeEntry(ManifestStatus::kAdded, kExpiredSnapshotId, kExpiredSequenceNumber,
+                 MakeDataFile(expired_data_file_path))});
+  auto expired_delete_manifest = WriteDeleteManifest(
+      expired_delete_manifest_path, kExpiredSnapshotId,
+      {MakeEntry(
+          ManifestStatus::kAdded, kExpiredSnapshotId, kExpiredSequenceNumber,
+          MakePositionDeleteFile(table_location_ + "/data/expired-delete.parquet"))});
+  WriteManifestList(expired_manifest_list_path, kExpiredSnapshotId,
+                    /*parent_snapshot_id=*/0, kExpiredSequenceNumber,
+                    {expired_data_manifest, expired_delete_manifest});
+  WriteManifestList(current_manifest_list_path, kCurrentSnapshotId, kExpiredSnapshotId,
+                    kCurrentSequenceNumber, {});
+  RewriteTableWithManifestLists(expired_manifest_list_path, current_manifest_list_path);
+
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->CleanupLevel(CleanupLevel::kMetadataOnly);
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  EXPECT_THAT(update->Commit(), IsOk());
+  EXPECT_THAT(deleted_files, testing::UnorderedElementsAre(expired_data_manifest_path,
+                                                           expired_delete_manifest_path,
+                                                           expired_manifest_list_path));
+}
+
+TEST_F(ExpireSnapshotsCleanupTest, RetainedDeleteManifestSkipsDataDeletion) {
+  const auto expired_data_file_path = table_location_ + "/data/expired-data.parquet";
+  const auto current_delete_file_path = table_location_ + "/data/current-delete.parquet";
+  const auto expired_data_manifest_path = table_location_ + "/metadata/expired-data.avro";
+  const auto current_delete_manifest_path =
+      table_location_ + "/metadata/current-delete.avro";
+  const auto expired_manifest_list_path =
+      table_location_ + "/metadata/expired-manifest-list.avro";
+  const auto current_manifest_list_path =
+      table_location_ + "/metadata/current-manifest-list.avro";
+
+  auto expired_data_manifest = WriteDataManifest(
+      expired_data_manifest_path, kExpiredSnapshotId,
+      {MakeEntry(ManifestStatus::kAdded, kExpiredSnapshotId, kExpiredSequenceNumber,
+                 MakeDataFile(expired_data_file_path))});
+  auto current_delete_manifest = WriteDeleteManifest(
+      current_delete_manifest_path, kCurrentSnapshotId,
+      {MakeEntry(ManifestStatus::kAdded, kCurrentSnapshotId, kCurrentSequenceNumber,
+                 MakePositionDeleteFile(current_delete_file_path))});
+  WriteManifestList(expired_manifest_list_path, kExpiredSnapshotId,
+                    /*parent_snapshot_id=*/0, kExpiredSequenceNumber,
+                    {expired_data_manifest});
+  WriteManifestList(current_manifest_list_path, kCurrentSnapshotId, kExpiredSnapshotId,
+                    kCurrentSequenceNumber, {current_delete_manifest});
+  RewriteTableWithManifestLists(expired_manifest_list_path, current_manifest_list_path);
+
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  EXPECT_THAT(update->Commit(), IsOk());
+  EXPECT_THAT(deleted_files, testing::UnorderedElementsAre(expired_data_manifest_path,
+                                                           expired_manifest_list_path));
+}
+
+TEST_F(ExpireSnapshotsCleanupTest, DeletesExpiredStats) {
+  const auto expired_manifest_list_path =
+      table_location_ + "/metadata/expired-manifest-list.avro";
+  const auto current_manifest_list_path =
+      table_location_ + "/metadata/current-manifest-list.avro";
+  const auto expired_statistics_path = table_location_ + "/metadata/stats-expired.puffin";
+
+  WriteManifestList(expired_manifest_list_path, kExpiredSnapshotId,
+                    /*parent_snapshot_id=*/0, kExpiredSequenceNumber, {});
+  WriteManifestList(current_manifest_list_path, kCurrentSnapshotId, kExpiredSnapshotId,
+                    kCurrentSequenceNumber, {});
+  RewriteTableWithManifestListsAndStatistics(
+      expired_manifest_list_path, current_manifest_list_path,
+      {MakeStatisticsFile(kExpiredSnapshotId, expired_statistics_path)}, {});
+
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  EXPECT_THAT(update->Commit(), IsOk());
+  EXPECT_THAT(deleted_files, testing::Contains(expired_statistics_path));
+}
+
+TEST_F(ExpireSnapshotsCleanupTest, KeepsReusedStats) {
+  const auto expired_manifest_list_path =
+      table_location_ + "/metadata/expired-manifest-list.avro";
+  const auto current_manifest_list_path =
+      table_location_ + "/metadata/current-manifest-list.avro";
+  const auto reused_statistics_path = table_location_ + "/metadata/stats-reused.puffin";
+
+  WriteManifestList(expired_manifest_list_path, kExpiredSnapshotId,
+                    /*parent_snapshot_id=*/0, kExpiredSequenceNumber, {});
+  WriteManifestList(current_manifest_list_path, kCurrentSnapshotId, kExpiredSnapshotId,
+                    kCurrentSequenceNumber, {});
+  RewriteTableWithManifestListsAndStatistics(
+      expired_manifest_list_path, current_manifest_list_path,
+      {MakeStatisticsFile(kExpiredSnapshotId, reused_statistics_path),
+       MakeStatisticsFile(kCurrentSnapshotId, reused_statistics_path)},
+      {});
+
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  EXPECT_THAT(update->Commit(), IsOk());
+  EXPECT_THAT(deleted_files, testing::Not(testing::Contains(reused_statistics_path)));
+}
+
+TEST_F(ExpireSnapshotsCleanupTest, DeletesExpiredPartitionStats) {
+  const auto expired_manifest_list_path =
+      table_location_ + "/metadata/expired-manifest-list.avro";
+  const auto current_manifest_list_path =
+      table_location_ + "/metadata/current-manifest-list.avro";
+  const auto expired_statistics_path =
+      table_location_ + "/metadata/partition-stats-expired.parquet";
+
+  WriteManifestList(expired_manifest_list_path, kExpiredSnapshotId,
+                    /*parent_snapshot_id=*/0, kExpiredSequenceNumber, {});
+  WriteManifestList(current_manifest_list_path, kCurrentSnapshotId, kExpiredSnapshotId,
+                    kCurrentSequenceNumber, {});
+  RewriteTableWithManifestListsAndStatistics(
+      expired_manifest_list_path, current_manifest_list_path, {},
+      {MakePartitionStatisticsFile(kExpiredSnapshotId, expired_statistics_path)});
+
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  EXPECT_THAT(update->Commit(), IsOk());
+  EXPECT_THAT(deleted_files, testing::Contains(expired_statistics_path));
+}
+
+TEST_F(ExpireSnapshotsCleanupTest, KeepsReusedPartitionStats) {
+  const auto expired_manifest_list_path =
+      table_location_ + "/metadata/expired-manifest-list.avro";
+  const auto current_manifest_list_path =
+      table_location_ + "/metadata/current-manifest-list.avro";
+  const auto reused_statistics_path =
+      table_location_ + "/metadata/partition-stats-reused.parquet";
+
+  WriteManifestList(expired_manifest_list_path, kExpiredSnapshotId,
+                    /*parent_snapshot_id=*/0, kExpiredSequenceNumber, {});
+  WriteManifestList(current_manifest_list_path, kCurrentSnapshotId, kExpiredSnapshotId,
+                    kCurrentSequenceNumber, {});
+  RewriteTableWithManifestListsAndStatistics(
+      expired_manifest_list_path, current_manifest_list_path, {},
+      {MakePartitionStatisticsFile(kExpiredSnapshotId, reused_statistics_path),
+       MakePartitionStatisticsFile(kCurrentSnapshotId, reused_statistics_path)});
+
+  std::vector<std::string> deleted_files;
+  ICEBERG_UNWRAP_OR_FAIL(auto update, table_->NewExpireSnapshots());
+  update->DeleteWith(
+      [&deleted_files](const std::string& path) { deleted_files.push_back(path); });
+
+  EXPECT_THAT(update->Commit(), IsOk());
+  EXPECT_THAT(deleted_files, testing::Not(testing::Contains(reused_statistics_path)));
 }
 
 }  // namespace iceberg

--- a/src/iceberg/transaction.cc
+++ b/src/iceberg/transaction.cc
@@ -363,10 +363,13 @@ Result<std::shared_ptr<Table>> Transaction::Commit() {
   auto commit_result =
       ctx_->table->catalog()->UpdateTable(ctx_->table->name(), requirements, updates);
 
+  Result<const TableMetadata*> finalize_result =
+      commit_result.has_value()
+          ? Result<const TableMetadata*>(commit_result.value()->metadata().get())
+          : std::unexpected(commit_result.error());
+
   for (const auto& update : pending_updates_) {
-    std::ignore = update->Finalize(commit_result.has_value()
-                                       ? std::nullopt
-                                       : std::make_optional(commit_result.error()));
+    std::ignore = update->Finalize(finalize_result);
   }
 
   ICEBERG_RETURN_UNEXPECTED(commit_result);

--- a/src/iceberg/update/expire_snapshots.cc
+++ b/src/iceberg/update/expire_snapshots.cc
@@ -49,7 +49,8 @@ Result<std::shared_ptr<ManifestReader>> MakeManifestReader(
     const ManifestFile& manifest, const std::shared_ptr<FileIO>& file_io,
     const TableMetadata& metadata) {
   ICEBERG_ASSIGN_OR_RAISE(auto schema, metadata.Schema());
-  ICEBERG_ASSIGN_OR_RAISE(auto spec, metadata.PartitionSpecById(manifest.partition_spec_id));
+  ICEBERG_ASSIGN_OR_RAISE(auto spec,
+                          metadata.PartitionSpecById(manifest.partition_spec_id));
   return ManifestReader::Make(manifest, file_io, std::move(schema), std::move(spec));
 }
 
@@ -98,8 +99,7 @@ class FileCleanupStrategy {
   /// if the same file path is shared across snapshots, it is only deleted when
   /// no retained snapshot references it.
   std::unordered_set<std::string> ExpiredStatisticsFilePaths(
-      const TableMetadata& metadata,
-      const std::unordered_set<int64_t>& expired_ids) {
+      const TableMetadata& metadata, const std::unordered_set<int64_t>& expired_ids) {
     std::unordered_set<std::string> retained_paths;
     for (const auto& stat : metadata.statistics) {
       if (stat && !expired_ids.contains(stat->snapshot_id)) {
@@ -568,9 +568,8 @@ Status ExpireSnapshots::Finalize(std::optional<Error> commit_error) {
     return {};
   }
 
-  std::unordered_set<int64_t> expired_ids(
-      apply_result_->snapshot_ids_to_remove.begin(),
-      apply_result_->snapshot_ids_to_remove.end());
+  std::unordered_set<int64_t> expired_ids(apply_result_->snapshot_ids_to_remove.begin(),
+                                          apply_result_->snapshot_ids_to_remove.end());
   apply_result_.reset();
 
   // File cleanup is best-effort: log and continue on individual file deletion failures

--- a/src/iceberg/update/expire_snapshots.cc
+++ b/src/iceberg/update/expire_snapshots.cc
@@ -33,6 +33,7 @@
 #include "iceberg/manifest/manifest_reader.h"
 #include "iceberg/schema.h"
 #include "iceberg/snapshot.h"
+#include "iceberg/statistics_file.h"
 #include "iceberg/table.h"
 #include "iceberg/table_metadata.h"
 #include "iceberg/transaction.h"
@@ -54,9 +55,6 @@ Result<std::shared_ptr<ManifestReader>> MakeManifestReader(
 }
 
 /// \brief Abstract strategy for cleaning up files after snapshot expiration.
-///
-/// Mirrors Java's FileCleanupStrategy: provides shared delete utilities while
-/// allowing different cleanup algorithms (ReachableFileCleanup, IncrementalFileCleanup).
 class FileCleanupStrategy {
  public:
   FileCleanupStrategy(std::shared_ptr<FileIO> file_io,
@@ -67,18 +65,17 @@ class FileCleanupStrategy {
 
   /// \brief Clean up files that are only reachable by expired snapshots.
   ///
-  /// \param metadata Table metadata before expiration (contains all snapshots).
+  /// \param metadata_before_expiration Table metadata before expiration.
+  /// \param metadata_after_expiration Table metadata after expiration.
   /// \param expired_snapshot_ids Snapshot IDs that were expired during this operation.
   /// \param level Controls which types of files are eligible for deletion.
-  virtual Status CleanFiles(const TableMetadata& metadata,
+  virtual Status CleanFiles(const TableMetadata& metadata_before_expiration,
+                            const TableMetadata& metadata_after_expiration,
                             const std::unordered_set<int64_t>& expired_snapshot_ids,
                             CleanupLevel level) = 0;
 
  protected:
-  /// \brief Delete a file, suppressing errors (best-effort).
-  ///
-  /// Uses the custom delete function if set, otherwise FileIO::DeleteFile.
-  /// Matches Java's suppressFailureWhenFinished behavior.
+  /// \brief Delete a single file
   void DeleteFile(const std::string& path) {
     try {
       if (delete_func_) {
@@ -87,9 +84,52 @@ class FileCleanupStrategy {
         std::ignore = file_io_->DeleteFile(path);
       }
     } catch (...) {
-      // Suppress all exceptions during file cleanup to match Java's
-      // suppressFailureWhenFinished behavior.
+      /// TODO(shangxinli): add retry
     }
+  }
+
+  /// TODO(shangxinli): Add bulk deletion
+  void DeleteFiles(const std::unordered_set<std::string>& paths) {
+    for (const auto& path : paths) {
+      DeleteFile(path);
+    }
+  }
+
+  bool HasAnyStatisticsFiles(const TableMetadata& metadata) const {
+    return !metadata.statistics.empty() || !metadata.partition_statistics.empty();
+  }
+
+  std::unordered_set<std::string> StatisticsFilesToDelete(
+      const TableMetadata& metadata_before_expiration,
+      const TableMetadata& metadata_after_expiration) const {
+    std::unordered_set<std::string> stats_files_to_delete;
+    std::unordered_set<std::string> live_stats_paths;
+
+    for (const auto& stats_file : metadata_after_expiration.statistics) {
+      if (stats_file) {
+        live_stats_paths.insert(stats_file->path);
+      }
+    }
+
+    for (const auto& part_stats_file : metadata_after_expiration.partition_statistics) {
+      if (part_stats_file) {
+        live_stats_paths.insert(part_stats_file->path);
+      }
+    }
+
+    for (const auto& stats_file : metadata_before_expiration.statistics) {
+      if (stats_file && !live_stats_paths.contains(stats_file->path)) {
+        stats_files_to_delete.insert(stats_file->path);
+      }
+    }
+
+    for (const auto& part_stats_file : metadata_before_expiration.partition_statistics) {
+      if (part_stats_file && !live_stats_paths.contains(part_stats_file->path)) {
+        stats_files_to_delete.insert(part_stats_file->path);
+      }
+    }
+
+    return stats_files_to_delete;
   }
 
   std::shared_ptr<FileIO> file_io_;
@@ -98,176 +138,192 @@ class FileCleanupStrategy {
 
 /// \brief File cleanup strategy that determines safe deletions via full reachability.
 ///
-/// Mirrors Java's ReachableFileCleanup: collects manifests from all expired and
-/// retained snapshots, prunes candidates still referenced by retained snapshots,
-/// then deletes orphaned manifests, data files, and manifest lists.
+/// Collects manifests from all expired and retained snapshots, prunes candidates
+/// still referenced by retained snapshots, then deletes orphaned manifests, data
+/// files, and manifest lists.
 ///
 /// TODO(shangxinli): Add multi-threaded manifest reading and file deletion support.
 class ReachableFileCleanup : public FileCleanupStrategy {
  public:
   using FileCleanupStrategy::FileCleanupStrategy;
 
-  Status CleanFiles(const TableMetadata& metadata,
+  Status CleanFiles(const TableMetadata& metadata_before_expiration,
+                    const TableMetadata& metadata_after_expiration,
                     const std::unordered_set<int64_t>& expired_snapshot_ids,
                     CleanupLevel level) override {
     std::unordered_set<int64_t> retained_snapshot_ids;
-    for (const auto& snapshot : metadata.snapshots) {
-      if (snapshot && !expired_snapshot_ids.contains(snapshot->snapshot_id)) {
+    for (const auto& snapshot : metadata_after_expiration.snapshots) {
+      if (snapshot) {
         retained_snapshot_ids.insert(snapshot->snapshot_id);
       }
     }
 
-    // Phase 1: Collect manifest paths from expired and retained snapshots.
-    // The manifest_cache_ is populated here to avoid O(M*S) repeated I/O in
-    // FindDataFilesToDelete.
-    std::unordered_set<std::string> expired_manifest_paths;
+    std::unordered_set<std::string> manifest_lists_to_delete;
     for (int64_t snapshot_id : expired_snapshot_ids) {
-      ReadManifestsForSnapshot(metadata, snapshot_id, expired_manifest_paths);
-    }
-    bool retained_manifests_complete = true;
-    std::unordered_set<std::string> retained_manifest_paths;
-    for (int64_t snapshot_id : retained_snapshot_ids) {
-      if (!ReadManifestsForSnapshot(metadata, snapshot_id, retained_manifest_paths)) {
-        retained_manifests_complete = false;
-        break;
+      ICEBERG_ASSIGN_OR_RAISE(auto snapshot,
+                              metadata_before_expiration.SnapshotById(snapshot_id));
+      if (snapshot && !snapshot->manifest_list.empty()) {
+        manifest_lists_to_delete.insert(snapshot->manifest_list);
       }
     }
 
-    // If any retained snapshot's manifests could not be read, skip manifest and
-    // data file deletion. An incomplete retained set means we cannot safely
-    // determine which manifests are still live, so deleting any candidates risks
-    // removing files still referenced by retained snapshots. This matches Java's
-    // throwFailureWhenFinished behavior.
-    if (retained_manifests_complete) {
-      // Phase 2: Prune manifests still referenced by retained snapshots.
-      std::unordered_set<std::string> manifests_to_delete;
-      for (const auto& path : expired_manifest_paths) {
-        if (!retained_manifest_paths.contains(path)) {
-          manifests_to_delete.insert(path);
+    ICEBERG_ASSIGN_OR_RAISE(
+        auto deletion_candidates,
+        ReadManifests(metadata_before_expiration, expired_snapshot_ids));
+
+    if (!deletion_candidates.empty()) {
+      std::unordered_set<ManifestFile> current_manifests;
+      ICEBERG_ASSIGN_OR_RAISE(
+          auto manifests_to_delete,
+          PruneReferencedManifests(metadata_after_expiration, retained_snapshot_ids,
+                                   std::move(deletion_candidates), current_manifests));
+
+      if (!manifests_to_delete.empty()) {
+        if (level == CleanupLevel::kAll) {
+          // Deleting data files
+          auto data_files_to_delete = FindDataFilesToDelete(
+              metadata_after_expiration, manifests_to_delete, current_manifests);
+          DeleteFiles(data_files_to_delete);
         }
-      }
 
-      // Phase 3: Delete data files if cleanup level is kAll.
-      if (level == CleanupLevel::kAll && !manifests_to_delete.empty()) {
-        auto data_files_result =
-            FindDataFilesToDelete(metadata, manifests_to_delete, retained_manifest_paths);
-        if (data_files_result.has_value()) {
-          for (const auto& path : data_files_result.value()) {
-            DeleteFile(path);
-          }
-        }
-      }
-
-      // Phase 4: Delete orphaned manifest files.
-      for (const auto& path : manifests_to_delete) {
-        DeleteFile(path);
+        // Deleting manifest files
+        DeleteFiles(ManifestPaths(manifests_to_delete));
       }
     }
 
-    // Phase 5: Delete manifest lists from expired snapshots.
-    for (int64_t snapshot_id : expired_snapshot_ids) {
-      auto snapshot_result = metadata.SnapshotById(snapshot_id);
-      if (!snapshot_result.has_value()) continue;
-      const auto& snapshot = snapshot_result.value();
-      if (!snapshot->manifest_list.empty()) {
-        DeleteFile(snapshot->manifest_list);
-      }
-    }
+    // Deleting manifest-list files
+    DeleteFiles(manifest_lists_to_delete);
 
-    // TODO(shangxinli): Delete expired statistics and partition-statistics files here.
-    // This requires RemoveStatistics/RemovePartitionStatistics to be wired into
-    // RemoveSnapshots first (see TODO in table_metadata.cc), so that physical file
-    // deletion and metadata entry removal stay in sync.
+    // Deleting statistics files
+    if (HasAnyStatisticsFiles(metadata_before_expiration) ||
+        HasAnyStatisticsFiles(metadata_after_expiration)) {
+      DeleteFiles(
+          StatisticsFilesToDelete(metadata_before_expiration, metadata_after_expiration));
+    }
 
     return {};
   }
 
  private:
-  /// Cache of manifest path -> ManifestFile, populated during Phase 1 to avoid
-  /// re-reading manifest lists in FindDataFilesToDelete.
-  std::unordered_map<std::string, ManifestFile> manifest_cache_;
-
-  /// \brief Collect manifest paths for a snapshot into manifest_paths.
-  ///
-  /// Returns true if manifests were collected successfully. Returns false if the
-  /// snapshot or its manifest list cannot be read — callers must treat a false
-  /// result for a retained snapshot as an incomplete retained set and skip
-  /// manifest deletion to avoid removing live files.
-  bool ReadManifestsForSnapshot(const TableMetadata& metadata, int64_t snapshot_id,
-                                std::unordered_set<std::string>& manifest_paths) {
-    auto snapshot_result = metadata.SnapshotById(snapshot_id);
-    if (!snapshot_result.has_value()) return false;
-    auto& snapshot = snapshot_result.value();
+  /// \brief Collect manifests for a snapshot into manifests.
+  Result<std::unordered_set<ManifestFile>> ReadManifestsForSnapshot(
+      const TableMetadata& metadata, int64_t snapshot_id) {
+    ICEBERG_ASSIGN_OR_RAISE(auto snapshot, metadata.SnapshotById(snapshot_id));
 
     SnapshotCache snapshot_cache(snapshot.get());
-    auto manifests_result = snapshot_cache.Manifests(file_io_);
-    if (!manifests_result.has_value()) return false;
+    ICEBERG_ASSIGN_OR_RAISE(auto snapshot_manifests, snapshot_cache.Manifests(file_io_));
 
-    for (const auto& manifest : manifests_result.value()) {
-      manifest_paths.insert(manifest.manifest_path);
-      manifest_cache_.emplace(manifest.manifest_path, manifest);
+    std::unordered_set<ManifestFile> manifests;
+    for (const auto& manifest : snapshot_manifests) {
+      manifests.insert(manifest);
     }
-    return true;
+    return manifests;
+  }
+
+  /// \brief Collect manifests for a set of snapshots.
+  Result<std::unordered_set<ManifestFile>> ReadManifests(
+      const TableMetadata& metadata, const std::unordered_set<int64_t>& snapshot_ids) {
+    std::unordered_set<ManifestFile> manifests;
+    for (int64_t snapshot_id : snapshot_ids) {
+      ICEBERG_ASSIGN_OR_RAISE(auto snapshot_manifests,
+                              ReadManifestsForSnapshot(metadata, snapshot_id));
+      manifests.insert(snapshot_manifests.begin(), snapshot_manifests.end());
+    }
+    return manifests;
+  }
+
+  /// \brief Remove manifests still referenced by retained snapshots.
+  Result<std::unordered_set<ManifestFile>> PruneReferencedManifests(
+      const TableMetadata& metadata,
+      const std::unordered_set<int64_t>& retained_snapshot_ids,
+      std::unordered_set<ManifestFile> manifests_to_delete,
+      std::unordered_set<ManifestFile>& current_manifests) {
+    for (int64_t snapshot_id : retained_snapshot_ids) {
+      ICEBERG_ASSIGN_OR_RAISE(auto snapshot_manifests,
+                              ReadManifestsForSnapshot(metadata, snapshot_id));
+
+      for (const auto& manifest : snapshot_manifests) {
+        manifests_to_delete.erase(manifest);
+
+        if (manifests_to_delete.empty()) {
+          return manifests_to_delete;
+        }
+
+        current_manifests.insert(manifest);
+      }
+    }
+
+    return manifests_to_delete;
+  }
+
+  Result<std::unordered_set<std::string>> ReadLiveDataFilePaths(
+      const TableMetadata& metadata, const ManifestFile& manifest) {
+    ICEBERG_PRECHECK(manifest.content == ManifestContent::kData,
+                     "Cannot read data file paths from a delete manifest: {}",
+                     manifest.manifest_path);
+
+    /// TODO(shangxinli): optimize by only reading file paths
+    ICEBERG_ASSIGN_OR_RAISE(auto reader,
+                            MakeManifestReader(manifest, file_io_, metadata));
+    ICEBERG_ASSIGN_OR_RAISE(auto entries, reader->LiveEntries());
+
+    std::unordered_set<std::string> data_file_paths;
+    for (const auto& entry : entries) {
+      if (entry.data_file) {
+        data_file_paths.insert(entry.data_file->file_path);
+      }
+    }
+
+    return data_file_paths;
+  }
+
+  /// \brief Project manifests to manifest paths for deletion.
+  std::unordered_set<std::string> ManifestPaths(
+      const std::unordered_set<ManifestFile>& manifests) const {
+    std::unordered_set<std::string> manifest_paths;
+    manifest_paths.reserve(manifests.size());
+    for (const auto& manifest : manifests) {
+      manifest_paths.insert(manifest.manifest_path);
+    }
+    return manifest_paths;
   }
 
   /// \brief Find data files to delete from manifests being removed.
-  ///
-  /// Reads live entries (ADDED/EXISTING) from manifests_to_delete, then subtracts
-  /// any files still referenced by retained_manifests. Uses LiveEntries() to match
-  /// Java's ManifestFiles.readPaths (delegates to liveEntries()).
-  ///
-  /// If any retained manifest cannot be read, returns an empty set to prevent
-  /// accidental data loss (matching Java's throwFailureWhenFinished for retained
-  /// manifest reads).
-  Result<std::unordered_set<std::string>> FindDataFilesToDelete(
+  std::unordered_set<std::string> FindDataFilesToDelete(
       const TableMetadata& metadata,
-      const std::unordered_set<std::string>& manifests_to_delete,
-      const std::unordered_set<std::string>& retained_manifests) {
+      const std::unordered_set<ManifestFile>& manifests_to_delete,
+      const std::unordered_set<ManifestFile>& current_manifests) {
     std::unordered_set<std::string> data_files_to_delete;
 
-    // Step 1: Collect live file paths from manifests being deleted.
-    for (const auto& [path, manifest] : manifest_cache_) {
-      if (!manifests_to_delete.contains(path)) continue;
-
-      auto reader_result = MakeManifestReader(manifest, file_io_, metadata);
-      if (!reader_result.has_value()) continue;
-
-      auto entries_result = reader_result.value()->LiveEntries();
-      if (!entries_result.has_value()) continue;
-
-      for (const auto& entry : entries_result.value()) {
-        if (entry.data_file) {
-          data_files_to_delete.insert(entry.data_file->file_path);
-        }
+    // Collect live file paths from manifests being deleted.
+    for (const auto& manifest : manifests_to_delete) {
+      auto live_data_files = ReadLiveDataFilePaths(metadata, manifest);
+      // Ignore expired-manifest read failures and keep scanning candidates.
+      if (!live_data_files.has_value()) {
+        continue;
       }
+
+      data_files_to_delete.insert(live_data_files->begin(), live_data_files->end());
     }
 
     if (data_files_to_delete.empty()) {
       return data_files_to_delete;
     }
 
-    // Step 2: Remove files still referenced by retained manifests.
-    // Abort entirely if a retained manifest cannot be read to prevent data loss.
-    for (const auto& manifest_path : retained_manifests) {
-      if (data_files_to_delete.empty()) break;
+    // Remove files still referenced by current manifests.
+    for (const auto& manifest : current_manifests) {
+      if (data_files_to_delete.empty()) {
+        return data_files_to_delete;
+      }
 
-      auto it = manifest_cache_.find(manifest_path);
-      if (it == manifest_cache_.end()) continue;
-
-      auto reader_result = MakeManifestReader(it->second, file_io_, metadata);
-      if (!reader_result.has_value()) {
+      auto live_data_files = ReadLiveDataFilePaths(metadata, manifest);
+      // Fail closed if any retained manifest cannot be read safely.
+      if (!live_data_files.has_value()) {
         return std::unordered_set<std::string>{};
       }
 
-      auto entries_result = reader_result.value()->LiveEntries();
-      if (!entries_result.has_value()) {
-        return std::unordered_set<std::string>{};
-      }
-
-      for (const auto& entry : entries_result.value()) {
-        if (entry.data_file) {
-          data_files_to_delete.erase(entry.data_file->file_path);
-        }
+      for (const auto& file_path : live_data_files.value()) {
+        data_files_to_delete.erase(file_path);
       }
     }
 
@@ -481,6 +537,7 @@ Result<ExpireSnapshots::ApplyResult> ExpireSnapshots::Apply() {
                        unreferenced_snapshot_ids.end());
 
   ApplyResult result;
+  result.metadata_before_expiration = std::make_shared<TableMetadata>(base);
 
   std::ranges::for_each(base.refs, [&retained_refs, &result](const auto& key_to_ref) {
     if (!retained_refs.contains(key_to_ref.first)) {
@@ -531,8 +588,8 @@ Result<ExpireSnapshots::ApplyResult> ExpireSnapshots::Apply() {
   return result;
 }
 
-Status ExpireSnapshots::Finalize(std::optional<Error> commit_error) {
-  if (commit_error.has_value()) {
+Status ExpireSnapshots::Finalize(Result<const TableMetadata*> commit_result) {
+  if (!commit_result.has_value()) {
     return {};
   }
 
@@ -544,22 +601,23 @@ Status ExpireSnapshots::Finalize(std::optional<Error> commit_error) {
     return {};
   }
 
+  ICEBERG_PRECHECK(apply_result_->metadata_before_expiration != nullptr,
+                   "Missing pre-expiration table metadata for cleanup");
+  ICEBERG_PRECHECK(commit_result.value() != nullptr,
+                   "Missing committed table metadata for cleanup");
+  auto metadata_before_expiration_ptr = apply_result_->metadata_before_expiration;
+  const TableMetadata& metadata_before_expiration = *metadata_before_expiration_ptr;
+  const TableMetadata& metadata_after_expiration = *commit_result.value();
   std::unordered_set<int64_t> expired_ids(apply_result_->snapshot_ids_to_remove.begin(),
                                           apply_result_->snapshot_ids_to_remove.end());
   apply_result_.reset();
 
   // File cleanup is best-effort: log and continue on individual file deletion failures
-  // to avoid blocking metadata updates (matching Java behavior).
   ReachableFileCleanup strategy(ctx_->table->io(), delete_func_);
-  return strategy.CleanFiles(base(), expired_ids, cleanup_level_);
+  return strategy.CleanFiles(metadata_before_expiration, metadata_after_expiration,
+                             expired_ids, cleanup_level_);
 }
 
-// TODO(shangxinli): Implement IncrementalFileCleanup strategy for linear ancestry
-// optimization. Java uses this when: !specifiedSnapshotId && simple linear main branch
-// ancestry (no non-main snapshots removed, no non-main snapshots remain).
-// The incremental strategy is more efficient because it only needs to scan
-// manifests written by expired snapshots (checking added_snapshot_id), avoiding
-// the full reachability analysis. It also handles cherry-pick protection via
-// SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP.
+// TODO(shangxinli): add IncrementalFileCleanup strategy for linear ancestry optimization.
 
 }  // namespace iceberg

--- a/src/iceberg/update/expire_snapshots.cc
+++ b/src/iceberg/update/expire_snapshots.cc
@@ -331,6 +331,17 @@ void ExpireSnapshots::DeleteFilePath(const std::string& path) {
   }
 }
 
+Result<std::shared_ptr<ManifestReader>> ExpireSnapshots::MakeManifestReader(
+    const ManifestFile& manifest, const std::shared_ptr<FileIO>& file_io) {
+  const TableMetadata& metadata = base();
+  auto schema_result = metadata.Schema();
+  if (!schema_result.has_value()) return std::unexpected<Error>(schema_result.error());
+  auto spec_result = metadata.PartitionSpecById(manifest.partition_spec_id);
+  if (!spec_result.has_value()) return std::unexpected<Error>(spec_result.error());
+  return ManifestReader::Make(manifest, file_io, schema_result.value(),
+                              spec_result.value());
+}
+
 Status ExpireSnapshots::ReadManifestsForSnapshot(
     int64_t snapshot_id, std::unordered_set<std::string>& manifest_paths) {
   const TableMetadata& metadata = base();
@@ -351,95 +362,73 @@ Status ExpireSnapshots::ReadManifestsForSnapshot(
 
   for (const auto& manifest : manifests_result.value()) {
     manifest_paths.insert(manifest.manifest_path);
+    // Cache manifest metadata for later use in FindDataFilesToDelete,
+    // avoiding O(M*S) repeated I/O from re-reading manifest lists.
+    manifest_cache_.emplace(manifest.manifest_path, manifest);
   }
 
   return {};
 }
 
-Status ExpireSnapshots::FindDataFilesToDelete(
+Result<std::unordered_set<std::string>> ExpireSnapshots::FindDataFilesToDelete(
     const std::unordered_set<std::string>& manifests_to_delete,
-    const std::unordered_set<std::string>& retained_manifests,
-    std::unordered_set<std::string>& data_files_to_delete) {
-  const TableMetadata& metadata = base();
+    const std::unordered_set<std::string>& retained_manifests) {
   auto file_io = ctx_->table->io();
+  std::unordered_set<std::string> data_files_to_delete;
 
-  // Step 1: Collect all file paths from manifests being deleted
-  for (const auto& manifest_path : manifests_to_delete) {
-    // Find the ManifestFile for this path by scanning expired snapshots
-    for (const auto& snapshot : metadata.snapshots) {
-      if (!snapshot) continue;
-      SnapshotCache snapshot_cache(snapshot.get());
-      auto manifests_result = snapshot_cache.Manifests(file_io);
-      if (!manifests_result.has_value()) continue;
+  // Step 1: Collect live file paths from manifests being deleted.
+  // Use LiveEntries() (ADDED/EXISTING only) to match Java's ManifestFiles.readPaths
+  // which delegates to liveEntries(). Using Entries() would include DELETED entries
+  // and could cause storage leaks.
+  for (const auto& [path, manifest] : manifest_cache_) {
+    if (!manifests_to_delete.contains(path)) continue;
 
-      for (const auto& manifest : manifests_result.value()) {
-        if (manifest.manifest_path != manifest_path) continue;
+    auto reader_result = MakeManifestReader(manifest, file_io);
+    if (!reader_result.has_value()) continue;
 
-        auto schema_result = metadata.Schema();
-        if (!schema_result.has_value()) continue;
-        auto spec_result = metadata.PartitionSpecById(manifest.partition_spec_id);
-        if (!spec_result.has_value()) continue;
+    auto entries_result = reader_result.value()->LiveEntries();
+    if (!entries_result.has_value()) continue;
 
-        auto reader_result = ManifestReader::Make(
-            manifest, file_io, schema_result.value(), spec_result.value());
-        if (!reader_result.has_value()) continue;
-
-        auto entries_result = reader_result.value()->Entries();
-        if (!entries_result.has_value()) continue;
-
-        for (const auto& entry : entries_result.value()) {
-          if (entry.data_file) {
-            data_files_to_delete.insert(entry.data_file->file_path);
-          }
-        }
-        goto next_manifest;  // Found and processed this manifest, move to next
+    for (const auto& entry : entries_result.value()) {
+      if (entry.data_file) {
+        data_files_to_delete.insert(entry.data_file->file_path);
       }
     }
-  next_manifest:;
   }
 
   if (data_files_to_delete.empty()) {
-    return {};
+    return data_files_to_delete;
   }
 
   // Step 2: Remove any files that are still referenced by retained manifests.
-  // This ensures we don't delete files that are shared across manifests.
+  // If reading a retained manifest fails, we must NOT delete its data files
+  // to avoid accidental data loss (matching Java's retry + throwFailureWhenFinished).
   for (const auto& manifest_path : retained_manifests) {
     if (data_files_to_delete.empty()) break;
 
-    for (const auto& snapshot : metadata.snapshots) {
-      if (!snapshot) continue;
-      SnapshotCache snapshot_cache(snapshot.get());
-      auto manifests_result = snapshot_cache.Manifests(file_io);
-      if (!manifests_result.has_value()) continue;
+    auto it = manifest_cache_.find(manifest_path);
+    if (it == manifest_cache_.end()) continue;
 
-      for (const auto& manifest : manifests_result.value()) {
-        if (manifest.manifest_path != manifest_path) continue;
+    auto reader_result = MakeManifestReader(it->second, file_io);
+    if (!reader_result.has_value()) {
+      // Cannot read a retained manifest — abort data file deletion to prevent
+      // accidental data loss. Java retries and throws on failure here.
+      return std::unordered_set<std::string>{};
+    }
 
-        auto schema_result = metadata.Schema();
-        if (!schema_result.has_value()) continue;
-        auto spec_result = metadata.PartitionSpecById(manifest.partition_spec_id);
-        if (!spec_result.has_value()) continue;
+    auto entries_result = reader_result.value()->LiveEntries();
+    if (!entries_result.has_value()) {
+      return std::unordered_set<std::string>{};
+    }
 
-        auto reader_result = ManifestReader::Make(
-            manifest, file_io, schema_result.value(), spec_result.value());
-        if (!reader_result.has_value()) continue;
-
-        auto entries_result = reader_result.value()->Entries();
-        if (!entries_result.has_value()) continue;
-
-        for (const auto& entry : entries_result.value()) {
-          if (entry.data_file) {
-            data_files_to_delete.erase(entry.data_file->file_path);
-          }
-        }
-        goto next_retained;
+    for (const auto& entry : entries_result.value()) {
+      if (entry.data_file) {
+        data_files_to_delete.erase(entry.data_file->file_path);
       }
     }
-  next_retained:;
   }
 
-  return {};
+  return data_files_to_delete;
 }
 
 Status ExpireSnapshots::CleanExpiredFiles(
@@ -483,13 +472,13 @@ Status ExpireSnapshots::CleanExpiredFiles(
   // Only read entries from manifests being deleted (not all expired manifests),
   // then subtract any files still reachable from retained manifests.
   if (cleanup_level_ == CleanupLevel::kAll && !manifests_to_delete.empty()) {
-    std::unordered_set<std::string> data_files_to_delete;
-    std::ignore = FindDataFilesToDelete(manifests_to_delete, retained_manifest_paths,
-                                        data_files_to_delete);
-
-    // TODO(shangxinli): Parallelize file deletion with a thread pool.
-    for (const auto& path : data_files_to_delete) {
-      DeleteFilePath(path);
+    auto data_files_result =
+        FindDataFilesToDelete(manifests_to_delete, retained_manifest_paths);
+    if (data_files_result.has_value()) {
+      // TODO(shangxinli): Parallelize file deletion with a thread pool.
+      for (const auto& path : data_files_result.value()) {
+        DeleteFilePath(path);
+      }
     }
   }
 
@@ -508,17 +497,31 @@ Status ExpireSnapshots::CleanExpiredFiles(
     }
   }
 
-  // Phase 6: Delete expired statistics files.
-  // Use set difference between before and after states (matching Java behavior).
-  // Since Finalize runs before table_ is updated, "after" is base() minus expired.
-  std::unordered_set<int64_t> retained_stats_snapshots(retained_snapshot_ids);
+  // Phase 6: Delete expired statistics files using path-based set difference.
+  // A statistics file should only be deleted if its path is not referenced by any
+  // retained snapshot, since the same file path could be shared across snapshots.
+  // Collect paths from retained snapshots, then delete any not in that set.
+  std::unordered_set<std::string> retained_stat_paths;
+  std::unordered_set<std::string> retained_part_stat_paths;
   for (const auto& stat_file : metadata.statistics) {
-    if (stat_file && !retained_stats_snapshots.contains(stat_file->snapshot_id)) {
+    if (stat_file && retained_snapshot_ids.contains(stat_file->snapshot_id)) {
+      retained_stat_paths.insert(stat_file->path);
+    }
+  }
+  for (const auto& part_stat : metadata.partition_statistics) {
+    if (part_stat && retained_snapshot_ids.contains(part_stat->snapshot_id)) {
+      retained_part_stat_paths.insert(part_stat->path);
+    }
+  }
+  for (const auto& stat_file : metadata.statistics) {
+    if (stat_file && expired_id_set.contains(stat_file->snapshot_id) &&
+        !retained_stat_paths.contains(stat_file->path)) {
       DeleteFilePath(stat_file->path);
     }
   }
   for (const auto& part_stat : metadata.partition_statistics) {
-    if (part_stat && !retained_stats_snapshots.contains(part_stat->snapshot_id)) {
+    if (part_stat && expired_id_set.contains(part_stat->snapshot_id) &&
+        !retained_part_stat_paths.contains(part_stat->path)) {
       DeleteFilePath(part_stat->path);
     }
   }

--- a/src/iceberg/update/expire_snapshots.cc
+++ b/src/iceberg/update/expire_snapshots.cc
@@ -33,7 +33,6 @@
 #include "iceberg/manifest/manifest_reader.h"
 #include "iceberg/schema.h"
 #include "iceberg/snapshot.h"
-#include "iceberg/statistics_file.h"
 #include "iceberg/table.h"
 #include "iceberg/table_metadata.h"
 #include "iceberg/transaction.h"
@@ -93,41 +92,6 @@ class FileCleanupStrategy {
     }
   }
 
-  /// \brief Returns paths of statistics files referenced only by expired snapshots.
-  ///
-  /// Uses path-based set difference (matching Java's expiredStatisticsFilesLocations):
-  /// if the same file path is shared across snapshots, it is only deleted when
-  /// no retained snapshot references it.
-  std::unordered_set<std::string> ExpiredStatisticsFilePaths(
-      const TableMetadata& metadata, const std::unordered_set<int64_t>& expired_ids) {
-    std::unordered_set<std::string> retained_paths;
-    for (const auto& stat : metadata.statistics) {
-      if (stat && !expired_ids.contains(stat->snapshot_id)) {
-        retained_paths.insert(stat->path);
-      }
-    }
-    for (const auto& part_stat : metadata.partition_statistics) {
-      if (part_stat && !expired_ids.contains(part_stat->snapshot_id)) {
-        retained_paths.insert(part_stat->path);
-      }
-    }
-
-    std::unordered_set<std::string> expired_paths;
-    for (const auto& stat : metadata.statistics) {
-      if (stat && expired_ids.contains(stat->snapshot_id) &&
-          !retained_paths.contains(stat->path)) {
-        expired_paths.insert(stat->path);
-      }
-    }
-    for (const auto& part_stat : metadata.partition_statistics) {
-      if (part_stat && expired_ids.contains(part_stat->snapshot_id) &&
-          !retained_paths.contains(part_stat->path)) {
-        expired_paths.insert(part_stat->path);
-      }
-    }
-    return expired_paths;
-  }
-
   std::shared_ptr<FileIO> file_io_;
   std::function<void(const std::string&)> delete_func_;
 };
@@ -136,7 +100,7 @@ class FileCleanupStrategy {
 ///
 /// Mirrors Java's ReachableFileCleanup: collects manifests from all expired and
 /// retained snapshots, prunes candidates still referenced by retained snapshots,
-/// then deletes orphaned manifests, data files, manifest lists, and statistics files.
+/// then deletes orphaned manifests, data files, and manifest lists.
 ///
 /// TODO(shangxinli): Add multi-threaded manifest reading and file deletion support.
 class ReachableFileCleanup : public FileCleanupStrategy {
@@ -160,33 +124,44 @@ class ReachableFileCleanup : public FileCleanupStrategy {
     for (int64_t snapshot_id : expired_snapshot_ids) {
       ReadManifestsForSnapshot(metadata, snapshot_id, expired_manifest_paths);
     }
+    bool retained_manifests_complete = true;
     std::unordered_set<std::string> retained_manifest_paths;
     for (int64_t snapshot_id : retained_snapshot_ids) {
-      ReadManifestsForSnapshot(metadata, snapshot_id, retained_manifest_paths);
-    }
-
-    // Phase 2: Prune manifests still referenced by retained snapshots.
-    std::unordered_set<std::string> manifests_to_delete;
-    for (const auto& path : expired_manifest_paths) {
-      if (!retained_manifest_paths.contains(path)) {
-        manifests_to_delete.insert(path);
+      if (!ReadManifestsForSnapshot(metadata, snapshot_id, retained_manifest_paths)) {
+        retained_manifests_complete = false;
+        break;
       }
     }
 
-    // Phase 3: Delete data files if cleanup level is kAll.
-    if (level == CleanupLevel::kAll && !manifests_to_delete.empty()) {
-      auto data_files_result =
-          FindDataFilesToDelete(metadata, manifests_to_delete, retained_manifest_paths);
-      if (data_files_result.has_value()) {
-        for (const auto& path : data_files_result.value()) {
-          DeleteFile(path);
+    // If any retained snapshot's manifests could not be read, skip manifest and
+    // data file deletion. An incomplete retained set means we cannot safely
+    // determine which manifests are still live, so deleting any candidates risks
+    // removing files still referenced by retained snapshots. This matches Java's
+    // throwFailureWhenFinished behavior.
+    if (retained_manifests_complete) {
+      // Phase 2: Prune manifests still referenced by retained snapshots.
+      std::unordered_set<std::string> manifests_to_delete;
+      for (const auto& path : expired_manifest_paths) {
+        if (!retained_manifest_paths.contains(path)) {
+          manifests_to_delete.insert(path);
         }
       }
-    }
 
-    // Phase 4: Delete orphaned manifest files.
-    for (const auto& path : manifests_to_delete) {
-      DeleteFile(path);
+      // Phase 3: Delete data files if cleanup level is kAll.
+      if (level == CleanupLevel::kAll && !manifests_to_delete.empty()) {
+        auto data_files_result =
+            FindDataFilesToDelete(metadata, manifests_to_delete, retained_manifest_paths);
+        if (data_files_result.has_value()) {
+          for (const auto& path : data_files_result.value()) {
+            DeleteFile(path);
+          }
+        }
+      }
+
+      // Phase 4: Delete orphaned manifest files.
+      for (const auto& path : manifests_to_delete) {
+        DeleteFile(path);
+      }
     }
 
     // Phase 5: Delete manifest lists from expired snapshots.
@@ -199,10 +174,10 @@ class ReachableFileCleanup : public FileCleanupStrategy {
       }
     }
 
-    // Phase 6: Delete expired statistics files using path-based set difference.
-    for (const auto& path : ExpiredStatisticsFilePaths(metadata, expired_snapshot_ids)) {
-      DeleteFile(path);
-    }
+    // TODO(shangxinli): Delete expired statistics and partition-statistics files here.
+    // This requires RemoveStatistics/RemovePartitionStatistics to be wired into
+    // RemoveSnapshots first (see TODO in table_metadata.cc), so that physical file
+    // deletion and metadata entry removal stay in sync.
 
     return {};
   }
@@ -214,24 +189,25 @@ class ReachableFileCleanup : public FileCleanupStrategy {
 
   /// \brief Collect manifest paths for a snapshot into manifest_paths.
   ///
-  /// Best-effort: if the snapshot or its manifest list cannot be read, the error
-  /// is silently suppressed. This is safe for expired snapshots (missed deletions
-  /// can be cleaned up by GC later) and conservative for retained snapshots (we
-  /// only delete files we can confirm are unreachable).
-  void ReadManifestsForSnapshot(const TableMetadata& metadata, int64_t snapshot_id,
+  /// Returns true if manifests were collected successfully. Returns false if the
+  /// snapshot or its manifest list cannot be read — callers must treat a false
+  /// result for a retained snapshot as an incomplete retained set and skip
+  /// manifest deletion to avoid removing live files.
+  bool ReadManifestsForSnapshot(const TableMetadata& metadata, int64_t snapshot_id,
                                 std::unordered_set<std::string>& manifest_paths) {
     auto snapshot_result = metadata.SnapshotById(snapshot_id);
-    if (!snapshot_result.has_value()) return;
+    if (!snapshot_result.has_value()) return false;
     auto& snapshot = snapshot_result.value();
 
     SnapshotCache snapshot_cache(snapshot.get());
     auto manifests_result = snapshot_cache.Manifests(file_io_);
-    if (!manifests_result.has_value()) return;
+    if (!manifests_result.has_value()) return false;
 
     for (const auto& manifest : manifests_result.value()) {
       manifest_paths.insert(manifest.manifest_path);
       manifest_cache_.emplace(manifest.manifest_path, manifest);
     }
+    return true;
   }
 
   /// \brief Find data files to delete from manifests being removed.

--- a/src/iceberg/update/expire_snapshots.cc
+++ b/src/iceberg/update/expire_snapshots.cc
@@ -43,6 +43,264 @@
 
 namespace iceberg {
 
+namespace {
+
+Result<std::shared_ptr<ManifestReader>> MakeManifestReader(
+    const ManifestFile& manifest, const std::shared_ptr<FileIO>& file_io,
+    const TableMetadata& metadata) {
+  ICEBERG_ASSIGN_OR_RAISE(auto schema, metadata.Schema());
+  ICEBERG_ASSIGN_OR_RAISE(auto spec, metadata.PartitionSpecById(manifest.partition_spec_id));
+  return ManifestReader::Make(manifest, file_io, std::move(schema), std::move(spec));
+}
+
+/// \brief Abstract strategy for cleaning up files after snapshot expiration.
+///
+/// Mirrors Java's FileCleanupStrategy: provides shared delete utilities while
+/// allowing different cleanup algorithms (ReachableFileCleanup, IncrementalFileCleanup).
+class FileCleanupStrategy {
+ public:
+  FileCleanupStrategy(std::shared_ptr<FileIO> file_io,
+                      std::function<void(const std::string&)> delete_func)
+      : file_io_(std::move(file_io)), delete_func_(std::move(delete_func)) {}
+
+  virtual ~FileCleanupStrategy() = default;
+
+  /// \brief Clean up files that are only reachable by expired snapshots.
+  ///
+  /// \param metadata Table metadata before expiration (contains all snapshots).
+  /// \param expired_snapshot_ids Snapshot IDs that were expired during this operation.
+  /// \param level Controls which types of files are eligible for deletion.
+  virtual Status CleanFiles(const TableMetadata& metadata,
+                            const std::unordered_set<int64_t>& expired_snapshot_ids,
+                            CleanupLevel level) = 0;
+
+ protected:
+  /// \brief Delete a file, suppressing errors (best-effort).
+  ///
+  /// Uses the custom delete function if set, otherwise FileIO::DeleteFile.
+  /// Matches Java's suppressFailureWhenFinished behavior.
+  void DeleteFile(const std::string& path) {
+    try {
+      if (delete_func_) {
+        delete_func_(path);
+      } else {
+        std::ignore = file_io_->DeleteFile(path);
+      }
+    } catch (...) {
+      // Suppress all exceptions during file cleanup to match Java's
+      // suppressFailureWhenFinished behavior.
+    }
+  }
+
+  /// \brief Returns paths of statistics files referenced only by expired snapshots.
+  ///
+  /// Uses path-based set difference (matching Java's expiredStatisticsFilesLocations):
+  /// if the same file path is shared across snapshots, it is only deleted when
+  /// no retained snapshot references it.
+  std::unordered_set<std::string> ExpiredStatisticsFilePaths(
+      const TableMetadata& metadata,
+      const std::unordered_set<int64_t>& expired_ids) {
+    std::unordered_set<std::string> retained_paths;
+    for (const auto& stat : metadata.statistics) {
+      if (stat && !expired_ids.contains(stat->snapshot_id)) {
+        retained_paths.insert(stat->path);
+      }
+    }
+    for (const auto& part_stat : metadata.partition_statistics) {
+      if (part_stat && !expired_ids.contains(part_stat->snapshot_id)) {
+        retained_paths.insert(part_stat->path);
+      }
+    }
+
+    std::unordered_set<std::string> expired_paths;
+    for (const auto& stat : metadata.statistics) {
+      if (stat && expired_ids.contains(stat->snapshot_id) &&
+          !retained_paths.contains(stat->path)) {
+        expired_paths.insert(stat->path);
+      }
+    }
+    for (const auto& part_stat : metadata.partition_statistics) {
+      if (part_stat && expired_ids.contains(part_stat->snapshot_id) &&
+          !retained_paths.contains(part_stat->path)) {
+        expired_paths.insert(part_stat->path);
+      }
+    }
+    return expired_paths;
+  }
+
+  std::shared_ptr<FileIO> file_io_;
+  std::function<void(const std::string&)> delete_func_;
+};
+
+/// \brief File cleanup strategy that determines safe deletions via full reachability.
+///
+/// Mirrors Java's ReachableFileCleanup: collects manifests from all expired and
+/// retained snapshots, prunes candidates still referenced by retained snapshots,
+/// then deletes orphaned manifests, data files, manifest lists, and statistics files.
+///
+/// TODO(shangxinli): Add multi-threaded manifest reading and file deletion support.
+class ReachableFileCleanup : public FileCleanupStrategy {
+ public:
+  using FileCleanupStrategy::FileCleanupStrategy;
+
+  Status CleanFiles(const TableMetadata& metadata,
+                    const std::unordered_set<int64_t>& expired_snapshot_ids,
+                    CleanupLevel level) override {
+    std::unordered_set<int64_t> retained_snapshot_ids;
+    for (const auto& snapshot : metadata.snapshots) {
+      if (snapshot && !expired_snapshot_ids.contains(snapshot->snapshot_id)) {
+        retained_snapshot_ids.insert(snapshot->snapshot_id);
+      }
+    }
+
+    // Phase 1: Collect manifest paths from expired and retained snapshots.
+    // The manifest_cache_ is populated here to avoid O(M*S) repeated I/O in
+    // FindDataFilesToDelete.
+    std::unordered_set<std::string> expired_manifest_paths;
+    for (int64_t snapshot_id : expired_snapshot_ids) {
+      ReadManifestsForSnapshot(metadata, snapshot_id, expired_manifest_paths);
+    }
+    std::unordered_set<std::string> retained_manifest_paths;
+    for (int64_t snapshot_id : retained_snapshot_ids) {
+      ReadManifestsForSnapshot(metadata, snapshot_id, retained_manifest_paths);
+    }
+
+    // Phase 2: Prune manifests still referenced by retained snapshots.
+    std::unordered_set<std::string> manifests_to_delete;
+    for (const auto& path : expired_manifest_paths) {
+      if (!retained_manifest_paths.contains(path)) {
+        manifests_to_delete.insert(path);
+      }
+    }
+
+    // Phase 3: Delete data files if cleanup level is kAll.
+    if (level == CleanupLevel::kAll && !manifests_to_delete.empty()) {
+      auto data_files_result =
+          FindDataFilesToDelete(metadata, manifests_to_delete, retained_manifest_paths);
+      if (data_files_result.has_value()) {
+        for (const auto& path : data_files_result.value()) {
+          DeleteFile(path);
+        }
+      }
+    }
+
+    // Phase 4: Delete orphaned manifest files.
+    for (const auto& path : manifests_to_delete) {
+      DeleteFile(path);
+    }
+
+    // Phase 5: Delete manifest lists from expired snapshots.
+    for (int64_t snapshot_id : expired_snapshot_ids) {
+      auto snapshot_result = metadata.SnapshotById(snapshot_id);
+      if (!snapshot_result.has_value()) continue;
+      const auto& snapshot = snapshot_result.value();
+      if (!snapshot->manifest_list.empty()) {
+        DeleteFile(snapshot->manifest_list);
+      }
+    }
+
+    // Phase 6: Delete expired statistics files using path-based set difference.
+    for (const auto& path : ExpiredStatisticsFilePaths(metadata, expired_snapshot_ids)) {
+      DeleteFile(path);
+    }
+
+    return {};
+  }
+
+ private:
+  /// Cache of manifest path -> ManifestFile, populated during Phase 1 to avoid
+  /// re-reading manifest lists in FindDataFilesToDelete.
+  std::unordered_map<std::string, ManifestFile> manifest_cache_;
+
+  /// \brief Collect manifest paths for a snapshot into manifest_paths.
+  ///
+  /// Best-effort: if the snapshot or its manifest list cannot be read, the error
+  /// is silently suppressed. This is safe for expired snapshots (missed deletions
+  /// can be cleaned up by GC later) and conservative for retained snapshots (we
+  /// only delete files we can confirm are unreachable).
+  void ReadManifestsForSnapshot(const TableMetadata& metadata, int64_t snapshot_id,
+                                std::unordered_set<std::string>& manifest_paths) {
+    auto snapshot_result = metadata.SnapshotById(snapshot_id);
+    if (!snapshot_result.has_value()) return;
+    auto& snapshot = snapshot_result.value();
+
+    SnapshotCache snapshot_cache(snapshot.get());
+    auto manifests_result = snapshot_cache.Manifests(file_io_);
+    if (!manifests_result.has_value()) return;
+
+    for (const auto& manifest : manifests_result.value()) {
+      manifest_paths.insert(manifest.manifest_path);
+      manifest_cache_.emplace(manifest.manifest_path, manifest);
+    }
+  }
+
+  /// \brief Find data files to delete from manifests being removed.
+  ///
+  /// Reads live entries (ADDED/EXISTING) from manifests_to_delete, then subtracts
+  /// any files still referenced by retained_manifests. Uses LiveEntries() to match
+  /// Java's ManifestFiles.readPaths (delegates to liveEntries()).
+  ///
+  /// If any retained manifest cannot be read, returns an empty set to prevent
+  /// accidental data loss (matching Java's throwFailureWhenFinished for retained
+  /// manifest reads).
+  Result<std::unordered_set<std::string>> FindDataFilesToDelete(
+      const TableMetadata& metadata,
+      const std::unordered_set<std::string>& manifests_to_delete,
+      const std::unordered_set<std::string>& retained_manifests) {
+    std::unordered_set<std::string> data_files_to_delete;
+
+    // Step 1: Collect live file paths from manifests being deleted.
+    for (const auto& [path, manifest] : manifest_cache_) {
+      if (!manifests_to_delete.contains(path)) continue;
+
+      auto reader_result = MakeManifestReader(manifest, file_io_, metadata);
+      if (!reader_result.has_value()) continue;
+
+      auto entries_result = reader_result.value()->LiveEntries();
+      if (!entries_result.has_value()) continue;
+
+      for (const auto& entry : entries_result.value()) {
+        if (entry.data_file) {
+          data_files_to_delete.insert(entry.data_file->file_path);
+        }
+      }
+    }
+
+    if (data_files_to_delete.empty()) {
+      return data_files_to_delete;
+    }
+
+    // Step 2: Remove files still referenced by retained manifests.
+    // Abort entirely if a retained manifest cannot be read to prevent data loss.
+    for (const auto& manifest_path : retained_manifests) {
+      if (data_files_to_delete.empty()) break;
+
+      auto it = manifest_cache_.find(manifest_path);
+      if (it == manifest_cache_.end()) continue;
+
+      auto reader_result = MakeManifestReader(it->second, file_io_, metadata);
+      if (!reader_result.has_value()) {
+        return std::unordered_set<std::string>{};
+      }
+
+      auto entries_result = reader_result.value()->LiveEntries();
+      if (!entries_result.has_value()) {
+        return std::unordered_set<std::string>{};
+      }
+
+      for (const auto& entry : entries_result.value()) {
+        if (entry.data_file) {
+          data_files_to_delete.erase(entry.data_file->file_path);
+        }
+      }
+    }
+
+    return data_files_to_delete;
+  }
+};
+
+}  // namespace
+
 Result<std::shared_ptr<ExpireSnapshots>> ExpireSnapshots::Make(
     std::shared_ptr<TransactionContext> ctx) {
   ICEBERG_PRECHECK(ctx != nullptr, "Cannot create ExpireSnapshots without a context");
@@ -310,223 +568,15 @@ Status ExpireSnapshots::Finalize(std::optional<Error> commit_error) {
     return {};
   }
 
+  std::unordered_set<int64_t> expired_ids(
+      apply_result_->snapshot_ids_to_remove.begin(),
+      apply_result_->snapshot_ids_to_remove.end());
+  apply_result_.reset();
+
   // File cleanup is best-effort: log and continue on individual file deletion failures
   // to avoid blocking metadata updates (matching Java behavior).
-  return CleanExpiredFiles(apply_result_->snapshot_ids_to_remove);
-}
-
-void ExpireSnapshots::DeleteFilePath(const std::string& path) {
-  try {
-    if (delete_func_) {
-      delete_func_(path);
-    } else {
-      auto status = ctx_->table->io()->DeleteFile(path);
-      // Best-effort: ignore NotFound (file already deleted) and other errors.
-      // Java uses suppressFailureWhenFinished + onFailure logging.
-      std::ignore = status;
-    }
-  } catch (...) {
-    // Suppress all exceptions during file cleanup to match Java's
-    // suppressFailureWhenFinished behavior.
-  }
-}
-
-Result<std::shared_ptr<ManifestReader>> ExpireSnapshots::MakeManifestReader(
-    const ManifestFile& manifest, const std::shared_ptr<FileIO>& file_io) {
-  const TableMetadata& metadata = base();
-  auto schema_result = metadata.Schema();
-  if (!schema_result.has_value()) return std::unexpected<Error>(schema_result.error());
-  auto spec_result = metadata.PartitionSpecById(manifest.partition_spec_id);
-  if (!spec_result.has_value()) return std::unexpected<Error>(spec_result.error());
-  return ManifestReader::Make(manifest, file_io, schema_result.value(),
-                              spec_result.value());
-}
-
-Status ExpireSnapshots::ReadManifestsForSnapshot(
-    int64_t snapshot_id, std::unordered_set<std::string>& manifest_paths) {
-  const TableMetadata& metadata = base();
-  auto file_io = ctx_->table->io();
-
-  auto snapshot_result = metadata.SnapshotById(snapshot_id);
-  if (!snapshot_result.has_value()) {
-    return {};
-  }
-  auto& snapshot = snapshot_result.value();
-
-  SnapshotCache snapshot_cache(snapshot.get());
-  auto manifests_result = snapshot_cache.Manifests(file_io);
-  if (!manifests_result.has_value()) {
-    // Best-effort: skip this snapshot if we can't read its manifests
-    return {};
-  }
-
-  for (const auto& manifest : manifests_result.value()) {
-    manifest_paths.insert(manifest.manifest_path);
-    // Cache manifest metadata for later use in FindDataFilesToDelete,
-    // avoiding O(M*S) repeated I/O from re-reading manifest lists.
-    manifest_cache_.emplace(manifest.manifest_path, manifest);
-  }
-
-  return {};
-}
-
-Result<std::unordered_set<std::string>> ExpireSnapshots::FindDataFilesToDelete(
-    const std::unordered_set<std::string>& manifests_to_delete,
-    const std::unordered_set<std::string>& retained_manifests) {
-  auto file_io = ctx_->table->io();
-  std::unordered_set<std::string> data_files_to_delete;
-
-  // Step 1: Collect live file paths from manifests being deleted.
-  // Use LiveEntries() (ADDED/EXISTING only) to match Java's ManifestFiles.readPaths
-  // which delegates to liveEntries(). Using Entries() would include DELETED entries
-  // and could cause storage leaks.
-  for (const auto& [path, manifest] : manifest_cache_) {
-    if (!manifests_to_delete.contains(path)) continue;
-
-    auto reader_result = MakeManifestReader(manifest, file_io);
-    if (!reader_result.has_value()) continue;
-
-    auto entries_result = reader_result.value()->LiveEntries();
-    if (!entries_result.has_value()) continue;
-
-    for (const auto& entry : entries_result.value()) {
-      if (entry.data_file) {
-        data_files_to_delete.insert(entry.data_file->file_path);
-      }
-    }
-  }
-
-  if (data_files_to_delete.empty()) {
-    return data_files_to_delete;
-  }
-
-  // Step 2: Remove any files that are still referenced by retained manifests.
-  // If reading a retained manifest fails, we must NOT delete its data files
-  // to avoid accidental data loss (matching Java's retry + throwFailureWhenFinished).
-  for (const auto& manifest_path : retained_manifests) {
-    if (data_files_to_delete.empty()) break;
-
-    auto it = manifest_cache_.find(manifest_path);
-    if (it == manifest_cache_.end()) continue;
-
-    auto reader_result = MakeManifestReader(it->second, file_io);
-    if (!reader_result.has_value()) {
-      // Cannot read a retained manifest — abort data file deletion to prevent
-      // accidental data loss. Java retries and throws on failure here.
-      return std::unordered_set<std::string>{};
-    }
-
-    auto entries_result = reader_result.value()->LiveEntries();
-    if (!entries_result.has_value()) {
-      return std::unordered_set<std::string>{};
-    }
-
-    for (const auto& entry : entries_result.value()) {
-      if (entry.data_file) {
-        data_files_to_delete.erase(entry.data_file->file_path);
-      }
-    }
-  }
-
-  return data_files_to_delete;
-}
-
-Status ExpireSnapshots::CleanExpiredFiles(
-    const std::vector<int64_t>& expired_snapshot_ids) {
-  const TableMetadata& metadata = base();
-
-  // Build expired and retained snapshot ID sets.
-  // The retained set includes ALL snapshots referenced by any branch or tag,
-  // since Apply() already computed retention across all refs.
-  std::unordered_set<int64_t> expired_id_set(expired_snapshot_ids.begin(),
-                                             expired_snapshot_ids.end());
-  std::unordered_set<int64_t> retained_snapshot_ids;
-  for (const auto& snapshot : metadata.snapshots) {
-    if (snapshot && !expired_id_set.contains(snapshot->snapshot_id)) {
-      retained_snapshot_ids.insert(snapshot->snapshot_id);
-    }
-  }
-
-  // Phase 1: Collect manifest paths from expired and retained snapshots.
-  // TODO(shangxinli): Parallelize manifest collection with a thread pool.
-  std::unordered_set<std::string> expired_manifest_paths;
-  for (int64_t snapshot_id : expired_snapshot_ids) {
-    std::ignore = ReadManifestsForSnapshot(snapshot_id, expired_manifest_paths);
-  }
-
-  std::unordered_set<std::string> retained_manifest_paths;
-  for (int64_t snapshot_id : retained_snapshot_ids) {
-    std::ignore = ReadManifestsForSnapshot(snapshot_id, retained_manifest_paths);
-  }
-
-  // Phase 2: Prune manifests still referenced by retained snapshots.
-  // Only manifests exclusively in expired snapshots should be deleted.
-  std::unordered_set<std::string> manifests_to_delete;
-  for (const auto& path : expired_manifest_paths) {
-    if (!retained_manifest_paths.contains(path)) {
-      manifests_to_delete.insert(path);
-    }
-  }
-
-  // Phase 3: If cleanup level is kAll, find data files to delete.
-  // Only read entries from manifests being deleted (not all expired manifests),
-  // then subtract any files still reachable from retained manifests.
-  if (cleanup_level_ == CleanupLevel::kAll && !manifests_to_delete.empty()) {
-    auto data_files_result =
-        FindDataFilesToDelete(manifests_to_delete, retained_manifest_paths);
-    if (data_files_result.has_value()) {
-      // TODO(shangxinli): Parallelize file deletion with a thread pool.
-      for (const auto& path : data_files_result.value()) {
-        DeleteFilePath(path);
-      }
-    }
-  }
-
-  // Phase 4: Delete orphaned manifest files.
-  for (const auto& path : manifests_to_delete) {
-    DeleteFilePath(path);
-  }
-
-  // Phase 5: Delete manifest lists from expired snapshots.
-  for (int64_t snapshot_id : expired_snapshot_ids) {
-    auto snapshot_result = metadata.SnapshotById(snapshot_id);
-    if (!snapshot_result.has_value()) continue;
-    auto& snapshot = snapshot_result.value();
-    if (!snapshot->manifest_list.empty()) {
-      DeleteFilePath(snapshot->manifest_list);
-    }
-  }
-
-  // Phase 6: Delete expired statistics files using path-based set difference.
-  // A statistics file should only be deleted if its path is not referenced by any
-  // retained snapshot, since the same file path could be shared across snapshots.
-  // Collect paths from retained snapshots, then delete any not in that set.
-  std::unordered_set<std::string> retained_stat_paths;
-  std::unordered_set<std::string> retained_part_stat_paths;
-  for (const auto& stat_file : metadata.statistics) {
-    if (stat_file && retained_snapshot_ids.contains(stat_file->snapshot_id)) {
-      retained_stat_paths.insert(stat_file->path);
-    }
-  }
-  for (const auto& part_stat : metadata.partition_statistics) {
-    if (part_stat && retained_snapshot_ids.contains(part_stat->snapshot_id)) {
-      retained_part_stat_paths.insert(part_stat->path);
-    }
-  }
-  for (const auto& stat_file : metadata.statistics) {
-    if (stat_file && expired_id_set.contains(stat_file->snapshot_id) &&
-        !retained_stat_paths.contains(stat_file->path)) {
-      DeleteFilePath(stat_file->path);
-    }
-  }
-  for (const auto& part_stat : metadata.partition_statistics) {
-    if (part_stat && expired_id_set.contains(part_stat->snapshot_id) &&
-        !retained_part_stat_paths.contains(part_stat->path)) {
-      DeleteFilePath(part_stat->path);
-    }
-  }
-
-  return {};
+  ReachableFileCleanup strategy(ctx_->table->io(), delete_func_);
+  return strategy.CleanFiles(base(), expired_ids, cleanup_level_);
 }
 
 // TODO(shangxinli): Implement IncrementalFileCleanup strategy for linear ancestry

--- a/src/iceberg/update/expire_snapshots.cc
+++ b/src/iceberg/update/expire_snapshots.cc
@@ -23,11 +23,17 @@
 #include <cstdint>
 #include <iterator>
 #include <memory>
+#include <optional>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
+#include "iceberg/file_io.h"
+#include "iceberg/manifest/manifest_entry.h"
+#include "iceberg/manifest/manifest_reader.h"
 #include "iceberg/schema.h"
 #include "iceberg/snapshot.h"
+#include "iceberg/statistics_file.h"
 #include "iceberg/table.h"
 #include "iceberg/table_metadata.h"
 #include "iceberg/transaction.h"
@@ -285,7 +291,247 @@ Result<ExpireSnapshots::ApplyResult> ExpireSnapshots::Apply() {
                           });
   }
 
+  // Cache the result for use during Finalize()
+  apply_result_ = result;
+
   return result;
 }
+
+Status ExpireSnapshots::Finalize(std::optional<Error> commit_error) {
+  if (commit_error.has_value()) {
+    return {};
+  }
+
+  if (cleanup_level_ == CleanupLevel::kNone) {
+    return {};
+  }
+
+  if (!apply_result_.has_value() || apply_result_->snapshot_ids_to_remove.empty()) {
+    return {};
+  }
+
+  // File cleanup is best-effort: log and continue on individual file deletion failures
+  // to avoid blocking metadata updates (matching Java behavior).
+  return CleanExpiredFiles(apply_result_->snapshot_ids_to_remove);
+}
+
+void ExpireSnapshots::DeleteFilePath(const std::string& path) {
+  try {
+    if (delete_func_) {
+      delete_func_(path);
+    } else {
+      auto status = ctx_->table->io()->DeleteFile(path);
+      // Best-effort: ignore NotFound (file already deleted) and other errors.
+      // Java uses suppressFailureWhenFinished + onFailure logging.
+      std::ignore = status;
+    }
+  } catch (...) {
+    // Suppress all exceptions during file cleanup to match Java's
+    // suppressFailureWhenFinished behavior.
+  }
+}
+
+Status ExpireSnapshots::ReadManifestsForSnapshot(
+    int64_t snapshot_id, std::unordered_set<std::string>& manifest_paths) {
+  const TableMetadata& metadata = base();
+  auto file_io = ctx_->table->io();
+
+  auto snapshot_result = metadata.SnapshotById(snapshot_id);
+  if (!snapshot_result.has_value()) {
+    return {};
+  }
+  auto& snapshot = snapshot_result.value();
+
+  SnapshotCache snapshot_cache(snapshot.get());
+  auto manifests_result = snapshot_cache.Manifests(file_io);
+  if (!manifests_result.has_value()) {
+    // Best-effort: skip this snapshot if we can't read its manifests
+    return {};
+  }
+
+  for (const auto& manifest : manifests_result.value()) {
+    manifest_paths.insert(manifest.manifest_path);
+  }
+
+  return {};
+}
+
+Status ExpireSnapshots::FindDataFilesToDelete(
+    const std::unordered_set<std::string>& manifests_to_delete,
+    const std::unordered_set<std::string>& retained_manifests,
+    std::unordered_set<std::string>& data_files_to_delete) {
+  const TableMetadata& metadata = base();
+  auto file_io = ctx_->table->io();
+
+  // Step 1: Collect all file paths from manifests being deleted
+  for (const auto& manifest_path : manifests_to_delete) {
+    // Find the ManifestFile for this path by scanning expired snapshots
+    for (const auto& snapshot : metadata.snapshots) {
+      if (!snapshot) continue;
+      SnapshotCache snapshot_cache(snapshot.get());
+      auto manifests_result = snapshot_cache.Manifests(file_io);
+      if (!manifests_result.has_value()) continue;
+
+      for (const auto& manifest : manifests_result.value()) {
+        if (manifest.manifest_path != manifest_path) continue;
+
+        auto schema_result = metadata.Schema();
+        if (!schema_result.has_value()) continue;
+        auto spec_result = metadata.PartitionSpecById(manifest.partition_spec_id);
+        if (!spec_result.has_value()) continue;
+
+        auto reader_result = ManifestReader::Make(
+            manifest, file_io, schema_result.value(), spec_result.value());
+        if (!reader_result.has_value()) continue;
+
+        auto entries_result = reader_result.value()->Entries();
+        if (!entries_result.has_value()) continue;
+
+        for (const auto& entry : entries_result.value()) {
+          if (entry.data_file) {
+            data_files_to_delete.insert(entry.data_file->file_path);
+          }
+        }
+        goto next_manifest;  // Found and processed this manifest, move to next
+      }
+    }
+  next_manifest:;
+  }
+
+  if (data_files_to_delete.empty()) {
+    return {};
+  }
+
+  // Step 2: Remove any files that are still referenced by retained manifests.
+  // This ensures we don't delete files that are shared across manifests.
+  for (const auto& manifest_path : retained_manifests) {
+    if (data_files_to_delete.empty()) break;
+
+    for (const auto& snapshot : metadata.snapshots) {
+      if (!snapshot) continue;
+      SnapshotCache snapshot_cache(snapshot.get());
+      auto manifests_result = snapshot_cache.Manifests(file_io);
+      if (!manifests_result.has_value()) continue;
+
+      for (const auto& manifest : manifests_result.value()) {
+        if (manifest.manifest_path != manifest_path) continue;
+
+        auto schema_result = metadata.Schema();
+        if (!schema_result.has_value()) continue;
+        auto spec_result = metadata.PartitionSpecById(manifest.partition_spec_id);
+        if (!spec_result.has_value()) continue;
+
+        auto reader_result = ManifestReader::Make(
+            manifest, file_io, schema_result.value(), spec_result.value());
+        if (!reader_result.has_value()) continue;
+
+        auto entries_result = reader_result.value()->Entries();
+        if (!entries_result.has_value()) continue;
+
+        for (const auto& entry : entries_result.value()) {
+          if (entry.data_file) {
+            data_files_to_delete.erase(entry.data_file->file_path);
+          }
+        }
+        goto next_retained;
+      }
+    }
+  next_retained:;
+  }
+
+  return {};
+}
+
+Status ExpireSnapshots::CleanExpiredFiles(
+    const std::vector<int64_t>& expired_snapshot_ids) {
+  const TableMetadata& metadata = base();
+
+  // Build expired and retained snapshot ID sets.
+  // The retained set includes ALL snapshots referenced by any branch or tag,
+  // since Apply() already computed retention across all refs.
+  std::unordered_set<int64_t> expired_id_set(expired_snapshot_ids.begin(),
+                                             expired_snapshot_ids.end());
+  std::unordered_set<int64_t> retained_snapshot_ids;
+  for (const auto& snapshot : metadata.snapshots) {
+    if (snapshot && !expired_id_set.contains(snapshot->snapshot_id)) {
+      retained_snapshot_ids.insert(snapshot->snapshot_id);
+    }
+  }
+
+  // Phase 1: Collect manifest paths from expired and retained snapshots.
+  // TODO(shangxinli): Parallelize manifest collection with a thread pool.
+  std::unordered_set<std::string> expired_manifest_paths;
+  for (int64_t snapshot_id : expired_snapshot_ids) {
+    std::ignore = ReadManifestsForSnapshot(snapshot_id, expired_manifest_paths);
+  }
+
+  std::unordered_set<std::string> retained_manifest_paths;
+  for (int64_t snapshot_id : retained_snapshot_ids) {
+    std::ignore = ReadManifestsForSnapshot(snapshot_id, retained_manifest_paths);
+  }
+
+  // Phase 2: Prune manifests still referenced by retained snapshots.
+  // Only manifests exclusively in expired snapshots should be deleted.
+  std::unordered_set<std::string> manifests_to_delete;
+  for (const auto& path : expired_manifest_paths) {
+    if (!retained_manifest_paths.contains(path)) {
+      manifests_to_delete.insert(path);
+    }
+  }
+
+  // Phase 3: If cleanup level is kAll, find data files to delete.
+  // Only read entries from manifests being deleted (not all expired manifests),
+  // then subtract any files still reachable from retained manifests.
+  if (cleanup_level_ == CleanupLevel::kAll && !manifests_to_delete.empty()) {
+    std::unordered_set<std::string> data_files_to_delete;
+    std::ignore = FindDataFilesToDelete(manifests_to_delete, retained_manifest_paths,
+                                        data_files_to_delete);
+
+    // TODO(shangxinli): Parallelize file deletion with a thread pool.
+    for (const auto& path : data_files_to_delete) {
+      DeleteFilePath(path);
+    }
+  }
+
+  // Phase 4: Delete orphaned manifest files.
+  for (const auto& path : manifests_to_delete) {
+    DeleteFilePath(path);
+  }
+
+  // Phase 5: Delete manifest lists from expired snapshots.
+  for (int64_t snapshot_id : expired_snapshot_ids) {
+    auto snapshot_result = metadata.SnapshotById(snapshot_id);
+    if (!snapshot_result.has_value()) continue;
+    auto& snapshot = snapshot_result.value();
+    if (!snapshot->manifest_list.empty()) {
+      DeleteFilePath(snapshot->manifest_list);
+    }
+  }
+
+  // Phase 6: Delete expired statistics files.
+  // Use set difference between before and after states (matching Java behavior).
+  // Since Finalize runs before table_ is updated, "after" is base() minus expired.
+  std::unordered_set<int64_t> retained_stats_snapshots(retained_snapshot_ids);
+  for (const auto& stat_file : metadata.statistics) {
+    if (stat_file && !retained_stats_snapshots.contains(stat_file->snapshot_id)) {
+      DeleteFilePath(stat_file->path);
+    }
+  }
+  for (const auto& part_stat : metadata.partition_statistics) {
+    if (part_stat && !retained_stats_snapshots.contains(part_stat->snapshot_id)) {
+      DeleteFilePath(part_stat->path);
+    }
+  }
+
+  return {};
+}
+
+// TODO(shangxinli): Implement IncrementalFileCleanup strategy for linear ancestry
+// optimization. Java uses this when: !specifiedSnapshotId && simple linear main branch
+// ancestry (no non-main snapshots removed, no non-main snapshots remain).
+// The incremental strategy is more efficient because it only needs to scan
+// manifests written by expired snapshots (checking added_snapshot_id), avoiding
+// the full reachability analysis. It also handles cherry-pick protection via
+// SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP.
 
 }  // namespace iceberg

--- a/src/iceberg/update/expire_snapshots.h
+++ b/src/iceberg/update/expire_snapshots.h
@@ -75,6 +75,7 @@ class ICEBERG_EXPORT ExpireSnapshots : public PendingUpdate {
     std::vector<int64_t> snapshot_ids_to_remove;
     std::vector<int32_t> partition_spec_ids_to_remove;
     std::unordered_set<int32_t> schema_ids_to_remove;
+    std::shared_ptr<const TableMetadata> metadata_before_expiration;
   };
 
   /// \brief Expires a specific Snapshot identified by id.
@@ -150,9 +151,10 @@ class ICEBERG_EXPORT ExpireSnapshots : public PendingUpdate {
   /// data files, and statistics files that are no longer referenced by any valid
   /// snapshot. The cleanup behavior is controlled by the CleanupLevel setting.
   ///
-  /// \param commit_error An optional error indicating whether the commit was successful
+  /// \param commit_result The committed table metadata when the commit succeeds, or the
+  /// commit error when it fails.
   /// \return Status indicating success or failure
-  Status Finalize(std::optional<Error> commit_error) override;
+  Status Finalize(Result<const TableMetadata*> commit_result) override;
 
  private:
   explicit ExpireSnapshots(std::shared_ptr<TransactionContext> ctx);

--- a/src/iceberg/update/expire_snapshots.h
+++ b/src/iceberg/update/expire_snapshots.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -142,6 +143,16 @@ class ICEBERG_EXPORT ExpireSnapshots : public PendingUpdate {
   /// \return The results of changes
   Result<ApplyResult> Apply();
 
+  /// \brief Finalize the expire snapshots update, cleaning up expired files.
+  ///
+  /// After a successful commit, this method deletes manifest files, manifest lists,
+  /// data files, and statistics files that are no longer referenced by any valid
+  /// snapshot. The cleanup behavior is controlled by the CleanupLevel setting.
+  ///
+  /// \param commit_error An optional error indicating whether the commit was successful
+  /// \return Status indicating success or failure
+  Status Finalize(std::optional<Error> commit_error) override;
+
  private:
   explicit ExpireSnapshots(std::shared_ptr<TransactionContext> ctx);
 
@@ -159,6 +170,41 @@ class ICEBERG_EXPORT ExpireSnapshots : public PendingUpdate {
   Result<std::unordered_set<int64_t>> UnreferencedSnapshotIdsToRetain(
       const SnapshotToRef& refs) const;
 
+  /// \brief Clean up files no longer referenced after snapshot expiration.
+  ///
+  /// Implements the "reachable file cleanup" strategy from Java's ReachableFileCleanup:
+  /// 1. Collect manifests from expired and retained snapshots
+  /// 2. Prune manifests still referenced by retained snapshots
+  /// 3. Find data files only in manifests being deleted (if kAll)
+  /// 4. Remove data files still reachable from retained manifests
+  /// 5. Delete orphaned manifests, manifest lists, and statistics files
+  ///
+  /// All deletions are best-effort: failures are suppressed to avoid blocking
+  /// metadata updates (matching Java's suppressFailureWhenFinished behavior).
+  ///
+  /// Branch/tag awareness: retained_snapshot_ids includes all snapshots referenced
+  /// by any branch or tag, as computed by Apply(). This prevents deleting files
+  /// that are still reachable from any ref.
+  ///
+  /// TODO(shangxinli): Add multi-threaded file deletion support.
+  /// TODO(shangxinli): Add IncrementalFileCleanup strategy for linear ancestry.
+  Status CleanExpiredFiles(const std::vector<int64_t>& expired_snapshot_ids);
+
+  /// \brief Read manifest paths from a single snapshot.
+  /// Best-effort: returns OK even if the snapshot or its manifests can't be read.
+  Status ReadManifestsForSnapshot(int64_t snapshot_id,
+                                  std::unordered_set<std::string>& manifest_paths);
+
+  /// \brief Find data files to delete by reading entries from manifests being deleted,
+  /// then subtracting files still reachable from retained manifests.
+  Status FindDataFilesToDelete(const std::unordered_set<std::string>& manifests_to_delete,
+                               const std::unordered_set<std::string>& retained_manifests,
+                               std::unordered_set<std::string>& data_files_to_delete);
+
+  /// \brief Delete a file, suppressing errors (best-effort).
+  /// Uses the custom delete function if set, otherwise FileIO::DeleteFile.
+  void DeleteFilePath(const std::string& path);
+
  private:
   const TimePointMs current_time_ms_;
   const int64_t default_max_ref_age_ms_;
@@ -169,6 +215,9 @@ class ICEBERG_EXPORT ExpireSnapshots : public PendingUpdate {
   enum CleanupLevel cleanup_level_ { CleanupLevel::kAll };
   bool clean_expired_metadata_{false};
   bool specified_snapshot_id_{false};
+
+  /// Cached result from Apply(), used during Finalize() for file cleanup
+  std::optional<ApplyResult> apply_result_;
 };
 
 }  // namespace iceberg

--- a/src/iceberg/update/expire_snapshots.h
+++ b/src/iceberg/update/expire_snapshots.h
@@ -28,8 +28,6 @@
 #include <vector>
 
 #include "iceberg/iceberg_export.h"
-#include "iceberg/manifest/manifest_list.h"
-#include "iceberg/manifest/manifest_reader.h"
 #include "iceberg/result.h"
 #include "iceberg/type_fwd.h"
 #include "iceberg/update/pending_update.h"
@@ -173,48 +171,6 @@ class ICEBERG_EXPORT ExpireSnapshots : public PendingUpdate {
   Result<std::unordered_set<int64_t>> UnreferencedSnapshotIdsToRetain(
       const SnapshotToRef& refs) const;
 
-  /// \brief Clean up files no longer referenced after snapshot expiration.
-  ///
-  /// Implements the "reachable file cleanup" strategy from Java's ReachableFileCleanup:
-  /// 1. Collect manifests from expired and retained snapshots
-  /// 2. Prune manifests still referenced by retained snapshots
-  /// 3. Find data files only in manifests being deleted (if kAll)
-  /// 4. Remove data files still reachable from retained manifests
-  /// 5. Delete orphaned manifests, manifest lists, and statistics files
-  ///
-  /// All deletions are best-effort: failures are suppressed to avoid blocking
-  /// metadata updates (matching Java's suppressFailureWhenFinished behavior).
-  ///
-  /// Branch/tag awareness: retained_snapshot_ids includes all snapshots referenced
-  /// by any branch or tag, as computed by Apply(). This prevents deleting files
-  /// that are still reachable from any ref.
-  ///
-  /// TODO(shangxinli): Add multi-threaded file deletion support.
-  /// TODO(shangxinli): Add IncrementalFileCleanup strategy for linear ancestry.
-  Status CleanExpiredFiles(const std::vector<int64_t>& expired_snapshot_ids);
-
-  /// \brief Read manifest paths from a single snapshot.
-  /// Best-effort: returns OK even if the snapshot or its manifests can't be read.
-  Status ReadManifestsForSnapshot(int64_t snapshot_id,
-                                  std::unordered_set<std::string>& manifest_paths);
-
-  /// \brief Find data files to delete by reading live entries from manifests being
-  /// deleted, then subtracting files still reachable from retained manifests.
-  /// If a retained manifest cannot be read, returns an empty set to prevent
-  /// accidental data loss.
-  Result<std::unordered_set<std::string>> FindDataFilesToDelete(
-      const std::unordered_set<std::string>& manifests_to_delete,
-      const std::unordered_set<std::string>& retained_manifests);
-
-  /// \brief Create a ManifestReader for the given ManifestFile.
-  Result<std::shared_ptr<ManifestReader>> MakeManifestReader(
-      const ManifestFile& manifest, const std::shared_ptr<FileIO>& file_io);
-
-  /// \brief Delete a file, suppressing errors (best-effort).
-  /// Uses the custom delete function if set, otherwise FileIO::DeleteFile.
-  void DeleteFilePath(const std::string& path);
-
- private:
   const TimePointMs current_time_ms_;
   const int64_t default_max_ref_age_ms_;
   int32_t default_min_num_snapshots_;
@@ -225,13 +181,8 @@ class ICEBERG_EXPORT ExpireSnapshots : public PendingUpdate {
   bool clean_expired_metadata_{false};
   bool specified_snapshot_id_{false};
 
-  /// Cached result from Apply(), used during Finalize() for file cleanup
+  /// Cached result from Apply(), consumed by Finalize() and cleared after use.
   std::optional<ApplyResult> apply_result_;
-
-  /// Cache of manifest path -> ManifestFile, built during ReadManifestsForSnapshot
-  /// to avoid O(M*S) repeated I/O from re-reading manifest lists in
-  /// FindDataFilesToDelete.
-  std::unordered_map<std::string, ManifestFile> manifest_cache_;
 };
 
 }  // namespace iceberg

--- a/src/iceberg/update/expire_snapshots.h
+++ b/src/iceberg/update/expire_snapshots.h
@@ -23,10 +23,13 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "iceberg/iceberg_export.h"
+#include "iceberg/manifest/manifest_list.h"
+#include "iceberg/manifest/manifest_reader.h"
 #include "iceberg/result.h"
 #include "iceberg/type_fwd.h"
 #include "iceberg/update/pending_update.h"
@@ -195,11 +198,17 @@ class ICEBERG_EXPORT ExpireSnapshots : public PendingUpdate {
   Status ReadManifestsForSnapshot(int64_t snapshot_id,
                                   std::unordered_set<std::string>& manifest_paths);
 
-  /// \brief Find data files to delete by reading entries from manifests being deleted,
-  /// then subtracting files still reachable from retained manifests.
-  Status FindDataFilesToDelete(const std::unordered_set<std::string>& manifests_to_delete,
-                               const std::unordered_set<std::string>& retained_manifests,
-                               std::unordered_set<std::string>& data_files_to_delete);
+  /// \brief Find data files to delete by reading live entries from manifests being
+  /// deleted, then subtracting files still reachable from retained manifests.
+  /// If a retained manifest cannot be read, returns an empty set to prevent
+  /// accidental data loss.
+  Result<std::unordered_set<std::string>> FindDataFilesToDelete(
+      const std::unordered_set<std::string>& manifests_to_delete,
+      const std::unordered_set<std::string>& retained_manifests);
+
+  /// \brief Create a ManifestReader for the given ManifestFile.
+  Result<std::shared_ptr<ManifestReader>> MakeManifestReader(
+      const ManifestFile& manifest, const std::shared_ptr<FileIO>& file_io);
 
   /// \brief Delete a file, suppressing errors (best-effort).
   /// Uses the custom delete function if set, otherwise FileIO::DeleteFile.
@@ -218,6 +227,11 @@ class ICEBERG_EXPORT ExpireSnapshots : public PendingUpdate {
 
   /// Cached result from Apply(), used during Finalize() for file cleanup
   std::optional<ApplyResult> apply_result_;
+
+  /// Cache of manifest path -> ManifestFile, built during ReadManifestsForSnapshot
+  /// to avoid O(M*S) repeated I/O from re-reading manifest lists in
+  /// FindDataFilesToDelete.
+  std::unordered_map<std::string, ManifestFile> manifest_cache_;
 };
 
 }  // namespace iceberg

--- a/src/iceberg/update/pending_update.cc
+++ b/src/iceberg/update/pending_update.cc
@@ -19,6 +19,8 @@
 
 #include "iceberg/update/pending_update.h"
 
+#include "iceberg/result.h"
+#include "iceberg/table.h"
 #include "iceberg/transaction.h"
 #include "iceberg/util/macros.h"
 
@@ -33,16 +35,20 @@ Status PendingUpdate::Commit() {
   if (!ctx_->transaction) {
     // Table-created path: no transaction exists yet, create a temporary one.
     ICEBERG_ASSIGN_OR_RAISE(auto txn, Transaction::Make(ctx_));
-    Status status = txn->Apply(*this);
-    if (status.has_value()) {
-      auto commit_result = txn->Commit();
-      if (!commit_result.has_value()) {
-        status = std::unexpected(commit_result.error());
-      }
+    auto apply_status = txn->Apply(*this);
+    if (!apply_status.has_value()) {
+      std::ignore = Finalize(std::unexpected(apply_status.error()));
+      return apply_status;
     }
-    std::ignore =
-        Finalize(status.has_value() ? std::nullopt : std::make_optional(status.error()));
-    return status;
+
+    auto commit_result = txn->Commit();
+    if (!commit_result.has_value()) {
+      std::ignore = Finalize(std::unexpected(commit_result.error()));
+      return std::unexpected(commit_result.error());
+    }
+
+    std::ignore = Finalize(commit_result.value()->metadata().get());
+    return {};
   }
   auto txn = ctx_->transaction->lock();
   if (!txn) {
@@ -51,7 +57,8 @@ Status PendingUpdate::Commit() {
   return txn->Apply(*this);
 }
 
-Status PendingUpdate::Finalize([[maybe_unused]] std::optional<Error> commit_error) {
+Status PendingUpdate::Finalize(
+    [[maybe_unused]] Result<const TableMetadata*> commit_result) {
   return {};
 }
 

--- a/src/iceberg/update/pending_update.h
+++ b/src/iceberg/update/pending_update.h
@@ -23,7 +23,6 @@
 /// API for table changes using builder pattern
 
 #include <memory>
-#include <optional>
 
 #include "iceberg/iceberg_export.h"
 #include "iceberg/result.h"
@@ -71,9 +70,10 @@ class ICEBERG_EXPORT PendingUpdate : public ErrorCollector {
   /// This method is called after the update is committed.
   /// Implementations should override this method to clean up any resources.
   ///
-  /// \param commit_error An optional error indicating whether the commit was successful
+  /// \param commit_result The committed table metadata when the commit succeeds, or the
+  /// commit error when it fails.
   /// \return Status indicating success or failure
-  virtual Status Finalize(std::optional<Error> commit_error);
+  virtual Status Finalize(Result<const TableMetadata*> commit_result);
 
   // Non-copyable, movable
   PendingUpdate(const PendingUpdate&) = delete;

--- a/src/iceberg/update/snapshot_update.cc
+++ b/src/iceberg/update/snapshot_update.cc
@@ -297,9 +297,9 @@ Result<SnapshotUpdate::ApplyResult> SnapshotUpdate::Apply() {
                      .stage_only = stage_only_};
 }
 
-Status SnapshotUpdate::Finalize(std::optional<Error> commit_error) {
-  if (commit_error.has_value()) {
-    if (commit_error->kind == ErrorKind::kCommitStateUnknown) {
+Status SnapshotUpdate::Finalize(Result<const TableMetadata*> commit_result) {
+  if (!commit_result.has_value()) {
+    if (commit_result.error().kind == ErrorKind::kCommitStateUnknown) {
       return {};
     }
     CleanAll();

--- a/src/iceberg/update/snapshot_update.h
+++ b/src/iceberg/update/snapshot_update.h
@@ -118,7 +118,7 @@ class ICEBERG_EXPORT SnapshotUpdate : public PendingUpdate {
   Result<ApplyResult> Apply();
 
   /// \brief Finalize the snapshot update, cleaning up any uncommitted files.
-  Status Finalize(std::optional<Error> commit_error) override;
+  Status Finalize(Result<const TableMetadata*> commit_result) override;
 
  protected:
   explicit SnapshotUpdate(std::shared_ptr<TransactionContext> ctx);


### PR DESCRIPTION
## Summary

- Implement the file cleanup logic missing from expire snapshots (#490 noted "TODO: File recycling will be added in a followup PR")
- Port the "reachable file cleanup" strategy from Java's `ReachableFileCleanup`
- Single-threaded implementation; multi-threaded and incremental cleanup as TODOs


