### PR TITLE
feat/perf: optimize AddRange in RoaringPositionBitmap

### DIFF
--- a/src/iceberg/deletes/roaring_position_bitmap.cc
+++ b/src/iceberg/deletes/roaring_position_bitmap.cc
@@ -128,7 +128,12 @@ void RoaringPositionBitmap::Add(int64_t pos) {
 }
 
 void RoaringPositionBitmap::AddRange(int64_t pos_start, int64_t pos_end) {
-  if (pos_start >= pos_end || pos_start < 0 || pos_end - 1 > kMaxPosition) {
+  if (pos_start >= pos_end) {
+    return;
+  }
+  pos_start = std::max(pos_start, int64_t{0});
+  pos_end = std::min(pos_end, kMaxPosition + 1);
+  if (pos_start >= pos_end) {
     return;
   }
 

--- a/src/iceberg/deletes/roaring_position_bitmap.cc
+++ b/src/iceberg/deletes/roaring_position_bitmap.cc
@@ -141,20 +141,12 @@ void RoaringPositionBitmap::AddRange(int64_t pos_start, int64_t pos_end) {
   int32_t end_key = Key(pos_end - 1);
   impl_->AllocateBitmapsIfNeeded(end_key + 1);
 
-  if (start_key == end_key) {
-    uint64_t low_start = Pos32Bits(pos_start);
-    uint64_t low_end = static_cast<uint64_t>(Pos32Bits(pos_end - 1)) + 1;
-    impl_->bitmaps[start_key].addRange(low_start, low_end);
-  } else {
-    uint64_t first_low_start = Pos32Bits(pos_start);
-    impl_->bitmaps[start_key].addRange(first_low_start, uint64_t{1} << 32);
-
-    for (int32_t key = start_key + 1; key < end_key; ++key) {
-      impl_->bitmaps[key].addRange(uint64_t{0}, uint64_t{1} << 32);
-    }
-
-    uint64_t last_low_end = static_cast<uint64_t>(Pos32Bits(pos_end - 1)) + 1;
-    impl_->bitmaps[end_key].addRange(uint64_t{0}, last_low_end);
+  for (int32_t key = start_key; key <= end_key; ++key) {
+    uint64_t low_start = (key == start_key) ? Pos32Bits(pos_start) : uint64_t{0};
+    uint64_t low_end = (key == end_key)
+                            ? static_cast<uint64_t>(Pos32Bits(pos_end - 1)) + 1
+                            : (uint64_t{1} << 32);
+    impl_->bitmaps[key].addRange(low_start, low_end);
   }
 }
 

--- a/src/iceberg/deletes/roaring_position_bitmap.cc
+++ b/src/iceberg/deletes/roaring_position_bitmap.cc
@@ -22,7 +22,6 @@
 #include <cstring>
 #include <exception>
 #include <limits>
-#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -129,11 +128,6 @@ void RoaringPositionBitmap::Add(int64_t pos) {
 }
 
 void RoaringPositionBitmap::AddRange(int64_t pos_start, int64_t pos_end) {
-  if (pos_start > pos_end) {
-    throw std::invalid_argument("AddRange requires pos_start <= pos_end, got [" +
-                                std::to_string(pos_start) + ", " +
-                                std::to_string(pos_end) + ")");
-  }
   pos_start = std::max(pos_start, int64_t{0});
   pos_end = std::min(pos_end, kMaxPosition + 1);
   if (pos_start >= pos_end) {

--- a/src/iceberg/deletes/roaring_position_bitmap.cc
+++ b/src/iceberg/deletes/roaring_position_bitmap.cc
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <exception>
 #include <limits>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -128,7 +129,12 @@ void RoaringPositionBitmap::Add(int64_t pos) {
 }
 
 void RoaringPositionBitmap::AddRange(int64_t pos_start, int64_t pos_end) {
-  if (pos_start >= pos_end) {
+  if (pos_start > pos_end) {
+    throw std::invalid_argument(
+        "AddRange requires pos_start <= pos_end, got [" + std::to_string(pos_start) +
+        ", " + std::to_string(pos_end) + ")");
+  }
+  if (pos_start == pos_end) {
     return;
   }
   pos_start = std::max(pos_start, int64_t{0});

--- a/src/iceberg/deletes/roaring_position_bitmap.cc
+++ b/src/iceberg/deletes/roaring_position_bitmap.cc
@@ -134,15 +134,15 @@ void RoaringPositionBitmap::AddRange(int64_t pos_start, int64_t pos_end) {
     return;
   }
 
+  int64_t pos_last = pos_end - 1;
   int32_t start_key = Key(pos_start);
-  int32_t end_key = Key(pos_end - 1);
+  int32_t end_key = Key(pos_last);
   impl_->AllocateBitmapsIfNeeded(end_key + 1);
 
   for (int32_t key = start_key; key <= end_key; ++key) {
     uint64_t low_start = (key == start_key) ? Pos32Bits(pos_start) : uint64_t{0};
-    uint64_t low_end = (key == end_key)
-                           ? static_cast<uint64_t>(Pos32Bits(pos_end - 1)) + 1
-                           : (uint64_t{1} << 32);
+    uint64_t low_end = (key == end_key) ? static_cast<uint64_t>(Pos32Bits(pos_last)) + 1
+                                        : (uint64_t{1} << 32);
     impl_->bitmaps[key].addRange(low_start, low_end);
   }
 }

--- a/src/iceberg/deletes/roaring_position_bitmap.cc
+++ b/src/iceberg/deletes/roaring_position_bitmap.cc
@@ -134,9 +134,6 @@ void RoaringPositionBitmap::AddRange(int64_t pos_start, int64_t pos_end) {
                                 std::to_string(pos_start) + ", " +
                                 std::to_string(pos_end) + ")");
   }
-  if (pos_start == pos_end) {
-    return;
-  }
   pos_start = std::max(pos_start, int64_t{0});
   pos_end = std::min(pos_end, kMaxPosition + 1);
   if (pos_start >= pos_end) {

--- a/src/iceberg/deletes/roaring_position_bitmap.cc
+++ b/src/iceberg/deletes/roaring_position_bitmap.cc
@@ -128,10 +128,7 @@ void RoaringPositionBitmap::Add(int64_t pos) {
 }
 
 void RoaringPositionBitmap::AddRange(int64_t pos_start, int64_t pos_end) {
-  if (pos_start >= pos_end) {
-    return;
-  }
-  if (pos_start < 0 || pos_end - 1 > kMaxPosition) {
+  if (pos_start >= pos_end || pos_start < 0 || pos_end - 1 > kMaxPosition) {
     return;
   }
 

--- a/src/iceberg/deletes/roaring_position_bitmap.cc
+++ b/src/iceberg/deletes/roaring_position_bitmap.cc
@@ -128,8 +128,31 @@ void RoaringPositionBitmap::Add(int64_t pos) {
 }
 
 void RoaringPositionBitmap::AddRange(int64_t pos_start, int64_t pos_end) {
-  for (int64_t pos = pos_start; pos < pos_end; ++pos) {
-    Add(pos);
+  if (pos_start >= pos_end) {
+    return;
+  }
+  if (pos_start < 0 || pos_end - 1 > kMaxPosition) {
+    return;
+  }
+
+  int32_t start_key = Key(pos_start);
+  int32_t end_key = Key(pos_end - 1);
+  impl_->AllocateBitmapsIfNeeded(end_key + 1);
+
+  if (start_key == end_key) {
+    uint64_t low_start = Pos32Bits(pos_start);
+    uint64_t low_end = static_cast<uint64_t>(Pos32Bits(pos_end - 1)) + 1;
+    impl_->bitmaps[start_key].addRange(low_start, low_end);
+  } else {
+    uint64_t first_low_start = Pos32Bits(pos_start);
+    impl_->bitmaps[start_key].addRange(first_low_start, uint64_t{1} << 32);
+
+    for (int32_t key = start_key + 1; key < end_key; ++key) {
+      impl_->bitmaps[key].addRange(uint64_t{0}, uint64_t{1} << 32);
+    }
+
+    uint64_t last_low_end = static_cast<uint64_t>(Pos32Bits(pos_end - 1)) + 1;
+    impl_->bitmaps[end_key].addRange(uint64_t{0}, last_low_end);
   }
 }
 

--- a/src/iceberg/deletes/roaring_position_bitmap.cc
+++ b/src/iceberg/deletes/roaring_position_bitmap.cc
@@ -130,9 +130,9 @@ void RoaringPositionBitmap::Add(int64_t pos) {
 
 void RoaringPositionBitmap::AddRange(int64_t pos_start, int64_t pos_end) {
   if (pos_start > pos_end) {
-    throw std::invalid_argument(
-        "AddRange requires pos_start <= pos_end, got [" + std::to_string(pos_start) +
-        ", " + std::to_string(pos_end) + ")");
+    throw std::invalid_argument("AddRange requires pos_start <= pos_end, got [" +
+                                std::to_string(pos_start) + ", " +
+                                std::to_string(pos_end) + ")");
   }
   if (pos_start == pos_end) {
     return;
@@ -150,8 +150,8 @@ void RoaringPositionBitmap::AddRange(int64_t pos_start, int64_t pos_end) {
   for (int32_t key = start_key; key <= end_key; ++key) {
     uint64_t low_start = (key == start_key) ? Pos32Bits(pos_start) : uint64_t{0};
     uint64_t low_end = (key == end_key)
-                            ? static_cast<uint64_t>(Pos32Bits(pos_end - 1)) + 1
-                            : (uint64_t{1} << 32);
+                           ? static_cast<uint64_t>(Pos32Bits(pos_end - 1)) + 1
+                           : (uint64_t{1} << 32);
     impl_->bitmaps[key].addRange(low_start, low_end);
   }
 }

--- a/src/iceberg/deletes/roaring_position_bitmap.h
+++ b/src/iceberg/deletes/roaring_position_bitmap.h
@@ -67,7 +67,8 @@ class ICEBERG_EXPORT RoaringPositionBitmap {
   /// \brief Sets a range of positions [pos_start, pos_end).
   /// \param pos_start the start of the range (inclusive), clamped to 0
   /// \param pos_end the end of the range (exclusive), clamped to kMaxPosition + 1
-  /// \note If pos_start >= pos_end after clamping, this method does nothing.
+  /// \throws std::invalid_argument if pos_start > pos_end
+  /// \note If pos_start == pos_end, this method does nothing.
   ///       Positions outside [0, kMaxPosition] are silently ignored.
   void AddRange(int64_t pos_start, int64_t pos_end);
 

--- a/src/iceberg/deletes/roaring_position_bitmap.h
+++ b/src/iceberg/deletes/roaring_position_bitmap.h
@@ -65,6 +65,7 @@ class ICEBERG_EXPORT RoaringPositionBitmap {
   void Add(int64_t pos);
 
   /// \brief Sets a range of positions [pos_start, pos_end).
+  /// If pos_start >= pos_end, this method does nothing.
   /// \note Invalid positions are silently ignored
   void AddRange(int64_t pos_start, int64_t pos_end);
 

--- a/src/iceberg/deletes/roaring_position_bitmap.h
+++ b/src/iceberg/deletes/roaring_position_bitmap.h
@@ -67,8 +67,8 @@ class ICEBERG_EXPORT RoaringPositionBitmap {
   /// \brief Sets a range of positions [pos_start, pos_end).
   /// \param pos_start the start of the range (inclusive), clamped to 0
   /// \param pos_end the end of the range (exclusive), clamped to kMaxPosition + 1
-  /// \throws std::invalid_argument if pos_start > pos_end
-  /// \note If pos_start == pos_end, this method does nothing.
+  /// \note If pos_start > pos_end, the call is silently ignored.
+  ///       If pos_start == pos_end, this method does nothing.
   ///       Positions outside [0, kMaxPosition] are silently ignored.
   void AddRange(int64_t pos_start, int64_t pos_end);
 

--- a/src/iceberg/deletes/roaring_position_bitmap.h
+++ b/src/iceberg/deletes/roaring_position_bitmap.h
@@ -65,8 +65,10 @@ class ICEBERG_EXPORT RoaringPositionBitmap {
   void Add(int64_t pos);
 
   /// \brief Sets a range of positions [pos_start, pos_end).
-  /// If pos_start >= pos_end, this method does nothing.
-  /// \note Invalid positions are silently ignored
+  /// \param pos_start the start of the range (inclusive), clamped to 0
+  /// \param pos_end the end of the range (exclusive), clamped to kMaxPosition + 1
+  /// \note If pos_start >= pos_end after clamping, this method does nothing.
+  ///       Positions outside [0, kMaxPosition] are silently ignored.
   void AddRange(int64_t pos_start, int64_t pos_end);
 
   /// \brief Checks if a position is set in the bitmap.

--- a/src/iceberg/test/roaring_position_bitmap_test.cc
+++ b/src/iceberg/test/roaring_position_bitmap_test.cc
@@ -25,7 +25,6 @@
 #include <fstream>
 #include <random>
 #include <set>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -211,9 +210,10 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.name;
     });
 
-TEST(RoaringPositionBitmapTest, TestAddRangeReversedThrows) {
+TEST(RoaringPositionBitmapTest, TestAddRangeReversedIsNoOp) {
   RoaringPositionBitmap bitmap;
-  ASSERT_THROW(bitmap.AddRange(100, 50), std::invalid_argument);
+  bitmap.AddRange(100, 50);
+  ASSERT_TRUE(bitmap.IsEmpty());
 }
 
 struct OrParams {

--- a/src/iceberg/test/roaring_position_bitmap_test.cc
+++ b/src/iceberg/test/roaring_position_bitmap_test.cc
@@ -177,12 +177,11 @@ TEST(RoaringPositionBitmapTest, TestAddRangeClampNegativeStart) {
 
 TEST(RoaringPositionBitmapTest, TestAddRangeClampBeyondMaxPosition) {
   RoaringPositionBitmap bitmap;
-  bitmap.AddRange(RoaringPositionBitmap::kMaxPosition - 1,
-                  RoaringPositionBitmap::kMaxPosition + 2);
-  ASSERT_EQ(bitmap.Cardinality(), 2u);
-  ASSERT_TRUE(bitmap.Contains(RoaringPositionBitmap::kMaxPosition - 1));
-  ASSERT_TRUE(bitmap.Contains(RoaringPositionBitmap::kMaxPosition));
-  ASSERT_FALSE(bitmap.Contains(RoaringPositionBitmap::kMaxPosition + 1));
+  // Range entirely beyond kMaxPosition: after clamping both endpoints the range
+  // becomes empty, so no allocation or insertion happens.
+  bitmap.AddRange(RoaringPositionBitmap::kMaxPosition + 1,
+                  RoaringPositionBitmap::kMaxPosition + 10);
+  ASSERT_TRUE(bitmap.IsEmpty());
 }
 
 struct AddRangeNoOpParams {

--- a/src/iceberg/test/roaring_position_bitmap_test.cc
+++ b/src/iceberg/test/roaring_position_bitmap_test.cc
@@ -204,13 +204,10 @@ TEST_P(RoaringPositionBitmapAddRangeNoOpTest, IsNoOp) {
 
 INSTANTIATE_TEST_SUITE_P(
     AddRangeNoOpScenarios, RoaringPositionBitmapAddRangeNoOpTest,
-    ::testing::Values(AddRangeNoOpParams{.name = "equal", .start = 100, .end = 100},
-                      AddRangeNoOpParams{.name = "zero_length_at_zero",
-                                         .start = 0,
-                                         .end = 0},
-                      AddRangeNoOpParams{.name = "negative_both",
-                                         .start = -10,
-                                         .end = -5}),
+    ::testing::Values(
+        AddRangeNoOpParams{.name = "equal", .start = 100, .end = 100},
+        AddRangeNoOpParams{.name = "zero_length_at_zero", .start = 0, .end = 0},
+        AddRangeNoOpParams{.name = "negative_both", .start = -10, .end = -5}),
     [](const ::testing::TestParamInfo<AddRangeNoOpParams>& info) {
       return info.param.name;
     });

--- a/src/iceberg/test/roaring_position_bitmap_test.cc
+++ b/src/iceberg/test/roaring_position_bitmap_test.cc
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <random>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -203,8 +204,7 @@ TEST_P(RoaringPositionBitmapAddRangeNoOpTest, IsNoOp) {
 
 INSTANTIATE_TEST_SUITE_P(
     AddRangeNoOpScenarios, RoaringPositionBitmapAddRangeNoOpTest,
-    ::testing::Values(AddRangeNoOpParams{.name = "reversed", .start = 100, .end = 50},
-                      AddRangeNoOpParams{.name = "equal", .start = 100, .end = 100},
+    ::testing::Values(AddRangeNoOpParams{.name = "equal", .start = 100, .end = 100},
                       AddRangeNoOpParams{.name = "zero_length_at_zero",
                                          .start = 0,
                                          .end = 0},
@@ -214,6 +214,11 @@ INSTANTIATE_TEST_SUITE_P(
     [](const ::testing::TestParamInfo<AddRangeNoOpParams>& info) {
       return info.param.name;
     });
+
+TEST(RoaringPositionBitmapTest, TestAddRangeReversedThrows) {
+  RoaringPositionBitmap bitmap;
+  ASSERT_THROW(bitmap.AddRange(100, 50), std::invalid_argument);
+}
 
 struct OrParams {
   const char* name;

--- a/src/iceberg/test/roaring_position_bitmap_test.cc
+++ b/src/iceberg/test/roaring_position_bitmap_test.cc
@@ -165,18 +165,23 @@ TEST(RoaringPositionBitmapTest, TestAddRangeSpanningThreeKeys) {
   ASSERT_TRUE(bitmap.Contains((int64_t{1} << 32) | int64_t{0xFFFFFFF0}));
 }
 
-TEST(RoaringPositionBitmapTest, TestAddRangeInvalidNegativeStartIsNoOp) {
+TEST(RoaringPositionBitmapTest, TestAddRangeClampNegativeStart) {
   RoaringPositionBitmap bitmap;
   bitmap.AddRange(-1, 10);
-  ASSERT_TRUE(bitmap.IsEmpty());
-  ASSERT_EQ(bitmap.Cardinality(), 0u);
+  ASSERT_EQ(bitmap.Cardinality(), 10u);
+  ASSERT_TRUE(bitmap.Contains(0));
+  ASSERT_TRUE(bitmap.Contains(9));
+  ASSERT_FALSE(bitmap.Contains(-1));
 }
 
-TEST(RoaringPositionBitmapTest, TestAddRangeInvalidBeyondMaxPositionIsNoOp) {
+TEST(RoaringPositionBitmapTest, TestAddRangeClampBeyondMaxPosition) {
   RoaringPositionBitmap bitmap;
-  bitmap.AddRange(0, RoaringPositionBitmap::kMaxPosition + 2);
-  ASSERT_TRUE(bitmap.IsEmpty());
-  ASSERT_EQ(bitmap.Cardinality(), 0u);
+  bitmap.AddRange(RoaringPositionBitmap::kMaxPosition - 1,
+                  RoaringPositionBitmap::kMaxPosition + 2);
+  ASSERT_EQ(bitmap.Cardinality(), 2u);
+  ASSERT_TRUE(bitmap.Contains(RoaringPositionBitmap::kMaxPosition - 1));
+  ASSERT_TRUE(bitmap.Contains(RoaringPositionBitmap::kMaxPosition));
+  ASSERT_FALSE(bitmap.Contains(RoaringPositionBitmap::kMaxPosition + 1));
 }
 
 TEST(RoaringPositionBitmapTest, TestAddRangeReversedIsNoOp) {

--- a/src/iceberg/test/roaring_position_bitmap_test.cc
+++ b/src/iceberg/test/roaring_position_bitmap_test.cc
@@ -461,7 +461,11 @@ TEST(RoaringPositionBitmapTest, TestIsEmpty) {
 
 TEST(RoaringPositionBitmapTest, TestOptimize) {
   RoaringPositionBitmap bitmap;
-  bitmap.AddRange(0, 10000);
+  // Use Add() instead of AddRange() because addRange() creates run-length
+  // encoded containers directly, leaving nothing for Optimize() to compress.
+  for (int64_t i = 0; i < 10000; ++i) {
+    bitmap.Add(i);
+  }
   size_t size_before = bitmap.SerializedSizeInBytes();
 
   bool changed = bitmap.Optimize();

--- a/src/iceberg/test/roaring_position_bitmap_test.cc
+++ b/src/iceberg/test/roaring_position_bitmap_test.cc
@@ -184,20 +184,36 @@ TEST(RoaringPositionBitmapTest, TestAddRangeClampBeyondMaxPosition) {
   ASSERT_FALSE(bitmap.Contains(RoaringPositionBitmap::kMaxPosition + 1));
 }
 
-TEST(RoaringPositionBitmapTest, TestAddRangeReversedIsNoOp) {
+struct AddRangeNoOpParams {
+  const char* name;
+  int64_t start;
+  int64_t end;
+};
+
+class RoaringPositionBitmapAddRangeNoOpTest
+    : public ::testing::TestWithParam<AddRangeNoOpParams> {};
+
+TEST_P(RoaringPositionBitmapAddRangeNoOpTest, IsNoOp) {
+  const auto& param = GetParam();
   RoaringPositionBitmap bitmap;
-  bitmap.AddRange(100, 50);
+  bitmap.AddRange(param.start, param.end);
   ASSERT_TRUE(bitmap.IsEmpty());
   ASSERT_EQ(bitmap.Cardinality(), 0u);
 }
 
-TEST(RoaringPositionBitmapTest, TestAddRangeEqualStartEndIsNoOp) {
-  RoaringPositionBitmap bitmap;
-  bitmap.AddRange(100, 100);
-  ASSERT_TRUE(bitmap.IsEmpty());
-  ASSERT_EQ(bitmap.Cardinality(), 0u);
-  ASSERT_FALSE(bitmap.Contains(100));
-}
+INSTANTIATE_TEST_SUITE_P(
+    AddRangeNoOpScenarios, RoaringPositionBitmapAddRangeNoOpTest,
+    ::testing::Values(AddRangeNoOpParams{.name = "reversed", .start = 100, .end = 50},
+                      AddRangeNoOpParams{.name = "equal", .start = 100, .end = 100},
+                      AddRangeNoOpParams{.name = "zero_length_at_zero",
+                                         .start = 0,
+                                         .end = 0},
+                      AddRangeNoOpParams{.name = "negative_both",
+                                         .start = -10,
+                                         .end = -5}),
+    [](const ::testing::TestParamInfo<AddRangeNoOpParams>& info) {
+      return info.param.name;
+    });
 
 struct OrParams {
   const char* name;

--- a/src/iceberg/test/roaring_position_bitmap_test.cc
+++ b/src/iceberg/test/roaring_position_bitmap_test.cc
@@ -128,8 +128,71 @@ INSTANTIATE_TEST_SUITE_P(
                           .start = (int64_t{1} << 32) - 5,
                           .end = (int64_t{1} << 32) + 5,
                           .absent_positions = {0, (int64_t{1} << 32) + 5},
+                      },
+                      AddRangeParams{
+                          .name = "single_position",
+                          .start = 42,
+                          .end = 43,
+                          .absent_positions = {41, 43},
                       }),
     [](const ::testing::TestParamInfo<AddRangeParams>& info) { return info.param.name; });
+
+TEST(RoaringPositionBitmapTest, TestAddRangeLargeContiguous) {
+  RoaringPositionBitmap bitmap;
+  bitmap.AddRange(500, 200500);
+
+  ASSERT_EQ(bitmap.Cardinality(), 200000u);
+  ASSERT_TRUE(bitmap.Contains(500));
+  ASSERT_TRUE(bitmap.Contains(200499));
+  ASSERT_FALSE(bitmap.Contains(499));
+  ASSERT_FALSE(bitmap.Contains(200500));
+}
+
+TEST(RoaringPositionBitmapTest, TestAddRangeSpanningThreeKeys) {
+  RoaringPositionBitmap bitmap;
+
+  int64_t start = (int64_t{0} << 32) | int64_t{0xFFFFFFF0};
+  int64_t end = (int64_t{2} << 32) | int64_t{0x10};
+  bitmap.AddRange(start, end);
+
+  ASSERT_EQ(bitmap.Cardinality(), static_cast<size_t>(end - start));
+  ASSERT_TRUE(bitmap.Contains(start));
+  ASSERT_TRUE(bitmap.Contains(end - 1));
+  ASSERT_FALSE(bitmap.Contains(start - 1));
+  ASSERT_FALSE(bitmap.Contains(end));
+  ASSERT_TRUE(bitmap.Contains(int64_t{1} << 32));
+  // Verify a sample near the end of the middle key is also present
+  ASSERT_TRUE(bitmap.Contains((int64_t{1} << 32) | int64_t{0xFFFFFFF0}));
+}
+
+TEST(RoaringPositionBitmapTest, TestAddRangeInvalidNegativeStartIsNoOp) {
+  RoaringPositionBitmap bitmap;
+  bitmap.AddRange(-1, 10);
+  ASSERT_TRUE(bitmap.IsEmpty());
+  ASSERT_EQ(bitmap.Cardinality(), 0u);
+}
+
+TEST(RoaringPositionBitmapTest, TestAddRangeInvalidBeyondMaxPositionIsNoOp) {
+  RoaringPositionBitmap bitmap;
+  bitmap.AddRange(0, RoaringPositionBitmap::kMaxPosition + 2);
+  ASSERT_TRUE(bitmap.IsEmpty());
+  ASSERT_EQ(bitmap.Cardinality(), 0u);
+}
+
+TEST(RoaringPositionBitmapTest, TestAddRangeReversedIsNoOp) {
+  RoaringPositionBitmap bitmap;
+  bitmap.AddRange(100, 50);
+  ASSERT_TRUE(bitmap.IsEmpty());
+  ASSERT_EQ(bitmap.Cardinality(), 0u);
+}
+
+TEST(RoaringPositionBitmapTest, TestAddRangeEqualStartEndIsNoOp) {
+  RoaringPositionBitmap bitmap;
+  bitmap.AddRange(100, 100);
+  ASSERT_TRUE(bitmap.IsEmpty());
+  ASSERT_EQ(bitmap.Cardinality(), 0u);
+  ASSERT_FALSE(bitmap.Contains(100));
+}
 
 struct OrParams {
   const char* name;


### PR DESCRIPTION
Replace the per-position loop in `RoaringPositionBitmap::AddRange` with direct calls to `roaring::Roaring::addRange`, matching the optimization in the Java implementation (https://github.com/apache/iceberg/pull/15791).

Added tests for single-position ranges, large contiguous ranges, three-key spanning ranges, and invalid inputs.

