### PR TITLE
feat(rest/auth): implement OAuth2 token refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,16 @@ jobs:
           - compiler: gcc-14
             cc: gcc-14
             cxx: g++-14
-          - compiler: clang-18
-            cc: clang-18
-            cxx: clang++-18
+          - compiler: clang-21
+            cc: clang-21
+            cxx: clang++-21
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev ninja-build
+      - name: Install clang-21
+        if: matrix.compiler == 'clang-21'
+        run: curl -s https://apt.llvm.org/llvm.sh | sudo bash -s -- 21
       - name: Build and test
         env:
           CC: ${{ matrix.cc }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ICEBERG_HOME: /tmp/iceberg
+
+jobs:
+  build:
+    name: ${{ matrix.compiler }} / Ubuntu 24.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - compiler: gcc-14
+            cc: gcc-14
+            cxx: g++-14
+          - compiler: clang-18
+            cc: clang-18
+            cxx: clang++-18
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev ninja-build
+      - name: Build and test
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+        run: ci/scripts/build_iceberg.sh $(pwd) ON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,19 @@ jobs:
           - compiler: gcc-14
             cc: gcc-14
             cxx: g++-14
-          - compiler: clang-21
-            cc: clang-21
-            cxx: clang++-21
+          - compiler: clang-20
+            cc: clang-20
+            cxx: clang++-20
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev ninja-build
-      - name: Install clang-21
-        if: matrix.compiler == 'clang-21'
-        run: curl -s https://apt.llvm.org/llvm.sh | sudo bash -s -- 21
+      - name: Install clang-20
+        if: matrix.compiler == 'clang-20'
+        run: |
+          wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh 20
       - name: Build and test
         env:
           CC: ${{ matrix.cc }}

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -180,6 +180,42 @@ function(resolve_arrow_dependency)
 endfunction()
 
 # ----------------------------------------------------------------------
+# fmt (required by Apache Avro)
+#
+# We fetch fmt explicitly before avro-cpp to ensure a compatible version.
+# Avro-cpp bundles fmt 10.2.1 which has consteval bugs with newer compilers.
+
+function(resolve_fmt_dependency)
+  prepare_fetchcontent()
+
+  set(FMT_INSTALL OFF)
+
+  fetchcontent_declare(fmt
+                       ${FC_DECLARE_COMMON_OPTIONS}
+                       GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+                       GIT_TAG 12.1.0
+                       FIND_PACKAGE_ARGS
+                       NAMES
+                       fmt
+                       CONFIG)
+  fetchcontent_makeavailable(fmt)
+
+  if(fmt_SOURCE_DIR)
+    set(FMT_VENDORED TRUE)
+  else()
+    set(FMT_VENDORED FALSE)
+    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES fmt)
+  endif()
+
+  set(ICEBERG_SYSTEM_DEPENDENCIES
+      ${ICEBERG_SYSTEM_DEPENDENCIES}
+      PARENT_SCOPE)
+  set(FMT_VENDORED
+      ${FMT_VENDORED}
+      PARENT_SCOPE)
+endfunction()
+
+# ----------------------------------------------------------------------
 # Apache Avro
 
 function(resolve_avro_dependency)
@@ -524,6 +560,7 @@ resolve_nlohmann_json_dependency()
 
 if(ICEBERG_BUILD_BUNDLE)
   resolve_arrow_dependency()
+  resolve_fmt_dependency()
   resolve_avro_dependency()
   resolve_zstd_dependency()
 endif()

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -167,8 +167,13 @@ function(resolve_arrow_dependency)
   else()
     set(ARROW_VENDORED FALSE)
     find_package(Arrow CONFIG REQUIRED)
-    find_package(Parquet CONFIG REQUIRED)
-    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES Arrow Parquet)
+    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES Arrow)
+    # Parquet may be bundled as a component of Arrow (e.g. Conan's arrow recipe).
+    # Only do a separate find_package if Arrow didn't already provide the target.
+    if(NOT TARGET Parquet::parquet_static AND NOT TARGET Parquet::parquet_shared)
+      find_package(Parquet CONFIG REQUIRED)
+    endif()
+    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES Parquet)
   endif()
 
   set(ICEBERG_SYSTEM_DEPENDENCIES

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,164 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import (
+    copy,
+    rm,
+    rmdir,
+)
+
+required_conan_version = ">=2.1.0"
+
+
+class IcebergCppConan(ConanFile):
+    name = "iceberg-cpp"
+    description = "Apache Iceberg C++ client library"
+    license = "Apache-2.0" f
+    homepage = "https://github.com/redpanda-data/iceberg-cpp"
+    url = "https://github.com/redpanda-data/iceberg-cpp"
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"fPIC": [True, False]}
+    default_options = {"fPIC": True}
+
+    def export_sources(self):
+        for pattern in [
+            "CMakeLists.txt",
+            "LICENSE",
+            "NOTICE",
+            "cmake_modules/*",
+            "src/*",
+        ]:
+            copy(self, pattern, src=self.recipe_folder, dst=self.export_sources_folder)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        self.options["arrow/*"].with_json = True
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires("arrow/22.0.0", transitive_headers=True)
+        self.requires("libcurl/[>=7.78 <9]")
+        self.requires("openssl/[>=1.1 <4]")
+        self.requires("zlib/[>=1.2.11 <2]")
+        self.requires("snappy/[>=1.1 <2]")
+        self.requires("zstd/[>=1.5 <2]")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ICEBERG_BUILD_BUNDLE"] = True
+        tc.variables["ICEBERG_BUILD_TESTS"] = False
+        tc.variables["ICEBERG_BUILD_REST"] = True
+        tc.variables["ICEBERG_BUILD_STATIC"] = True
+        tc.variables["ICEBERG_BUILD_SHARED"] = False
+        tc.variables["CMAKE_FIND_USE_PACKAGE_REGISTRY"] = False
+        # GCC false positive: inlining std::expected<T, Error> destructor in
+        # json_internal.cc makes GCC think Error::~Error() frees a non-heap
+        # pointer.  Same family as https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118867
+        if self.settings.compiler == "gcc":
+            tc.extra_cxxflags = ["-Wno-free-nonheap-object"]
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        cmake = CMake(self)
+        cmake.install()
+        # Remove vendored Arrow/Parquet — consumers use Conan's Arrow package.
+        rm(
+            self,
+            "libiceberg_vendored_arrow.a",
+            os.path.join(self.package_folder, "lib"),
+        )
+        rm(
+            self,
+            "libiceberg_vendored_parquet.a",
+            os.path.join(self.package_folder, "lib"),
+        )
+        rm(
+            self,
+            "libarrow_bundled_dependencies.a",
+            os.path.join(self.package_folder, "lib"),
+        )
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        # Vendored libraries (built and packaged by iceberg-cpp)
+        self.cpp_info.components["vendored_nanoarrow"].libs = [
+            "iceberg_vendored_nanoarrow",
+        ]
+
+        self.cpp_info.components["vendored_croaring"].libs = [
+            "iceberg_vendored_croaring",
+        ]
+
+        self.cpp_info.components["vendored_avrocpp"].libs = [
+            "iceberg_vendored_avrocpp",
+        ]
+        self.cpp_info.components["vendored_avrocpp"].requires = [
+            "zlib::zlib",
+            "snappy::snappy",
+            "zstd::zstd",
+        ]
+
+        self.cpp_info.components["vendored_cpr"].libs = ["iceberg_vendored_cpr"]
+        self.cpp_info.components["vendored_cpr"].requires = [
+            "libcurl::libcurl",
+            "openssl::openssl",
+        ]
+
+        # Core iceberg library
+        self.cpp_info.components["iceberg"].libs = ["iceberg"]
+        self.cpp_info.components["iceberg"].requires = [
+            "vendored_nanoarrow",
+            "vendored_croaring",
+        ]
+
+        # REST catalog support
+        self.cpp_info.components["iceberg_rest"].libs = ["iceberg_rest"]
+        self.cpp_info.components["iceberg_rest"].requires = [
+            "iceberg",
+            "vendored_cpr",
+        ]
+
+        # Bundle (Arrow/Parquet integration)
+        self.cpp_info.components["iceberg_bundle"].libs = ["iceberg_bundle"]
+        self.cpp_info.components["iceberg_bundle"].requires = [
+            "iceberg",
+            "arrow::libarrow",
+            "arrow::libparquet",
+            "vendored_avrocpp",
+        ]

--- a/src/iceberg/arrow/CMakeLists.txt
+++ b/src/iceberg/arrow/CMakeLists.txt
@@ -16,3 +16,6 @@
 # under the License.
 
 iceberg_install_all_headers(iceberg/arrow)
+
+# Also install internal header needed by consumers wrapping arrow::fs::FileSystem as iceberg FileIO.
+install(FILES arrow_fs_file_io_internal.h DESTINATION "${ICEBERG_INSTALL_INCLUDEDIR}/iceberg/arrow")

--- a/src/iceberg/arrow/CMakeLists.txt
+++ b/src/iceberg/arrow/CMakeLists.txt
@@ -18,4 +18,5 @@
 iceberg_install_all_headers(iceberg/arrow)
 
 # Also install internal header needed by consumers wrapping arrow::fs::FileSystem as iceberg FileIO.
-install(FILES arrow_fs_file_io_internal.h DESTINATION "${ICEBERG_INSTALL_INCLUDEDIR}/iceberg/arrow")
+install(FILES arrow_fs_file_io_internal.h
+        DESTINATION "${ICEBERG_INSTALL_INCLUDEDIR}/iceberg/arrow")

--- a/src/iceberg/catalog/rest/auth/auth_manager.cc
+++ b/src/iceberg/catalog/rest/auth/auth_manager.cc
@@ -128,9 +128,9 @@ class OAuth2Manager : public AuthManager {
     if (init_token_response_.has_value()) {
       auto token_response = std::move(*init_token_response_);
       init_token_response_.reset();
-      return AuthSession::MakeOAuth2(token_response, config.oauth2_server_uri(),
-                                     config.client_id(), config.client_secret(),
-                                     config.scope(), client);
+      return AuthSession::MakeOAuth2(
+          token_response, config.oauth2_server_uri(), config.client_id(),
+          config.client_secret(), config.scope(), client, config.expiry_margin_seconds());
     }
 
     // If token is provided, use it directly.
@@ -143,10 +143,9 @@ class OAuth2Manager : public AuthManager {
       auto base_session = AuthSession::MakeDefault(AuthHeaders(config.token()));
       OAuthTokenResponse token_response;
       ICEBERG_ASSIGN_OR_RAISE(token_response, FetchToken(client, *base_session, config));
-      // TODO(lishuxu): should we directly pass config to the MakeOAuth2 call?
-      return AuthSession::MakeOAuth2(token_response, config.oauth2_server_uri(),
-                                     config.client_id(), config.client_secret(),
-                                     config.scope(), client);
+      return AuthSession::MakeOAuth2(
+          token_response, config.oauth2_server_uri(), config.client_id(),
+          config.client_secret(), config.scope(), client, config.expiry_margin_seconds());
     }
 
     return AuthSession::MakeDefault({});

--- a/src/iceberg/catalog/rest/auth/auth_properties.h
+++ b/src/iceberg/catalog/rest/auth/auth_properties.h
@@ -70,6 +70,8 @@ class ICEBERG_REST_EXPORT AuthProperties : public ConfigBase<AuthProperties> {
   inline static Entry<bool> kExchangeEnabled{"token-exchange-enabled", true};
   inline static Entry<std::string> kAudience{"audience", ""};
   inline static Entry<std::string> kResource{"resource", ""};
+  inline static Entry<int64_t> kExpiryMarginSeconds{"oauth2.token-refresh-margin-seconds",
+                                                    300};
 
   /// \brief Build an AuthProperties from a properties map.
   static Result<AuthProperties> FromProperties(
@@ -87,6 +89,8 @@ class ICEBERG_REST_EXPORT AuthProperties : public ConfigBase<AuthProperties> {
   bool keep_refreshed() const { return Get(kKeepRefreshed); }
   /// \brief Whether token exchange is enabled.
   bool exchange_enabled() const { return Get(kExchangeEnabled); }
+  /// \brief Token expiry safety margin in seconds.
+  int64_t expiry_margin_seconds() const { return Get(kExpiryMarginSeconds); }
 
   /// \brief Parsed client_id from credential (empty if no colon).
   const std::string& client_id() const { return client_id_; }

--- a/src/iceberg/catalog/rest/auth/auth_session.cc
+++ b/src/iceberg/catalog/rest/auth/auth_session.cc
@@ -19,9 +19,17 @@
 
 #include "iceberg/catalog/rest/auth/auth_session.h"
 
+#include <chrono>
+#include <mutex>
 #include <utility>
 
 #include "iceberg/catalog/rest/auth/oauth2_util.h"
+#include "iceberg/catalog/rest/error_handlers.h"
+#include "iceberg/catalog/rest/http_client.h"
+#include "iceberg/catalog/rest/json_serde_internal.h"
+#include "iceberg/catalog/rest/types.h"
+#include "iceberg/json_serde_internal.h"
+#include "iceberg/util/macros.h"
 
 namespace iceberg::rest::auth {
 
@@ -44,6 +52,120 @@ class DefaultAuthSession : public AuthSession {
   std::unordered_map<std::string, std::string> headers_;
 };
 
+using SteadyClock = std::chrono::steady_clock;
+using TimePoint = SteadyClock::time_point;
+
+/// \brief OAuth2 session with transparent token refresh.
+///
+/// Thread-safe: multiple concurrent callers of Authenticate() are serialized
+/// through a mutex. Only the first caller that detects an expired token
+/// performs the refresh; the rest wait and reuse the result.
+class OAuth2AuthSession : public AuthSession {
+ public:
+  OAuth2AuthSession(OAuthTokenResponse initial_token, std::string token_endpoint,
+                    std::string client_id, std::string client_secret, std::string scope,
+                    HttpClient& client, std::chrono::seconds expiry_margin)
+      : token_(std::move(initial_token)),
+        token_endpoint_(std::move(token_endpoint)),
+        client_id_(std::move(client_id)),
+        client_secret_(std::move(client_secret)),
+        scope_(std::move(scope)),
+        client_(client),
+        expiry_margin_(expiry_margin) {
+    UpdateExpiry();
+  }
+
+  Status Authenticate(std::unordered_map<std::string, std::string>& headers) override {
+    std::lock_guard lock(mutex_);
+    if (IsExpired()) {
+      ICEBERG_RETURN_UNEXPECTED(DoRefresh());
+    }
+    headers.insert_or_assign(std::string(kAuthorizationHeader),
+                             std::string(kBearerPrefix) + token_.access_token);
+    return {};
+  }
+
+ private:
+  bool IsExpired() const {
+    if (expires_at_ == TimePoint{}) {
+      return false;  // no expiry info → assume valid
+    }
+    return SteadyClock::now() >= expires_at_;
+  }
+
+  void UpdateExpiry() {
+    if (token_.expires_in_secs.has_value() && *token_.expires_in_secs > 0) {
+      expires_at_ = SteadyClock::now() + std::chrono::seconds(*token_.expires_in_secs) -
+                    expiry_margin_;
+    } else {
+      expires_at_ = {};  // no expiry
+    }
+  }
+
+  /// Try refresh_token grant first, fall back to client_credentials.
+  Status DoRefresh() {
+    // Use a noop session for the refresh request itself to avoid recursion.
+    auto noop = AuthSession::MakeDefault({});
+
+    if (!token_.refresh_token.empty()) {
+      auto result = RefreshToken(client_, *noop, token_endpoint_, client_id_,
+                                 token_.refresh_token, scope_);
+      if (result.has_value()) {
+        token_ = std::move(*result);
+        UpdateExpiry();
+        return {};
+      }
+      // refresh_token grant failed, fall through to client_credentials
+    }
+
+    // Re-fetch using client_credentials
+    if (!client_secret_.empty()) {
+      // Build a minimal AuthProperties-compatible fetch
+      auto noop2 = AuthSession::MakeDefault({});
+      std::unordered_map<std::string, std::string> form_data{
+          {"grant_type", "client_credentials"},
+          {"client_id", client_id_},
+          {"client_secret", client_secret_},
+      };
+      if (!scope_.empty()) {
+        form_data.emplace("scope", scope_);
+      }
+      auto response = client_.PostForm(token_endpoint_, form_data, /*headers=*/{},
+                                       *DefaultErrorHandler::Instance(), *noop2);
+      if (!response.has_value()) {
+        return AuthenticationFailed("Failed to refresh OAuth2 token: {}",
+                                    response.error().message);
+      }
+      auto json = FromJsonString(response->body());
+      if (!json.has_value()) {
+        return AuthenticationFailed("Failed to parse OAuth2 token response");
+      }
+      auto token_result = FromJson<OAuthTokenResponse>(*json);
+      if (!token_result.has_value()) {
+        return AuthenticationFailed("Failed to deserialize OAuth2 token response");
+      }
+      token_ = std::move(*token_result);
+      UpdateExpiry();
+      return {};
+    }
+
+    return AuthenticationFailed(
+        "Failed to refresh OAuth2 token: no refresh_token "
+        "or client_secret available");
+  }
+
+  std::mutex mutex_;
+  OAuthTokenResponse token_;
+  TimePoint expires_at_{};
+
+  const std::string token_endpoint_;
+  const std::string client_id_;
+  const std::string client_secret_;
+  const std::string scope_;
+  HttpClient& client_;
+  const std::chrono::seconds expiry_margin_;
+};
+
 }  // namespace
 
 std::shared_ptr<AuthSession> AuthSession::MakeDefault(
@@ -52,12 +174,12 @@ std::shared_ptr<AuthSession> AuthSession::MakeDefault(
 }
 
 std::shared_ptr<AuthSession> AuthSession::MakeOAuth2(
-    const OAuthTokenResponse& initial_token, const std::string& /*token_endpoint*/,
-    const std::string& /*client_id*/, const std::string& /*client_secret*/,
-    const std::string& /*scope*/, HttpClient& /*client*/) {
-  // TODO(lishuxu): Create OAuth2AuthSession with auto-refresh support.
-  return MakeDefault({{std::string(kAuthorizationHeader),
-                       std::string(kBearerPrefix) + initial_token.access_token}});
+    const OAuthTokenResponse& initial_token, const std::string& token_endpoint,
+    const std::string& client_id, const std::string& client_secret,
+    const std::string& scope, HttpClient& client, int64_t expiry_margin_seconds) {
+  return std::make_shared<OAuth2AuthSession>(initial_token, token_endpoint, client_id,
+                                             client_secret, scope, client,
+                                             std::chrono::seconds(expiry_margin_seconds));
 }
 
 }  // namespace iceberg::rest::auth

--- a/src/iceberg/catalog/rest/auth/auth_session.h
+++ b/src/iceberg/catalog/rest/auth/auth_session.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -86,12 +87,10 @@ class ICEBERG_REST_EXPORT AuthSession {
   /// \param scope OAuth2 scope for refresh requests.
   /// \param client HTTP client for making refresh requests.
   /// \return A new session that manages token lifecycle automatically.
-  static std::shared_ptr<AuthSession> MakeOAuth2(const OAuthTokenResponse& initial_token,
-                                                 const std::string& token_endpoint,
-                                                 const std::string& client_id,
-                                                 const std::string& client_secret,
-                                                 const std::string& scope,
-                                                 HttpClient& client);
+  static std::shared_ptr<AuthSession> MakeOAuth2(
+      const OAuthTokenResponse& initial_token, const std::string& token_endpoint,
+      const std::string& client_id, const std::string& client_secret,
+      const std::string& scope, HttpClient& client, int64_t expiry_margin_seconds = 300);
 };
 
 }  // namespace iceberg::rest::auth

--- a/src/iceberg/catalog/rest/auth/oauth2_util.cc
+++ b/src/iceberg/catalog/rest/auth/oauth2_util.cc
@@ -74,4 +74,28 @@ Result<OAuthTokenResponse> FetchToken(HttpClient& client, AuthSession& session,
   return token_response;
 }
 
+Result<OAuthTokenResponse> RefreshToken(HttpClient& client, AuthSession& session,
+                                        const std::string& token_endpoint,
+                                        const std::string& client_id,
+                                        const std::string& refresh_token,
+                                        const std::string& scope) {
+  std::unordered_map<std::string, std::string> form_data{
+      {std::string(kGrantType), "refresh_token"},
+      {"refresh_token", refresh_token},
+      {std::string(kClientId), client_id},
+  };
+  if (!scope.empty()) {
+    form_data.emplace(std::string(kScope), scope);
+  }
+
+  ICEBERG_ASSIGN_OR_RAISE(auto response,
+                          client.PostForm(token_endpoint, form_data, /*headers=*/{},
+                                          *DefaultErrorHandler::Instance(), session));
+
+  ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
+  ICEBERG_ASSIGN_OR_RAISE(auto token_response, FromJson<OAuthTokenResponse>(json));
+  ICEBERG_RETURN_UNEXPECTED(token_response.Validate());
+  return token_response;
+}
+
 }  // namespace iceberg::rest::auth

--- a/src/iceberg/catalog/rest/auth/oauth2_util.h
+++ b/src/iceberg/catalog/rest/auth/oauth2_util.h
@@ -46,6 +46,20 @@ inline constexpr std::string_view kBearerPrefix = "Bearer ";
 ICEBERG_REST_EXPORT Result<OAuthTokenResponse> FetchToken(
     HttpClient& client, AuthSession& session, const AuthProperties& properties);
 
+/// \brief Refresh an expired access token using a refresh_token grant.
+///
+/// \param client HTTP client to use for the request.
+/// \param session Auth session for the request headers.
+/// \param token_endpoint Full URL of the OAuth2 token endpoint.
+/// \param client_id OAuth2 client ID.
+/// \param refresh_token The refresh token to use.
+/// \param scope OAuth2 scope to request.
+/// \return The refreshed token response or an error.
+ICEBERG_REST_EXPORT Result<OAuthTokenResponse> RefreshToken(
+    HttpClient& client, AuthSession& session, const std::string& token_endpoint,
+    const std::string& client_id, const std::string& refresh_token,
+    const std::string& scope);
+
 /// \brief Build auth headers from a token string.
 ///
 /// \param token Bearer token string (may be empty).

--- a/src/iceberg/catalog/rest/http_client.cc
+++ b/src/iceberg/catalog/rest/http_client.cc
@@ -229,8 +229,8 @@ Result<HttpResponse> HttpClient::Head(
     const ErrorHandler& error_handler, auth::AuthSession& session) {
   ICEBERG_ASSIGN_OR_RAISE(auto all_headers,
                           BuildHeaders(headers, default_headers_, session));
-  cpr::Response response =
-      cpr::Head(cpr::Url{path}, all_headers, BuildSslOptions(ssl_config_), *connection_pool_);
+  cpr::Response response = cpr::Head(cpr::Url{path}, all_headers,
+                                     BuildSslOptions(ssl_config_), *connection_pool_);
 
   ICEBERG_RETURN_UNEXPECTED(HandleFailureResponse(response, error_handler));
   HttpResponse http_response;
@@ -244,9 +244,8 @@ Result<HttpResponse> HttpClient::Delete(
     const ErrorHandler& error_handler, auth::AuthSession& session) {
   ICEBERG_ASSIGN_OR_RAISE(auto all_headers,
                           BuildHeaders(headers, default_headers_, session));
-  cpr::Response response =
-      cpr::Delete(cpr::Url{path}, GetParameters(params), all_headers,
-                  BuildSslOptions(ssl_config_), *connection_pool_);
+  cpr::Response response = cpr::Delete(cpr::Url{path}, GetParameters(params), all_headers,
+                                       BuildSslOptions(ssl_config_), *connection_pool_);
 
   ICEBERG_RETURN_UNEXPECTED(HandleFailureResponse(response, error_handler));
   HttpResponse http_response;

--- a/src/iceberg/catalog/rest/http_client.cc
+++ b/src/iceberg/catalog/rest/http_client.cc
@@ -81,6 +81,22 @@ Result<cpr::Header> BuildHeaders(
   return cpr::Header(headers.begin(), headers.end());
 }
 
+cpr::SslOptions BuildSslOptions(const SslConfig& config) {
+  cpr::SslOptions opts;
+  opts.verify_host = config.verify;
+  opts.verify_peer = config.verify;
+  if (!config.ca_info.empty()) {
+    opts.ca_info = config.ca_info;
+  }
+  if (!config.ca_path.empty()) {
+    opts.ca_path = config.ca_path;
+  }
+  if (!config.crl_file.empty()) {
+    opts.crl_file = config.crl_file;
+  }
+  return opts;
+}
+
 /// \brief Converts a map of string key-value pairs to cpr::Parameters.
 cpr::Parameters GetParameters(
     const std::unordered_map<std::string, std::string>& params) {
@@ -101,11 +117,18 @@ bool IsSuccessful(int32_t status_code) {
 
 /// \brief Builds a default ErrorResponse when the response body cannot be parsed.
 ErrorResponse BuildDefaultErrorResponse(const cpr::Response& response) {
+  std::string message;
+  if (response.error) {
+    message = response.error.message;
+  } else if (!response.reason.empty()) {
+    message = response.reason;
+  } else {
+    message = GetStandardReasonPhrase(response.status_code);
+  }
   return {
       .code = static_cast<uint32_t>(response.status_code),
       .type = std::string(kRestExceptionType),
-      .message = !response.reason.empty() ? response.reason
-                                          : GetStandardReasonPhrase(response.status_code),
+      .message = std::move(message),
   };
 }
 
@@ -133,8 +156,10 @@ Status HandleFailureResponse(const cpr::Response& response,
 
 }  // namespace
 
-HttpClient::HttpClient(std::unordered_map<std::string, std::string> default_headers)
+HttpClient::HttpClient(std::unordered_map<std::string, std::string> default_headers,
+                       SslConfig ssl_config)
     : default_headers_{std::move(default_headers)},
+      ssl_config_{std::move(ssl_config)},
       connection_pool_{std::make_unique<cpr::ConnectionPool>()} {
   // Set default Content-Type for all requests (including GET/HEAD/DELETE).
   // Many systems require that content type is set regardless and will fail,
@@ -151,8 +176,8 @@ Result<HttpResponse> HttpClient::Get(
     const ErrorHandler& error_handler, auth::AuthSession& session) {
   ICEBERG_ASSIGN_OR_RAISE(auto all_headers,
                           BuildHeaders(headers, default_headers_, session));
-  cpr::Response response =
-      cpr::Get(cpr::Url{path}, GetParameters(params), all_headers, *connection_pool_);
+  cpr::Response response = cpr::Get(cpr::Url{path}, GetParameters(params), all_headers,
+                                    BuildSslOptions(ssl_config_), *connection_pool_);
 
   ICEBERG_RETURN_UNEXPECTED(HandleFailureResponse(response, error_handler));
   HttpResponse http_response;
@@ -166,8 +191,8 @@ Result<HttpResponse> HttpClient::Post(
     const ErrorHandler& error_handler, auth::AuthSession& session) {
   ICEBERG_ASSIGN_OR_RAISE(auto all_headers,
                           BuildHeaders(headers, default_headers_, session));
-  cpr::Response response =
-      cpr::Post(cpr::Url{path}, cpr::Body{body}, all_headers, *connection_pool_);
+  cpr::Response response = cpr::Post(cpr::Url{path}, cpr::Body{body}, all_headers,
+                                     BuildSslOptions(ssl_config_), *connection_pool_);
 
   ICEBERG_RETURN_UNEXPECTED(HandleFailureResponse(response, error_handler));
   HttpResponse http_response;
@@ -191,7 +216,7 @@ Result<HttpResponse> HttpClient::PostForm(
   }
   cpr::Response response =
       cpr::Post(cpr::Url{path}, cpr::Payload(pair_list.begin(), pair_list.end()),
-                all_headers, *connection_pool_);
+                all_headers, BuildSslOptions(ssl_config_), *connection_pool_);
 
   ICEBERG_RETURN_UNEXPECTED(HandleFailureResponse(response, error_handler));
   HttpResponse http_response;
@@ -204,7 +229,8 @@ Result<HttpResponse> HttpClient::Head(
     const ErrorHandler& error_handler, auth::AuthSession& session) {
   ICEBERG_ASSIGN_OR_RAISE(auto all_headers,
                           BuildHeaders(headers, default_headers_, session));
-  cpr::Response response = cpr::Head(cpr::Url{path}, all_headers, *connection_pool_);
+  cpr::Response response =
+      cpr::Head(cpr::Url{path}, all_headers, BuildSslOptions(ssl_config_), *connection_pool_);
 
   ICEBERG_RETURN_UNEXPECTED(HandleFailureResponse(response, error_handler));
   HttpResponse http_response;
@@ -219,7 +245,8 @@ Result<HttpResponse> HttpClient::Delete(
   ICEBERG_ASSIGN_OR_RAISE(auto all_headers,
                           BuildHeaders(headers, default_headers_, session));
   cpr::Response response =
-      cpr::Delete(cpr::Url{path}, GetParameters(params), all_headers, *connection_pool_);
+      cpr::Delete(cpr::Url{path}, GetParameters(params), all_headers,
+                  BuildSslOptions(ssl_config_), *connection_pool_);
 
   ICEBERG_RETURN_UNEXPECTED(HandleFailureResponse(response, error_handler));
   HttpResponse http_response;

--- a/src/iceberg/catalog/rest/http_client.h
+++ b/src/iceberg/catalog/rest/http_client.h
@@ -67,10 +67,19 @@ class ICEBERG_REST_EXPORT HttpResponse {
   std::unique_ptr<Impl> impl_;
 };
 
+/// \brief SSL/TLS configuration for the HTTP client.
+struct ICEBERG_REST_EXPORT SslConfig {
+  bool verify = true;
+  std::string ca_info;
+  std::string ca_path;
+  std::string crl_file;
+};
+
 /// \brief HTTP client for making requests to Iceberg REST Catalog API.
 class ICEBERG_REST_EXPORT HttpClient {
  public:
-  explicit HttpClient(std::unordered_map<std::string, std::string> default_headers = {});
+  explicit HttpClient(std::unordered_map<std::string, std::string> default_headers = {},
+                      SslConfig ssl_config = {});
   ~HttpClient();
 
   HttpClient(const HttpClient&) = delete;
@@ -112,6 +121,7 @@ class ICEBERG_REST_EXPORT HttpClient {
 
  private:
   std::unordered_map<std::string, std::string> default_headers_;
+  SslConfig ssl_config_;
   std::unique_ptr<cpr::ConnectionPool> connection_pool_;
 };
 

--- a/src/iceberg/catalog/rest/rest_catalog.cc
+++ b/src/iceberg/catalog/rest/rest_catalog.cc
@@ -65,12 +65,30 @@ std::unordered_set<Endpoint> GetDefaultEndpoints() {
   };
 }
 
+SslConfig ExtractSslConfig(const std::unordered_map<std::string, std::string>& props) {
+  SslConfig ssl;
+  if (auto it = props.find("ssl.verify"); it != props.end()) {
+    ssl.verify = (it->second != "false");
+  }
+  if (auto it = props.find("ssl.ca-info"); it != props.end()) {
+    ssl.ca_info = it->second;
+  }
+  if (auto it = props.find("ssl.ca-path"); it != props.end()) {
+    ssl.ca_path = it->second;
+  }
+  if (auto it = props.find("ssl.crl-file"); it != props.end()) {
+    ssl.crl_file = it->second;
+  }
+  return ssl;
+}
+
 /// \brief Fetch server configuration from the REST catalog server.
 Result<CatalogConfig> FetchServerConfig(const ResourcePaths& paths,
                                         const RestCatalogProperties& current_config,
                                         auth::AuthSession& session) {
   ICEBERG_ASSIGN_OR_RAISE(auto config_path, paths.Config());
-  HttpClient client(current_config.ExtractHeaders());
+  HttpClient client(current_config.ExtractHeaders(),
+                    ExtractSslConfig(current_config.configs()));
 
   // Send the client's warehouse location to the service to keep in sync.
   // This is needed for cases where the warehouse is configured client side, but may
@@ -137,7 +155,8 @@ Result<std::shared_ptr<RestCatalog>> RestCatalog::Make(
                           config.Get(RestCatalogProperties::kNamespaceSeparator)));
 
   // Create init session for fetching server configuration
-  HttpClient init_client(config.ExtractHeaders());
+  auto ssl = ExtractSslConfig(config.configs());
+  HttpClient init_client(config.ExtractHeaders(), ssl);
   ICEBERG_ASSIGN_OR_RAISE(auto init_session,
                           auth_manager->InitSession(init_client, config.configs()));
   ICEBERG_ASSIGN_OR_RAISE(auto server_config,
@@ -168,7 +187,8 @@ Result<std::shared_ptr<RestCatalog>> RestCatalog::Make(
   // Get snapshot loading mode
   ICEBERG_ASSIGN_OR_RAISE(auto snapshot_mode, final_config.SnapshotLoadingMode());
 
-  auto client = std::make_unique<HttpClient>(final_config.ExtractHeaders());
+  auto final_ssl = ExtractSslConfig(final_config.configs());
+  auto client = std::make_unique<HttpClient>(final_config.ExtractHeaders(), final_ssl);
   ICEBERG_ASSIGN_OR_RAISE(auto catalog_session,
                           auth_manager->CatalogSession(*client, final_config.configs()));
 

--- a/src/iceberg/delete_file_index.cc
+++ b/src/iceberg/delete_file_index.cc
@@ -244,8 +244,7 @@ Result<std::vector<std::shared_ptr<DataFile>>> EqualityDeletes::Filter(
 std::vector<std::shared_ptr<DataFile>> EqualityDeletes::ReferencedDeleteFiles() {
   IndexIfNeeded();
   return std::ranges::to<std::vector<std::shared_ptr<DataFile>>>(
-      files_ |
-      std::views::transform([](const auto& f) { return f.wrapped.data_file; }));
+      files_ | std::views::transform([](const auto& f) { return f.wrapped.data_file; }));
 }
 
 void EqualityDeletes::IndexIfNeeded() {

--- a/src/iceberg/delete_file_index.cc
+++ b/src/iceberg/delete_file_index.cc
@@ -182,15 +182,15 @@ std::vector<std::shared_ptr<DataFile>> PositionDeletes::Filter(int64_t seq) {
   if (iter == seqs_.end()) {
     return {};
   }
-  return files_ | std::views::drop(iter - seqs_.begin()) |
-         std::views::transform(&ManifestEntry::data_file) |
-         std::ranges::to<std::vector<std::shared_ptr<DataFile>>>();
+  return std::ranges::to<std::vector<std::shared_ptr<DataFile>>>(
+      files_ | std::views::drop(iter - seqs_.begin()) |
+      std::views::transform(&ManifestEntry::data_file));
 }
 
 std::vector<std::shared_ptr<DataFile>> PositionDeletes::ReferencedDeleteFiles() {
   IndexIfNeeded();
-  return files_ | std::views::transform(&ManifestEntry::data_file) |
-         std::ranges::to<std::vector<std::shared_ptr<DataFile>>>();
+  return std::ranges::to<std::vector<std::shared_ptr<DataFile>>>(
+      files_ | std::views::transform(&ManifestEntry::data_file));
 }
 
 void PositionDeletes::IndexIfNeeded() {
@@ -202,9 +202,9 @@ void PositionDeletes::IndexIfNeeded() {
   std::ranges::sort(files_, std::ranges::less{}, &ManifestEntry::sequence_number);
 
   // Build sequence number array for binary search
-  seqs_ = files_ |
-          std::views::transform([](const auto& e) { return e.sequence_number.value(); }) |
-          std::ranges::to<std::vector<int64_t>>();
+  seqs_ = std::ranges::to<std::vector<int64_t>>(
+      files_ |
+      std::views::transform([](const auto& e) { return e.sequence_number.value(); }));
 
   indexed_ = true;
 }
@@ -243,9 +243,9 @@ Result<std::vector<std::shared_ptr<DataFile>>> EqualityDeletes::Filter(
 
 std::vector<std::shared_ptr<DataFile>> EqualityDeletes::ReferencedDeleteFiles() {
   IndexIfNeeded();
-  return files_ |
-         std::views::transform([](const auto& f) { return f.wrapped.data_file; }) |
-         std::ranges::to<std::vector<std::shared_ptr<DataFile>>>();
+  return std::ranges::to<std::vector<std::shared_ptr<DataFile>>>(
+      files_ |
+      std::views::transform([](const auto& f) { return f.wrapped.data_file; }));
 }
 
 void EqualityDeletes::IndexIfNeeded() {
@@ -258,8 +258,8 @@ void EqualityDeletes::IndexIfNeeded() {
                     &EqualityDeleteFile::apply_sequence_number);
 
   // Build sequence number array for binary search
-  seqs_ = files_ | std::views::transform(&EqualityDeleteFile::apply_sequence_number) |
-          std::ranges::to<std::vector<int64_t>>();
+  seqs_ = std::ranges::to<std::vector<int64_t>>(
+      files_ | std::views::transform(&EqualityDeleteFile::apply_sequence_number));
 
   indexed_ = true;
 }

--- a/src/iceberg/json_serde.cc
+++ b/src/iceberg/json_serde.cc
@@ -209,6 +209,10 @@ constexpr std::string_view kSnapshotIds = "snapshot-ids";
 constexpr std::string_view kRefName = "ref-name";
 constexpr std::string_view kUpdates = "updates";
 constexpr std::string_view kRemovals = "removals";
+// The Iceberg REST spec uses "ref" (not "ref-name") for the
+// assert-ref-snapshot-id requirement.  "ref-name" is correct only for
+// table-update actions (set-snapshot-ref, remove-snapshot-ref).
+constexpr std::string_view kRef = "ref";
 
 // TableRequirement type constants
 constexpr std::string_view kRequirementAssertDoesNotExist = "assert-create";
@@ -1491,7 +1495,7 @@ nlohmann::json ToJson(const TableRequirement& requirement) {
       const auto& r =
           internal::checked_cast<const table::AssertRefSnapshotID&>(requirement);
       json[kType] = kRequirementAssertRefSnapshotID;
-      json[kRefName] = r.ref_name();
+      json[kRef] = r.ref_name();
       if (r.snapshot_id().has_value()) {
         json[kSnapshotId] = r.snapshot_id().value();
       } else {
@@ -1688,7 +1692,7 @@ Result<std::unique_ptr<TableRequirement>> TableRequirementFromJson(
     return std::make_unique<table::AssertUUID>(std::move(uuid));
   }
   if (type == kRequirementAssertRefSnapshotID) {
-    ICEBERG_ASSIGN_OR_RAISE(auto ref_name, GetJsonValue<std::string>(json, kRefName));
+    ICEBERG_ASSIGN_OR_RAISE(auto ref_name, GetJsonValue<std::string>(json, kRef));
     ICEBERG_ASSIGN_OR_RAISE(auto snapshot_id_opt,
                             GetJsonValueOptional<int64_t>(json, kSnapshotId));
     return std::make_unique<table::AssertRefSnapshotID>(std::move(ref_name),

--- a/src/iceberg/sort_order.cc
+++ b/src/iceberg/sort_order.cc
@@ -135,8 +135,7 @@ Result<std::unique_ptr<SortOrder>> SortOrder::Make(int32_t sort_id,
 std::unordered_set<std::string_view> SortOrder::OrderPreservingSortedColumns(
     const Schema& schema, const SortOrder& order) {
   return std::ranges::to<std::unordered_set<std::string_view>>(
-      order.fields() |
-      std::views::filter([&schema](const SortField& field) {
+      order.fields() | std::views::filter([&schema](const SortField& field) {
         return field.transform()->PreservesOrder();
       }) |
       std::views::transform([&schema](const SortField& field) {

--- a/src/iceberg/sort_order.cc
+++ b/src/iceberg/sort_order.cc
@@ -134,16 +134,17 @@ Result<std::unique_ptr<SortOrder>> SortOrder::Make(int32_t sort_id,
 
 std::unordered_set<std::string_view> SortOrder::OrderPreservingSortedColumns(
     const Schema& schema, const SortOrder& order) {
-  return order.fields() | std::views::filter([&schema](const SortField& field) {
-           return field.transform()->PreservesOrder();
-         }) |
-         std::views::transform([&schema](const SortField& field) {
-           return schema.FindColumnNameById(field.source_id())
-               .value_or(std::nullopt)
-               .value_or("");
-         }) |
-         std::views::filter([](std::string_view name) { return !name.empty(); }) |
-         std::ranges::to<std::unordered_set<std::string_view>>();
+  return std::ranges::to<std::unordered_set<std::string_view>>(
+      order.fields() |
+      std::views::filter([&schema](const SortField& field) {
+        return field.transform()->PreservesOrder();
+      }) |
+      std::views::transform([&schema](const SortField& field) {
+        return schema.FindColumnNameById(field.source_id())
+            .value_or(std::nullopt)
+            .value_or("");
+      }) |
+      std::views::filter([](std::string_view name) { return !name.empty(); }));
 }
 
 }  // namespace iceberg

--- a/src/iceberg/table_metadata.cc
+++ b/src/iceberg/table_metadata.cc
@@ -377,10 +377,10 @@ Result<TableMetadataCache::SnapshotsMapRef> TableMetadataCache::GetSnapshotsById
 
 Result<TableMetadataCache::SchemasMap> TableMetadataCache::InitSchemasMap(
     const TableMetadata* metadata) {
-  return std::ranges::to<SchemasMap>(
-      metadata->schemas | std::views::transform([](const auto& schema) {
-        return std::make_pair(schema->schema_id(), schema);
-      }));
+  return std::ranges::to<SchemasMap>(metadata->schemas |
+                                     std::views::transform([](const auto& schema) {
+                                       return std::make_pair(schema->schema_id(), schema);
+                                     }));
 }
 
 Result<TableMetadataCache::PartitionSpecsMap> TableMetadataCache::InitPartitionSpecsMap(
@@ -393,10 +393,10 @@ Result<TableMetadataCache::PartitionSpecsMap> TableMetadataCache::InitPartitionS
 
 Result<TableMetadataCache::SortOrdersMap> TableMetadataCache::InitSortOrdersMap(
     const TableMetadata* metadata) {
-  return std::ranges::to<SortOrdersMap>(
-      metadata->sort_orders | std::views::transform([](const auto& order) {
-        return std::make_pair(order->order_id(), order);
-      }));
+  return std::ranges::to<SortOrdersMap>(metadata->sort_orders |
+                                        std::views::transform([](const auto& order) {
+                                          return std::make_pair(order->order_id(), order);
+                                        }));
 }
 
 Result<TableMetadataCache::SnapshotsMap> TableMetadataCache::InitSnapshotMap(

--- a/src/iceberg/table_metadata.cc
+++ b/src/iceberg/table_metadata.cc
@@ -377,34 +377,34 @@ Result<TableMetadataCache::SnapshotsMapRef> TableMetadataCache::GetSnapshotsById
 
 Result<TableMetadataCache::SchemasMap> TableMetadataCache::InitSchemasMap(
     const TableMetadata* metadata) {
-  return metadata->schemas | std::views::transform([](const auto& schema) {
-           return std::make_pair(schema->schema_id(), schema);
-         }) |
-         std::ranges::to<SchemasMap>();
+  return std::ranges::to<SchemasMap>(
+      metadata->schemas | std::views::transform([](const auto& schema) {
+        return std::make_pair(schema->schema_id(), schema);
+      }));
 }
 
 Result<TableMetadataCache::PartitionSpecsMap> TableMetadataCache::InitPartitionSpecsMap(
     const TableMetadata* metadata) {
-  return metadata->partition_specs | std::views::transform([](const auto& spec) {
-           return std::make_pair(spec->spec_id(), spec);
-         }) |
-         std::ranges::to<PartitionSpecsMap>();
+  return std::ranges::to<PartitionSpecsMap>(
+      metadata->partition_specs | std::views::transform([](const auto& spec) {
+        return std::make_pair(spec->spec_id(), spec);
+      }));
 }
 
 Result<TableMetadataCache::SortOrdersMap> TableMetadataCache::InitSortOrdersMap(
     const TableMetadata* metadata) {
-  return metadata->sort_orders | std::views::transform([](const auto& order) {
-           return std::make_pair(order->order_id(), order);
-         }) |
-         std::ranges::to<SortOrdersMap>();
+  return std::ranges::to<SortOrdersMap>(
+      metadata->sort_orders | std::views::transform([](const auto& order) {
+        return std::make_pair(order->order_id(), order);
+      }));
 }
 
 Result<TableMetadataCache::SnapshotsMap> TableMetadataCache::InitSnapshotMap(
     const TableMetadata* metadata) {
-  return metadata->snapshots | std::views::transform([](const auto& snapshot) {
-           return std::make_pair(snapshot->snapshot_id, snapshot);
-         }) |
-         std::ranges::to<SnapshotsMap>();
+  return std::ranges::to<SnapshotsMap>(
+      metadata->snapshots | std::views::transform([](const auto& snapshot) {
+        return std::make_pair(snapshot->snapshot_id, snapshot);
+      }));
 }
 
 Result<MetadataFileCodecType> TableMetadataUtil::Codec::FromString(
@@ -499,7 +499,7 @@ void TableMetadataUtil::DeleteRemovedMetadataFiles(FileIO& io, const TableMetada
       metadata.properties.Get(TableProperties::kMetadataDeleteAfterCommitEnabled);
   if (delete_after_commit) {
     auto current_files =
-        metadata.metadata_log | std::ranges::to<std::unordered_set<MetadataLogEntry>>();
+        std::ranges::to<std::unordered_set<MetadataLogEntry>>(metadata.metadata_log);
     std::ranges::for_each(
         base->metadata_log | std::views::filter([&current_files](const auto& entry) {
           return !current_files.contains(entry);
@@ -862,7 +862,7 @@ Result<int32_t> TableMetadataBuilder::Impl::AddPartitionSpec(const PartitionSpec
 
   ICEBERG_ASSIGN_OR_RAISE(
       std::shared_ptr<PartitionSpec> new_spec,
-      PartitionSpec::Make(new_spec_id, spec.fields() | std::ranges::to<std::vector>()));
+      PartitionSpec::Make(new_spec_id, std::ranges::to<std::vector>(spec.fields())));
   metadata_.last_partition_id =
       std::max(metadata_.last_partition_id, new_spec->last_assigned_field_id());
   metadata_.partition_specs.push_back(new_spec);
@@ -933,7 +933,7 @@ Status TableMetadataBuilder::Impl::SetCurrentSchema(int32_t schema_id) {
     ICEBERG_ASSIGN_OR_RAISE(
         auto updated_spec,
         PartitionSpec::Make(partition_spec->spec_id(),
-                            partition_spec->fields() | std::ranges::to<std::vector>()));
+                            std::ranges::to<std::vector>(partition_spec->fields())));
 
     ICEBERG_RETURN_UNEXPECTED(
         PartitionSpec::ValidatePartitionName(*schema, *updated_spec));
@@ -953,7 +953,7 @@ Status TableMetadataBuilder::Impl::SetCurrentSchema(int32_t schema_id) {
     ICEBERG_ASSIGN_OR_RAISE(
         auto updated_order,
         SortOrder::Make(sort_order->order_id(),
-                        sort_order->fields() | std::ranges::to<std::vector>()));
+                        std::ranges::to<std::vector>(sort_order->fields())));
     updated_orders.push_back(std::move(updated_order));
   }
   metadata_.sort_orders = std::move(updated_orders);
@@ -983,10 +983,10 @@ Status TableMetadataBuilder::Impl::RemoveSchemas(
                    "Cannot remove current schema: {}", current_schema_id);
 
   if (!schema_ids.empty()) {
-    metadata_.schemas = metadata_.schemas | std::views::filter([&](const auto& schema) {
-                          return !schema_ids.contains(schema->schema_id());
-                        }) |
-                        std::ranges::to<std::vector<std::shared_ptr<Schema>>>();
+    metadata_.schemas = std::ranges::to<std::vector<std::shared_ptr<Schema>>>(
+        metadata_.schemas | std::views::filter([&](const auto& schema) {
+          return !schema_ids.contains(schema->schema_id());
+        }));
     changes_.push_back(std::make_unique<table::RemoveSchemas>(schema_ids));
   }
 
@@ -1023,7 +1023,7 @@ Result<int32_t> TableMetadataBuilder::Impl::AddSchema(const Schema& schema,
   metadata_.last_column_id = new_last_column_id;
 
   ICEBERG_ASSIGN_OR_RAISE(std::shared_ptr<Schema> new_schema,
-                          Schema::Make(schema.fields() | std::ranges::to<std::vector>(),
+                          Schema::Make(std::ranges::to<std::vector>(schema.fields()),
                                        new_schema_id, schema.IdentifierFieldIds()))
 
   if (!schema_found) {
@@ -1479,10 +1479,10 @@ Status TableMetadataBuilder::Impl::RemovePartitionSpecs(
                    "Cannot remove the default partition spec");
 
   metadata_.partition_specs =
-      metadata_.partition_specs | std::views::filter([&](const auto& spec) {
-        return !spec_ids_to_remove.contains(spec->spec_id());
-      }) |
-      std::ranges::to<std::vector<std::shared_ptr<PartitionSpec>>>();
+      std::ranges::to<std::vector<std::shared_ptr<PartitionSpec>>>(
+          metadata_.partition_specs | std::views::filter([&](const auto& spec) {
+            return !spec_ids_to_remove.contains(spec->spec_id());
+          }));
   changes_.push_back(std::make_unique<table::RemovePartitionSpecs>(spec_ids));
 
   return {};

--- a/src/iceberg/test/delete_file_index_test.cc
+++ b/src/iceberg/test/delete_file_index_test.cc
@@ -212,9 +212,9 @@ class DeleteFileIndexTest : public testing::TestWithParam<int8_t> {
   // Helper to extract paths from delete files for comparison
   static std::vector<std::string> GetPaths(
       const std::vector<std::shared_ptr<DataFile>>& files) {
-    return std::ranges::transform_view(files,
-                                       [](const auto& f) { return f->file_path; }) |
-           std::ranges::to<std::vector<std::string>>();
+    return std::ranges::to<std::vector<std::string>>(
+        std::ranges::transform_view(files,
+                                    [](const auto& f) { return f->file_path; }));
   }
 };
 

--- a/src/iceberg/test/delete_file_index_test.cc
+++ b/src/iceberg/test/delete_file_index_test.cc
@@ -213,8 +213,7 @@ class DeleteFileIndexTest : public testing::TestWithParam<int8_t> {
   static std::vector<std::string> GetPaths(
       const std::vector<std::shared_ptr<DataFile>>& files) {
     return std::ranges::to<std::vector<std::string>>(
-        std::ranges::transform_view(files,
-                                    [](const auto& f) { return f->file_path; }));
+        std::ranges::transform_view(files, [](const auto& f) { return f->file_path; }));
   }
 };
 

--- a/src/iceberg/test/json_serde_test.cc
+++ b/src/iceberg/test/json_serde_test.cc
@@ -681,7 +681,7 @@ TEST(TableRequirementJsonTest, TableRequirementAssertUUID) {
 TEST(TableRequirementJsonTest, TableRequirementAssertRefSnapshotID) {
   table::AssertRefSnapshotID req("main", 123456789);
   nlohmann::json expected =
-      R"({"type":"assert-ref-snapshot-id","ref-name":"main","snapshot-id":123456789})"_json;
+      R"({"type":"assert-ref-snapshot-id","ref":"main","snapshot-id":123456789})"_json;
 
   EXPECT_EQ(ToJson(req), expected);
   auto parsed = TableRequirementFromJson(expected);
@@ -693,7 +693,7 @@ TEST(TableRequirementJsonTest, TableRequirementAssertRefSnapshotID) {
 TEST(TableRequirementJsonTest, TableRequirementAssertRefSnapshotIDWithNull) {
   table::AssertRefSnapshotID req("main", std::nullopt);
   nlohmann::json expected =
-      R"({"type":"assert-ref-snapshot-id","ref-name":"main","snapshot-id":null})"_json;
+      R"({"type":"assert-ref-snapshot-id","ref":"main","snapshot-id":null})"_json;
 
   EXPECT_EQ(ToJson(req), expected);
   auto parsed = TableRequirementFromJson(expected);

--- a/src/iceberg/test/manifest_group_test.cc
+++ b/src/iceberg/test/manifest_group_test.cc
@@ -216,17 +216,15 @@ class ManifestGroupTest : public testing::TestWithParam<int8_t> {
   static std::vector<std::string> GetPaths(
       const std::vector<std::shared_ptr<FileScanTask>>& tasks) {
     return std::ranges::to<std::vector<std::string>>(
-        tasks | std::views::transform([](const auto& task) {
-          return task->data_file()->file_path;
-        }));
+        tasks | std::views::transform(
+                    [](const auto& task) { return task->data_file()->file_path; }));
   }
 
   static std::vector<std::string> GetEntryPaths(
       const std::vector<ManifestEntry>& entries) {
     return std::ranges::to<std::vector<std::string>>(
-        entries | std::views::transform([](const auto& entry) {
-          return entry.data_file->file_path;
-        }));
+        entries | std::views::transform(
+                      [](const auto& entry) { return entry.data_file->file_path; }));
   }
 
   std::shared_ptr<FileIO> file_io_;

--- a/src/iceberg/test/manifest_group_test.cc
+++ b/src/iceberg/test/manifest_group_test.cc
@@ -215,18 +215,18 @@ class ManifestGroupTest : public testing::TestWithParam<int8_t> {
 
   static std::vector<std::string> GetPaths(
       const std::vector<std::shared_ptr<FileScanTask>>& tasks) {
-    return tasks | std::views::transform([](const auto& task) {
-             return task->data_file()->file_path;
-           }) |
-           std::ranges::to<std::vector<std::string>>();
+    return std::ranges::to<std::vector<std::string>>(
+        tasks | std::views::transform([](const auto& task) {
+          return task->data_file()->file_path;
+        }));
   }
 
   static std::vector<std::string> GetEntryPaths(
       const std::vector<ManifestEntry>& entries) {
-    return entries | std::views::transform([](const auto& entry) {
-             return entry.data_file->file_path;
-           }) |
-           std::ranges::to<std::vector<std::string>>();
+    return std::ranges::to<std::vector<std::string>>(
+        entries | std::views::transform([](const auto& entry) {
+          return entry.data_file->file_path;
+        }));
   }
 
   std::shared_ptr<FileIO> file_io_;

--- a/src/iceberg/test/scan_test_base.h
+++ b/src/iceberg/test/scan_test_base.h
@@ -161,9 +161,8 @@ class ScanTestBase : public testing::TestWithParam<int8_t> {
   static std::vector<std::string> GetPaths(
       const std::vector<std::shared_ptr<FileScanTask>>& tasks) {
     return std::ranges::to<std::vector<std::string>>(
-        tasks | std::views::transform([](const auto& task) {
-          return task->data_file()->file_path;
-        }));
+        tasks | std::views::transform(
+                    [](const auto& task) { return task->data_file()->file_path; }));
   }
 
   /// \brief Create table metadata with the given snapshots.

--- a/src/iceberg/test/scan_test_base.h
+++ b/src/iceberg/test/scan_test_base.h
@@ -160,10 +160,10 @@ class ScanTestBase : public testing::TestWithParam<int8_t> {
   /// \brief Extract file paths from scan tasks.
   static std::vector<std::string> GetPaths(
       const std::vector<std::shared_ptr<FileScanTask>>& tasks) {
-    return tasks | std::views::transform([](const auto& task) {
-             return task->data_file()->file_path;
-           }) |
-           std::ranges::to<std::vector<std::string>>();
+    return std::ranges::to<std::vector<std::string>>(
+        tasks | std::views::transform([](const auto& task) {
+          return task->data_file()->file_path;
+        }));
   }
 
   /// \brief Create table metadata with the given snapshots.

--- a/src/iceberg/test/table_metadata_builder_test.cc
+++ b/src/iceberg/test/table_metadata_builder_test.cc
@@ -104,7 +104,7 @@ TEST(TableMetadataTest, Make) {
       auto metadata, TableMetadata::Make(*Schema, *spec, *order, "s3://bucket/test", {}));
   // Check schema fields
   ASSERT_EQ(1, metadata->schemas.size());
-  auto fields = metadata->schemas[0]->fields() | std::ranges::to<std::vector>();
+  auto fields = std::ranges::to<std::vector>(metadata->schemas[0]->fields());
   ASSERT_EQ(3, fields.size());
   EXPECT_EQ(1, fields[0].field_id());
   EXPECT_EQ("id", fields[0].name());
@@ -120,7 +120,7 @@ TEST(TableMetadataTest, Make) {
   ASSERT_EQ(1, metadata->partition_specs.size());
   EXPECT_EQ(PartitionSpec::kInitialSpecId, metadata->partition_specs[0]->spec_id());
   auto spec_fields =
-      metadata->partition_specs[0]->fields() | std::ranges::to<std::vector>();
+      std::ranges::to<std::vector>(metadata->partition_specs[0]->fields());
   ASSERT_EQ(1, spec_fields.size());
   EXPECT_EQ(PartitionSpec::kInvalidPartitionFieldId + 1, spec_fields[0].field_id());
   EXPECT_EQ(2, spec_fields[0].source_id());
@@ -129,7 +129,7 @@ TEST(TableMetadataTest, Make) {
   // Check sort order
   ASSERT_EQ(1, metadata->sort_orders.size());
   EXPECT_EQ(SortOrder::kInitialSortOrderId, metadata->sort_orders[0]->order_id());
-  auto order_fields = metadata->sort_orders[0]->fields() | std::ranges::to<std::vector>();
+  auto order_fields = std::ranges::to<std::vector>(metadata->sort_orders[0]->fields());
   ASSERT_EQ(1, order_fields.size());
   EXPECT_EQ(3, order_fields[0].source_id());
   EXPECT_EQ(SortDirection::kAscending, order_fields[0].direction());

--- a/src/iceberg/test/table_metadata_builder_test.cc
+++ b/src/iceberg/test/table_metadata_builder_test.cc
@@ -119,8 +119,7 @@ TEST(TableMetadataTest, Make) {
   // Check partition spec
   ASSERT_EQ(1, metadata->partition_specs.size());
   EXPECT_EQ(PartitionSpec::kInitialSpecId, metadata->partition_specs[0]->spec_id());
-  auto spec_fields =
-      std::ranges::to<std::vector>(metadata->partition_specs[0]->fields());
+  auto spec_fields = std::ranges::to<std::vector>(metadata->partition_specs[0]->fields());
   ASSERT_EQ(1, spec_fields.size());
   EXPECT_EQ(PartitionSpec::kInvalidPartitionFieldId + 1, spec_fields[0].field_id());
   EXPECT_EQ(2, spec_fields[0].source_id());

--- a/src/iceberg/update/snapshot_update.cc
+++ b/src/iceberg/update/snapshot_update.cc
@@ -311,10 +311,10 @@ Status SnapshotUpdate::Finalize(std::optional<Error> commit_error) {
                   "Staged snapshot is null during finalize after commit");
     auto cached_snapshot = SnapshotCache(staged_snapshot_.get());
     ICEBERG_ASSIGN_OR_RAISE(auto manifests, cached_snapshot.Manifests(ctx_->table->io()));
-    CleanUncommitted(manifests | std::views::transform([](const auto& manifest) {
-                       return manifest.manifest_path;
-                     }) |
-                     std::ranges::to<std::unordered_set<std::string>>());
+    CleanUncommitted(std::ranges::to<std::unordered_set<std::string>>(
+        manifests | std::views::transform([](const auto& manifest) {
+          return manifest.manifest_path;
+        })));
   }
 
   // Also clean up unused manifest lists created by multiple attempts

--- a/src/iceberg/update/snapshot_update.cc
+++ b/src/iceberg/update/snapshot_update.cc
@@ -312,9 +312,8 @@ Status SnapshotUpdate::Finalize(std::optional<Error> commit_error) {
     auto cached_snapshot = SnapshotCache(staged_snapshot_.get());
     ICEBERG_ASSIGN_OR_RAISE(auto manifests, cached_snapshot.Manifests(ctx_->table->io()));
     CleanUncommitted(std::ranges::to<std::unordered_set<std::string>>(
-        manifests | std::views::transform([](const auto& manifest) {
-          return manifest.manifest_path;
-        })));
+        manifests | std::views::transform(
+                        [](const auto& manifest) { return manifest.manifest_path; })));
   }
 
   // Also clean up unused manifest lists created by multiple attempts

--- a/src/iceberg/update/update_schema.cc
+++ b/src/iceberg/update/update_schema.cc
@@ -542,7 +542,7 @@ UpdateSchema& UpdateSchema::UnionByNameWith(std::shared_ptr<Schema> new_schema) 
 
 UpdateSchema& UpdateSchema::SetIdentifierFields(
     const std::span<std::string_view>& names) {
-  identifier_field_names_ = names | std::ranges::to<std::vector<std::string>>();
+  identifier_field_names_ = std::ranges::to<std::vector<std::string>>(names);
   return *this;
 }
 
@@ -589,7 +589,7 @@ Result<UpdateSchema::ApplyResult> UpdateSchema::Apply() {
     fresh_identifier_ids.push_back(field_opt->get().field_id());
   }
 
-  auto new_fields = temp_schema->fields() | std::ranges::to<std::vector<SchemaField>>();
+  auto new_fields = std::ranges::to<std::vector<SchemaField>>(temp_schema->fields());
   ICEBERG_ASSIGN_OR_RAISE(
       auto new_schema,
       Schema::Make(std::move(new_fields), schema_->schema_id(), fresh_identifier_ids));

--- a/src/iceberg/util/projection_util_internal.h
+++ b/src/iceberg/util/projection_util_internal.h
@@ -351,10 +351,9 @@ class ProjectionUtil {
           }
         }
         if (has_negative_value) {
-          auto values =
+          auto values = std::ranges::to<std::vector>(
               std::views::transform(value_set,
-                                    [](int32_t value) { return Literal::Int(value); }) |
-              std::ranges::to<std::vector>();
+                                    [](int32_t value) { return Literal::Int(value); }));
           return UnboundPredicateImpl<BoundReference>::Make(Expression::Operation::kIn,
                                                             std::move(projected->term()),
                                                             std::move(values));
@@ -455,10 +454,9 @@ class ProjectionUtil {
           }
         }
         if (has_negative_value) {
-          auto values =
+          auto values = std::ranges::to<std::vector>(
               std::views::transform(value_set,
-                                    [](int32_t value) { return Literal::Int(value); }) |
-              std::ranges::to<std::vector>();
+                                    [](int32_t value) { return Literal::Int(value); }));
           return UnboundPredicateImpl<BoundReference>::Make(Expression::Operation::kNotIn,
                                                             std::move(projected->term()),
                                                             std::move(values));

--- a/src/iceberg/util/projection_util_internal.h
+++ b/src/iceberg/util/projection_util_internal.h
@@ -351,9 +351,8 @@ class ProjectionUtil {
           }
         }
         if (has_negative_value) {
-          auto values = std::ranges::to<std::vector>(
-              std::views::transform(value_set,
-                                    [](int32_t value) { return Literal::Int(value); }));
+          auto values = std::ranges::to<std::vector>(std::views::transform(
+              value_set, [](int32_t value) { return Literal::Int(value); }));
           return UnboundPredicateImpl<BoundReference>::Make(Expression::Operation::kIn,
                                                             std::move(projected->term()),
                                                             std::move(values));
@@ -454,9 +453,8 @@ class ProjectionUtil {
           }
         }
         if (has_negative_value) {
-          auto values = std::ranges::to<std::vector>(
-              std::views::transform(value_set,
-                                    [](int32_t value) { return Literal::Int(value); }));
+          auto values = std::ranges::to<std::vector>(std::views::transform(
+              value_set, [](int32_t value) { return Literal::Int(value); }));
           return UnboundPredicateImpl<BoundReference>::Make(Expression::Operation::kNotIn,
                                                             std::move(projected->term()),
                                                             std::move(values));

--- a/src/iceberg/util/snapshot_util.cc
+++ b/src/iceberg/util/snapshot_util.cc
@@ -291,8 +291,7 @@ Result<std::vector<int64_t>> SnapshotUtil::ToIds(
   return std::ranges::to<std::vector<int64_t>>(
       snapshots |
       std::views::filter([](const auto& snapshot) { return snapshot != nullptr; }) |
-      std::views::transform(
-          [](const auto& snapshot) { return snapshot->snapshot_id; }));
+      std::views::transform([](const auto& snapshot) { return snapshot->snapshot_id; }));
 }
 
 Result<std::shared_ptr<Snapshot>> SnapshotUtil::SnapshotAfter(const Table& table,

--- a/src/iceberg/util/snapshot_util.cc
+++ b/src/iceberg/util/snapshot_util.cc
@@ -288,11 +288,11 @@ Result<std::vector<std::shared_ptr<Snapshot>>> SnapshotUtil::AncestorsOf(
 
 Result<std::vector<int64_t>> SnapshotUtil::ToIds(
     const std::vector<std::shared_ptr<Snapshot>>& snapshots) {
-  return snapshots |
-         std::views::filter([](const auto& snapshot) { return snapshot != nullptr; }) |
-         std::views::transform(
-             [](const auto& snapshot) { return snapshot->snapshot_id; }) |
-         std::ranges::to<std::vector<int64_t>>();
+  return std::ranges::to<std::vector<int64_t>>(
+      snapshots |
+      std::views::filter([](const auto& snapshot) { return snapshot != nullptr; }) |
+      std::views::transform(
+          [](const auto& snapshot) { return snapshot->snapshot_id; }));
 }
 
 Result<std::shared_ptr<Snapshot>> SnapshotUtil::SnapshotAfter(const Table& table,

--- a/src/iceberg/util/string_util.h
+++ b/src/iceberg/util/string_util.h
@@ -41,13 +41,17 @@ concept FromChars = requires(const char* p, T& v) { std::from_chars(p, p, v); };
 class ICEBERG_EXPORT StringUtils {
  public:
   static std::string ToLower(std::string_view str) {
-    return str | std::ranges::views::transform([](char c) { return std::tolower(c); }) |
-           std::ranges::to<std::string>();
+    std::string result(str);
+    std::ranges::transform(result, result.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+    return result;
   }
 
   static std::string ToUpper(std::string_view str) {
-    return str | std::ranges::views::transform([](char c) { return std::toupper(c); }) |
-           std::ranges::to<std::string>();
+    std::string result(str);
+    std::ranges::transform(result, result.begin(),
+                           [](unsigned char c) { return std::toupper(c); });
+    return result;
   }
 
   static bool EqualsIgnoreCase(std::string_view lhs, std::string_view rhs) {

--- a/src/iceberg/util/type_util.cc
+++ b/src/iceberg/util/type_util.cc
@@ -357,10 +357,9 @@ std::shared_ptr<Type> AssignFreshIdVisitor::Visit(
 }
 
 std::shared_ptr<StructType> AssignFreshIdVisitor::Visit(const StructType& type) const {
-  auto fresh_ids =
+  auto fresh_ids = std::ranges::to<std::vector<int32_t>>(
       type.fields() |
-      std::views::transform([&](const auto& /* unused */) { return next_id_(); }) |
-      std::ranges::to<std::vector<int32_t>>();
+      std::views::transform([&](const auto& /* unused */) { return next_id_(); }));
   std::vector<SchemaField> fresh_fields;
   for (size_t i = 0; i < type.fields().size(); ++i) {
     const auto& field = type.fields()[i];
@@ -402,7 +401,7 @@ Result<std::shared_ptr<Schema>> AssignFreshIds(int32_t schema_id, const Schema& 
   auto fresh_type = AssignFreshIdVisitor(std::move(next_id))
                         .Visit(internal::checked_cast<const StructType&>(schema));
   std::vector<SchemaField> fields =
-      fresh_type->fields() | std::ranges::to<std::vector<SchemaField>>();
+      std::ranges::to<std::vector<SchemaField>>(fresh_type->fields());
   ICEBERG_ASSIGN_OR_RAISE(auto identifier_field_names, schema.IdentifierFieldNames());
   return Schema::Make(std::move(fields), schema_id, identifier_field_names);
 }


### PR DESCRIPTION
## Summary
- Implement `OAuth2AuthSession` with transparent, mutex-guarded token refresh — replaces the previous `MakeOAuth2` stub that only set a static bearer header
- Add `RefreshToken()` utility for the `refresh_token` grant type, with fallback to `client_credentials` when the refresh token is absent or expired
- Add configurable `oauth2.token-refresh-margin-seconds` property (default 300 s) to control the safety margin before token expiry

This is the missing piece from the Oxla patch `005-auth-oauth2-refresh.patch` — the rest of that patch (auth manager wiring, HTTP client auth integration, SSL config) was already applied via earlier commits.

## Test plan
- [ ] Verify build succeeds with `-DICEBERG_BUILD_REST=ON`
- [ ] Verify token refresh triggers correctly when `expires_in_secs` is set and the margin is reached
- [ ] Verify `refresh_token` grant is attempted first, falling back to `client_credentials`
- [ ] Verify thread safety: concurrent `Authenticate()` calls serialize through the mutex