### PR TITLE
fix: use base_location instead of location in CreateTable

### DIFF
--- a/src/iceberg/catalog/memory/in_memory_catalog.cc
+++ b/src/iceberg/catalog/memory/in_memory_catalog.cc
@@ -418,8 +418,9 @@ Result<std::shared_ptr<Table>> InMemoryCatalog::CreateTable(
   std::string base_location =
       location.empty() ? warehouse_location_ + "/" + identifier.ToString() : location;
 
-  ICEBERG_ASSIGN_OR_RAISE(auto table_metadata, TableMetadata::Make(*schema, *spec, *order,
-                                                                   location, properties));
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto table_metadata,
+      TableMetadata::Make(*schema, *spec, *order, base_location, properties));
 
   ICEBERG_ASSIGN_OR_RAISE(
       auto metadata_file_location,


### PR DESCRIPTION
Pass the resolved base_location to TableMetadata::Make instead of the raw location parameter, ensuring the computed default warehouse path is used when no explicit location is provided.