### PR TITLE
ci: set zizmor min-severity and min-confidence to medium

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           vcpkg install zlib:x64-windows nlohmann-json:x64-windows nanoarrow:x64-windows roaring:x64-windows cpr:x64-windows
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9 # zizmor: ignore[cache-poisoning] -- only used for build caching, no artifacts published
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Start MinIO
         shell: bash
         run: bash ci/scripts/start_minio.sh

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -42,3 +42,5 @@ jobs:
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
           advanced-security: false
+          min-severity: medium
+          min-confidence: medium


### PR DESCRIPTION
Part of https://github.com/apache/iceberg/issues/16000

Gets rid of `zizmor: ignore[cache-poisoning]`, its low confidence. 
Set `min-severity: medium` and `min-confidence: medium` in `.github/workflows/zizmor.yml` 


Validated locally:
```
GH_TOKEN=`gh auth token` uvx zizmor --min-severity medium --min-confidence medium .github/
```