### PR TITLE
fix:  add using StructType::Equals to fix `-Woverloaded-virtual` warning

### DIFF
--- a/src/iceberg/schema.h
+++ b/src/iceberg/schema.h
@@ -187,6 +187,7 @@ class ICEBERG_EXPORT Schema : public StructType {
   friend bool operator==(const Schema& lhs, const Schema& rhs) { return lhs.Equals(rhs); }
 
  private:
+  using StructType::Equals;
   /// \brief Compare two schemas for equality.
   bool Equals(const Schema& other) const;
 


### PR DESCRIPTION
Schema::Equals(const Schema&) hides StructType::Equals(const Type&), triggering Clang's `-Woverloaded-virtual` warning. Add `using StructType::Equals` to bring the base class overload into scope alongside the Schema-specific one.