### PR TITLE
feat(puffin): add puffin file reader and writer

### DIFF
--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -68,6 +68,8 @@ set(ICEBERG_SOURCES
     partition_summary.cc
     puffin/file_metadata.cc
     puffin/puffin_format.cc
+    puffin/puffin_reader.cc
+    puffin/puffin_writer.cc
     puffin/json_serde.cc
     row/arrow_array_wrapper.cc
     row/manifest_wrapper.cc

--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -175,7 +175,9 @@ set(ICEBERG_DATA_SOURCES
     deletes/roaring_position_bitmap.cc
     puffin/file_metadata.cc
     puffin/json_serde.cc
-    puffin/puffin_format.cc)
+    puffin/puffin_format.cc
+    puffin/puffin_reader.cc
+    puffin/puffin_writer.cc)
 
 set(ICEBERG_DATA_STATIC_BUILD_INTERFACE_LIBS)
 set(ICEBERG_DATA_SHARED_BUILD_INTERFACE_LIBS)

--- a/src/iceberg/meson.build
+++ b/src/iceberg/meson.build
@@ -91,6 +91,8 @@ iceberg_sources = files(
     'puffin/file_metadata.cc',
     'puffin/json_serde.cc',
     'puffin/puffin_format.cc',
+    'puffin/puffin_reader.cc',
+    'puffin/puffin_writer.cc',
     'row/arrow_array_wrapper.cc',
     'row/manifest_wrapper.cc',
     'row/partition_values.cc',

--- a/src/iceberg/meson.build
+++ b/src/iceberg/meson.build
@@ -157,6 +157,8 @@ iceberg_data_sources = files(
     'puffin/file_metadata.cc',
     'puffin/json_serde.cc',
     'puffin/puffin_format.cc',
+    'puffin/puffin_reader.cc',
+    'puffin/puffin_writer.cc',
 )
 
 # CRoaring does not export symbols, so on Windows it must

--- a/src/iceberg/puffin/meson.build
+++ b/src/iceberg/puffin/meson.build
@@ -16,6 +16,12 @@
 # under the License.
 
 install_headers(
-    ['file_metadata.h', 'puffin_format.h', 'type_fwd.h'],
+    [
+        'file_metadata.h',
+        'puffin_format.h',
+        'puffin_reader.h',
+        'puffin_writer.h',
+        'type_fwd.h',
+    ],
     subdir: 'iceberg/puffin',
 )

--- a/src/iceberg/puffin/puffin_format.cc
+++ b/src/iceberg/puffin/puffin_format.cc
@@ -36,6 +36,18 @@ constexpr std::pair<int, int> GetFlagPosition(PuffinFlag flag) {
   std::unreachable();
 }
 
+}  // namespace
+
+bool IsFlagSet(std::span<const uint8_t, 4> flags, PuffinFlag flag) {
+  auto [byte_num, bit_num] = GetFlagPosition(flag);
+  return (flags[byte_num] & (1 << bit_num)) != 0;
+}
+
+void SetFlag(std::span<uint8_t, 4> flags, PuffinFlag flag) {
+  auto [byte_num, bit_num] = GetFlagPosition(flag);
+  flags[byte_num] |= (1 << bit_num);
+}
+
 // TODO(zhaoxuan1994): Move compression logic to a unified codec interface.
 Result<std::vector<std::byte>> Compress(PuffinCompressionCodec codec,
                                         std::span<const std::byte> input) {
@@ -61,18 +73,6 @@ Result<std::vector<std::byte>> Decompress(PuffinCompressionCodec codec,
       return NotSupported("Zstd decompression is not yet supported");
   }
   std::unreachable();
-}
-
-}  // namespace
-
-bool IsFlagSet(std::span<const uint8_t, 4> flags, PuffinFlag flag) {
-  auto [byte_num, bit_num] = GetFlagPosition(flag);
-  return (flags[byte_num] & (1 << bit_num)) != 0;
-}
-
-void SetFlag(std::span<uint8_t, 4> flags, PuffinFlag flag) {
-  auto [byte_num, bit_num] = GetFlagPosition(flag);
-  flags[byte_num] |= (1 << bit_num);
 }
 
 }  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_format.h
+++ b/src/iceberg/puffin/puffin_format.h
@@ -23,8 +23,10 @@
 /// Puffin file format constants and utilities.
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <span>
+#include <vector>
 
 #include "iceberg/iceberg_export.h"
 #include "iceberg/puffin/file_metadata.h"
@@ -65,5 +67,13 @@ ICEBERG_EXPORT bool IsFlagSet(std::span<const uint8_t, 4> flags, PuffinFlag flag
 
 /// \brief Set a flag in the flags bytes.
 ICEBERG_EXPORT void SetFlag(std::span<uint8_t, 4> flags, PuffinFlag flag);
+
+/// \brief Compress data using the specified codec.
+ICEBERG_EXPORT Result<std::vector<std::byte>> Compress(PuffinCompressionCodec codec,
+                                                       std::span<const std::byte> input);
+
+/// \brief Decompress data using the specified codec.
+ICEBERG_EXPORT Result<std::vector<std::byte>> Decompress(
+    PuffinCompressionCodec codec, std::span<const std::byte> input);
 
 }  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_format.h
+++ b/src/iceberg/puffin/puffin_format.h
@@ -23,8 +23,10 @@
 /// Puffin file format constants and utilities.
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <span>
+#include <vector>
 
 #include "iceberg/iceberg_data_export.h"
 #include "iceberg/puffin/file_metadata.h"
@@ -65,5 +67,13 @@ ICEBERG_DATA_EXPORT bool IsFlagSet(std::span<const uint8_t, 4> flags, PuffinFlag
 
 /// \brief Set a flag in the flags bytes.
 ICEBERG_DATA_EXPORT void SetFlag(std::span<uint8_t, 4> flags, PuffinFlag flag);
+
+/// \brief Compress data using the specified codec.
+ICEBERG_DATA_EXPORT Result<std::vector<std::byte>> Compress(
+    PuffinCompressionCodec codec, std::span<const std::byte> input);
+
+/// \brief Decompress data using the specified codec.
+ICEBERG_DATA_EXPORT Result<std::vector<std::byte>> Decompress(
+    PuffinCompressionCodec codec, std::span<const std::byte> input);
 
 }  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_reader.cc
+++ b/src/iceberg/puffin/puffin_reader.cc
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/puffin/puffin_reader.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <string_view>
+
+#include "iceberg/puffin/json_serde_internal.h"
+#include "iceberg/puffin/puffin_format.h"
+#include "iceberg/util/endian.h"
+#include "iceberg/util/macros.h"
+
+namespace iceberg::puffin {
+
+namespace {
+
+// Validate magic bytes at the given offset.
+Status CheckMagic(std::span<const std::byte> data, int64_t offset) {
+  if (offset < 0 ||
+      offset + PuffinFormat::kMagicLength > static_cast<int64_t>(data.size())) {
+    return Invalid("Invalid file: cannot read magic at offset {}", offset);
+  }
+  auto* begin = reinterpret_cast<const uint8_t*>(data.data() + offset);
+  if (!std::equal(PuffinFormat::kMagicV1.begin(), PuffinFormat::kMagicV1.end(), begin)) {
+    return Invalid("Invalid file: expected magic at offset {}", offset);
+  }
+  return {};
+}
+
+}  // namespace
+
+PuffinReader::PuffinReader(std::span<const std::byte> data) : data_(data) {}
+
+Result<FileMetadata> PuffinReader::ReadFileMetadata() {
+  auto file_size = static_cast<int64_t>(data_.size());
+
+  if (file_size < PuffinFormat::kFooterStructLength) {
+    return Invalid("Invalid file: file length {} is less than minimal footer size {}",
+                   file_size, PuffinFormat::kFooterStructLength);
+  }
+
+  // Read footer struct from end of file
+  auto footer_struct_offset = file_size - PuffinFormat::kFooterStructLength;
+
+  // Validate footer end magic
+  ICEBERG_RETURN_UNEXPECTED(
+      CheckMagic(data_, footer_struct_offset + PuffinFormat::kFooterStructMagicOffset));
+
+  // Read payload size from footer struct
+  auto payload_size = ReadLittleEndian<int32_t>(
+      data_.data() + footer_struct_offset + PuffinFormat::kFooterStructPayloadSizeOffset);
+
+  if (payload_size < 0) {
+    return Invalid("Invalid file: negative payload size {}", payload_size);
+  }
+
+  // Calculate total footer size and validate
+  int64_t footer_size = PuffinFormat::kFooterStartMagicLength +
+                        static_cast<int64_t>(payload_size) +
+                        PuffinFormat::kFooterStructLength;
+  auto footer_offset = file_size - footer_size;
+  if (footer_offset < 0) {
+    return Invalid("Invalid file: footer size {} exceeds file size {}", footer_size,
+                   file_size);
+  }
+
+  // Validate footer start magic
+  ICEBERG_RETURN_UNEXPECTED(CheckMagic(data_, footer_offset));
+
+  // Check flags for footer compression
+  std::array<uint8_t, 4> flags{};
+  std::memcpy(
+      flags.data(),
+      data_.data() + footer_struct_offset + PuffinFormat::kFooterStructFlagsOffset, 4);
+
+  PuffinCompressionCodec footer_compression = PuffinCompressionCodec::kNone;
+  if (IsFlagSet(flags, PuffinFlag::kFooterPayloadCompressed)) {
+    footer_compression = PuffinFormat::kDefaultFooterCompressionCodec;
+  }
+
+  // Extract footer payload
+  auto payload_offset = footer_offset + PuffinFormat::kFooterStartMagicLength;
+  std::span<const std::byte> payload_span(data_.data() + payload_offset, payload_size);
+  ICEBERG_ASSIGN_OR_RAISE(auto payload_bytes,
+                          Decompress(footer_compression, payload_span));
+
+  // Parse JSON
+  std::string_view json_str(reinterpret_cast<const char*>(payload_bytes.data()),
+                            payload_bytes.size());
+  ICEBERG_ASSIGN_OR_RAISE(auto file_metadata, FileMetadataFromJsonString(json_str));
+
+  // Validate header magic
+  ICEBERG_RETURN_UNEXPECTED(CheckMagic(data_, 0));
+
+  return file_metadata;
+}
+
+Result<std::pair<BlobMetadata, std::vector<std::byte>>> PuffinReader::ReadBlob(
+    const BlobMetadata& blob_metadata) {
+  auto file_size = static_cast<int64_t>(data_.size());
+
+  if (blob_metadata.offset < 0 || blob_metadata.length < 0 ||
+      blob_metadata.offset > file_size ||
+      blob_metadata.length > file_size - blob_metadata.offset) {
+    return Invalid("Invalid blob: offset {} + length {} exceeds file size {}",
+                   blob_metadata.offset, blob_metadata.length, file_size);
+  }
+
+  std::span<const std::byte> raw_data(data_.data() + blob_metadata.offset,
+                                      blob_metadata.length);
+
+  // Determine compression codec
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto codec, PuffinCompressionCodecFromName(blob_metadata.compression_codec));
+  ICEBERG_ASSIGN_OR_RAISE(auto decompressed, Decompress(codec, raw_data));
+
+  return std::pair{blob_metadata, std::move(decompressed)};
+}
+
+Result<std::vector<std::pair<BlobMetadata, std::vector<std::byte>>>>
+PuffinReader::ReadAll(const std::vector<BlobMetadata>& blobs) {
+  std::vector<std::pair<BlobMetadata, std::vector<std::byte>>> results;
+  results.reserve(blobs.size());
+  for (const auto& blob : blobs) {
+    ICEBERG_ASSIGN_OR_RAISE(auto blob_pair, ReadBlob(blob));
+    results.push_back(std::move(blob_pair));
+  }
+  return results;
+}
+
+}  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_reader.cc
+++ b/src/iceberg/puffin/puffin_reader.cc
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/puffin/puffin_reader.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+
+#include "iceberg/file_io.h"
+#include "iceberg/puffin/json_serde_internal.h"
+#include "iceberg/puffin/puffin_format.h"
+#include "iceberg/util/endian.h"
+#include "iceberg/util/macros.h"
+
+namespace iceberg::puffin {
+
+namespace {
+
+// Validate magic bytes in a buffer at offset 0.
+Status CheckMagic(std::span<const std::byte> data) {
+  if (static_cast<int64_t>(data.size()) < PuffinFormat::kMagicLength) {
+    return Invalid("Invalid file: buffer too small for magic");
+  }
+  auto* begin = reinterpret_cast<const uint8_t*>(data.data());
+  if (!std::equal(PuffinFormat::kMagicV1.begin(), PuffinFormat::kMagicV1.end(), begin)) {
+    return Invalid(
+        "Invalid file: expected magic, got [{:#04x}, {:#04x}, {:#04x}, {:#04x}]",
+        begin[0], begin[1], begin[2], begin[3]);
+  }
+  return {};
+}
+
+// Validate that no unknown flag bits are set.
+Status CheckUnknownFlags(std::span<const uint8_t, 4> flags) {
+  constexpr uint8_t kKnownBitsMask = 0x01;
+  if ((flags[0] & ~kKnownBitsMask) != 0 || flags[1] != 0 || flags[2] != 0 ||
+      flags[3] != 0) {
+    return Invalid(
+        "Invalid file: unknown footer flags set [{:#04x}, {:#04x}, {:#04x}, {:#04x}]",
+        flags[0], flags[1], flags[2], flags[3]);
+  }
+  return {};
+}
+
+}  // namespace
+
+PuffinReader::PuffinReader(std::unique_ptr<SeekableInputStream> stream, int64_t file_size,
+                           std::optional<int64_t> known_footer_size)
+    : stream_(std::move(stream)),
+      file_size_(file_size),
+      known_footer_size_(known_footer_size) {}
+
+PuffinReader::~PuffinReader() = default;
+
+Result<std::unique_ptr<PuffinReader>> PuffinReader::Make(
+    std::unique_ptr<InputFile> input_file, std::optional<int64_t> footer_size) {
+  if (!input_file) {
+    return InvalidArgument("input_file must not be null");
+  }
+  ICEBERG_ASSIGN_OR_RAISE(auto file_size, input_file->Size());
+  ICEBERG_ASSIGN_OR_RAISE(auto stream, input_file->Open());
+  return std::unique_ptr<PuffinReader>(
+      new PuffinReader(std::move(stream), file_size, footer_size));
+}
+
+Result<std::vector<std::byte>> PuffinReader::ReadBytes(int64_t offset, int64_t length) {
+  if (offset < 0 || length < 0 || offset > file_size_ || length > file_size_ - offset) {
+    return Invalid("Read out of bounds: offset {} + length {} exceeds file size {}",
+                   offset, length, file_size_);
+  }
+  std::vector<std::byte> buf(length);
+  ICEBERG_RETURN_UNEXPECTED(stream_->ReadFully(offset, buf));
+  return buf;
+}
+
+Result<FileMetadata> PuffinReader::ReadFileMetadata() {
+  if (file_size_ < PuffinFormat::kFooterStructLength) {
+    return Invalid("Invalid file: file length {} is less than minimal footer size {}",
+                   file_size_, PuffinFormat::kFooterStructLength);
+  }
+
+  // Validate header magic
+  ICEBERG_ASSIGN_OR_RAISE(auto header_bytes, ReadBytes(0, PuffinFormat::kMagicLength));
+  ICEBERG_RETURN_UNEXPECTED(CheckMagic(header_bytes));
+
+  // Read footer struct from end of file
+  auto footer_struct_offset = file_size_ - PuffinFormat::kFooterStructLength;
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto footer_struct,
+      ReadBytes(footer_struct_offset, PuffinFormat::kFooterStructLength));
+
+  // Validate footer end magic
+  std::span<const std::byte> footer_end_magic(
+      footer_struct.data() + PuffinFormat::kFooterStructMagicOffset,
+      PuffinFormat::kMagicLength);
+  ICEBERG_RETURN_UNEXPECTED(CheckMagic(footer_end_magic));
+
+  // Read payload size
+  auto payload_size = ReadLittleEndian<int32_t>(
+      footer_struct.data() + PuffinFormat::kFooterStructPayloadSizeOffset);
+
+  if (payload_size < 0) {
+    return Invalid("Invalid file: negative payload size {}", payload_size);
+  }
+
+  // Calculate total footer size and validate
+  int64_t footer_size = PuffinFormat::kFooterStartMagicLength +
+                        static_cast<int64_t>(payload_size) +
+                        PuffinFormat::kFooterStructLength;
+  auto footer_offset = file_size_ - footer_size;
+  if (footer_offset < 0) {
+    return Invalid("Invalid file: footer size {} exceeds file size {}", footer_size,
+                   file_size_);
+  }
+
+  // Validate footer start magic
+  ICEBERG_ASSIGN_OR_RAISE(auto footer_start_magic,
+                          ReadBytes(footer_offset, PuffinFormat::kMagicLength));
+  ICEBERG_RETURN_UNEXPECTED(CheckMagic(footer_start_magic));
+
+  // Check flags
+  std::array<uint8_t, 4> flags{};
+  std::memcpy(flags.data(), footer_struct.data() + PuffinFormat::kFooterStructFlagsOffset,
+              4);
+  ICEBERG_RETURN_UNEXPECTED(CheckUnknownFlags(flags));
+
+  PuffinCompressionCodec footer_compression = PuffinCompressionCodec::kNone;
+  if (IsFlagSet(flags, PuffinFlag::kFooterPayloadCompressed)) {
+    footer_compression = PuffinFormat::kDefaultFooterCompressionCodec;
+  }
+
+  // Read and decompress footer payload
+  auto payload_offset = footer_offset + PuffinFormat::kFooterStartMagicLength;
+  ICEBERG_ASSIGN_OR_RAISE(auto payload_bytes, ReadBytes(payload_offset, payload_size));
+  ICEBERG_ASSIGN_OR_RAISE(auto decompressed,
+                          Decompress(footer_compression, payload_bytes));
+
+  // Parse JSON
+  std::string_view json_str(reinterpret_cast<const char*>(decompressed.data()),
+                            decompressed.size());
+  return FileMetadataFromJsonString(json_str);
+}
+
+Result<std::pair<BlobMetadata, std::vector<std::byte>>> PuffinReader::ReadBlob(
+    const BlobMetadata& blob_metadata) {
+  if (blob_metadata.offset < 0 || blob_metadata.length < 0 ||
+      blob_metadata.offset > file_size_ ||
+      blob_metadata.length > file_size_ - blob_metadata.offset) {
+    return Invalid("Invalid blob: offset {} + length {} exceeds file size {}",
+                   blob_metadata.offset, blob_metadata.length, file_size_);
+  }
+
+  ICEBERG_ASSIGN_OR_RAISE(auto raw_data,
+                          ReadBytes(blob_metadata.offset, blob_metadata.length));
+
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto codec, PuffinCompressionCodecFromName(blob_metadata.compression_codec));
+  ICEBERG_ASSIGN_OR_RAISE(auto decompressed, Decompress(codec, raw_data));
+
+  return std::pair{blob_metadata, std::move(decompressed)};
+}
+
+Result<std::vector<std::pair<BlobMetadata, std::vector<std::byte>>>>
+PuffinReader::ReadAll(const std::vector<BlobMetadata>& blobs) {
+  // Sort by offset for sequential I/O access pattern
+  std::vector<const BlobMetadata*> sorted;
+  sorted.reserve(blobs.size());
+  for (const auto& blob : blobs) {
+    sorted.push_back(&blob);
+  }
+  std::ranges::sort(sorted,
+                    [](const auto* a, const auto* b) { return a->offset < b->offset; });
+
+  std::vector<std::pair<BlobMetadata, std::vector<std::byte>>> results;
+  results.reserve(blobs.size());
+  for (const auto* blob : sorted) {
+    ICEBERG_ASSIGN_OR_RAISE(auto blob_pair, ReadBlob(*blob));
+    results.push_back(std::move(blob_pair));
+  }
+  return results;
+}
+
+}  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_reader.cc
+++ b/src/iceberg/puffin/puffin_reader.cc
@@ -23,6 +23,8 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <limits>
+#include <span>
 #include <string_view>
 
 #include "iceberg/file_io.h"
@@ -35,30 +37,108 @@ namespace iceberg::puffin {
 
 namespace {
 
-// Validate magic bytes in a buffer at offset 0.
-Status CheckMagic(std::span<const std::byte> data) {
-  if (static_cast<int64_t>(data.size()) < PuffinFormat::kMagicLength) {
-    return Invalid("Invalid file: buffer too small for magic");
-  }
-  auto* begin = reinterpret_cast<const uint8_t*>(data.data());
-  if (!std::equal(PuffinFormat::kMagicV1.begin(), PuffinFormat::kMagicV1.end(), begin)) {
-    return Invalid(
-        "Invalid file: expected magic, got [{:#04x}, {:#04x}, {:#04x}, {:#04x}]",
-        begin[0], begin[1], begin[2], begin[3]);
-  }
+struct FooterInfo {
+  int32_t payload_size;
+  PuffinCompressionCodec compression;
+};
+
+Status CheckMagic(std::span<const std::byte> data, int64_t offset = 0) {
+  ICEBERG_PRECHECK(offset >= 0, "Invalid file: magic offset {} is negative", offset);
+  auto offset_size = static_cast<size_t>(offset);
+  ICEBERG_PRECHECK(offset_size <= data.size() &&
+                       data.size() - offset_size >= PuffinFormat::kMagicLength,
+                   "Invalid file: buffer too small for magic at offset {}", offset);
+  auto* begin = reinterpret_cast<const uint8_t*>(data.data() + offset_size);
+  ICEBERG_PRECHECK(
+      std::equal(PuffinFormat::kMagicV1.cbegin(), PuffinFormat::kMagicV1.cend(), begin),
+      "Invalid file: expected magic at offset {}, got [{:#04x}, {:#04x}, {:#04x}, "
+      "{:#04x}]",
+      offset, begin[0], begin[1], begin[2], begin[3]);
   return {};
 }
 
-// Validate that no unknown flag bits are set.
 Status CheckUnknownFlags(std::span<const uint8_t, 4> flags) {
   constexpr uint8_t kKnownBitsMask = 0x01;
-  if ((flags[0] & ~kKnownBitsMask) != 0 || flags[1] != 0 || flags[2] != 0 ||
-      flags[3] != 0) {
-    return Invalid(
-        "Invalid file: unknown footer flags set [{:#04x}, {:#04x}, {:#04x}, {:#04x}]",
-        flags[0], flags[1], flags[2], flags[3]);
-  }
+  ICEBERG_PRECHECK(
+      (flags[0] & ~kKnownBitsMask) == 0 && flags[1] == 0 && flags[2] == 0 &&
+          flags[3] == 0,
+      "Invalid file: unknown footer flags set [{:#04x}, {:#04x}, {:#04x}, {:#04x}]",
+      flags[0], flags[1], flags[2], flags[3]);
   return {};
+}
+
+Result<int32_t> FooterPayloadSize(std::span<const std::byte> footer_struct) {
+  ICEBERG_PRECHECK(footer_struct.size() >= PuffinFormat::kFooterStructLength,
+                   "Invalid file: footer struct is too small");
+  auto payload_size = ReadLittleEndian<int32_t>(
+      footer_struct.data() + PuffinFormat::kFooterStructPayloadSizeOffset);
+  ICEBERG_PRECHECK(payload_size >= 0, "Invalid file: negative payload size {}",
+                   payload_size);
+  return payload_size;
+}
+
+Result<std::array<uint8_t, 4>> DecodeFlags(std::span<const std::byte> footer_struct) {
+  ICEBERG_PRECHECK(footer_struct.size() >= PuffinFormat::kFooterStructLength,
+                   "Invalid file: footer struct is too small");
+  std::array<uint8_t, 4> flags{};
+  std::memcpy(flags.data(), footer_struct.data() + PuffinFormat::kFooterStructFlagsOffset,
+              flags.size());
+  ICEBERG_RETURN_UNEXPECTED(CheckUnknownFlags(flags));
+  return flags;
+}
+
+PuffinCompressionCodec FooterCompressionCodec(std::span<const uint8_t, 4> flags) {
+  if (IsFlagSet(flags, PuffinFlag::kFooterPayloadCompressed)) {
+    return PuffinFormat::kDefaultFooterCompressionCodec;
+  }
+  return PuffinCompressionCodec::kNone;
+}
+
+Status CheckFooterSize(int64_t footer_size, int32_t payload_size) {
+  auto expected_footer_size = PuffinFormat::kFooterStartMagicLength +
+                              static_cast<int64_t>(payload_size) +
+                              PuffinFormat::kFooterStructLength;
+  ICEBERG_PRECHECK(footer_size == expected_footer_size,
+                   "Invalid file: footer size {} does not match payload size {}",
+                   footer_size, payload_size);
+  return {};
+}
+
+Result<FooterInfo> DecodeFooterInfo(std::span<const std::byte> footer,
+                                    int64_t footer_size) {
+  ICEBERG_PRECHECK(footer_size >= PuffinFormat::kFooterStartMagicLength +
+                                      PuffinFormat::kFooterStructLength,
+                   "Invalid file: footer size {} is too small", footer_size);
+  ICEBERG_PRECHECK(static_cast<uint64_t>(footer_size) <= footer.size(),
+                   "Invalid file: footer size {} exceeds buffer size {}", footer_size,
+                   footer.size());
+
+  ICEBERG_RETURN_UNEXPECTED(CheckMagic(footer, PuffinFormat::kFooterStartMagicOffset));
+
+  auto footer_struct_offset = footer_size - PuffinFormat::kFooterStructLength;
+  std::span<const std::byte> footer_struct(footer.data() + footer_struct_offset,
+                                           PuffinFormat::kFooterStructLength);
+  ICEBERG_RETURN_UNEXPECTED(
+      CheckMagic(footer_struct, PuffinFormat::kFooterStructMagicOffset));
+
+  ICEBERG_ASSIGN_OR_RAISE(auto payload_size, FooterPayloadSize(footer_struct));
+  ICEBERG_RETURN_UNEXPECTED(CheckFooterSize(footer_size, payload_size));
+
+  ICEBERG_ASSIGN_OR_RAISE(auto flags, DecodeFlags(footer_struct));
+  return FooterInfo{.payload_size = payload_size,
+                    .compression = FooterCompressionCodec(flags)};
+}
+
+Result<FileMetadata> ParseFileMetadata(std::span<const std::byte> payload,
+                                       PuffinCompressionCodec compression) {
+  std::vector<std::byte> decompressed;
+  if (compression != PuffinCompressionCodec::kNone) {
+    ICEBERG_ASSIGN_OR_RAISE(decompressed, Decompress(compression, payload));
+    payload = decompressed;
+  }
+
+  return FileMetadataFromJsonString(
+      std::string_view(reinterpret_cast<const char*>(payload.data()), payload.size()));
 }
 
 }  // namespace
@@ -72,108 +152,88 @@ PuffinReader::PuffinReader(std::unique_ptr<SeekableInputStream> stream, int64_t 
 PuffinReader::~PuffinReader() = default;
 
 Result<std::unique_ptr<PuffinReader>> PuffinReader::Make(
-    std::unique_ptr<InputFile> input_file, std::optional<int64_t> footer_size) {
-  if (!input_file) {
-    return InvalidArgument("input_file must not be null");
+    std::unique_ptr<InputFile> input_file, std::optional<int64_t> footer_size,
+    std::optional<int64_t> file_size) {
+  ICEBERG_PRECHECK(input_file, "Input file must not be null");
+  int64_t resolved_file_size = 0;
+  if (file_size.has_value()) {
+    ICEBERG_PRECHECK(*file_size >= 0, "File size must not be negative: {}", *file_size);
+    resolved_file_size = *file_size;
+  } else {
+    ICEBERG_ASSIGN_OR_RAISE(resolved_file_size, input_file->Size());
   }
-  ICEBERG_ASSIGN_OR_RAISE(auto file_size, input_file->Size());
+  if (footer_size.has_value()) {
+    ICEBERG_PRECHECK(*footer_size > 0, "Footer size must be positive: {}", *footer_size);
+    ICEBERG_PRECHECK(*footer_size <= resolved_file_size - PuffinFormat::kMagicLength,
+                     "Footer size {} exceeds file size {}", *footer_size,
+                     resolved_file_size);
+    ICEBERG_PRECHECK(*footer_size <= std::numeric_limits<int32_t>::max(),
+                     "Footer size {} is too large", *footer_size);
+  }
   ICEBERG_ASSIGN_OR_RAISE(auto stream, input_file->Open());
   return std::unique_ptr<PuffinReader>(
-      new PuffinReader(std::move(stream), file_size, footer_size));
+      new PuffinReader(std::move(stream), resolved_file_size, footer_size));
 }
 
 Result<std::vector<std::byte>> PuffinReader::ReadBytes(int64_t offset, int64_t length) {
-  if (offset < 0 || length < 0 || offset > file_size_ || length > file_size_ - offset) {
-    return Invalid("Read out of bounds: offset {} + length {} exceeds file size {}",
-                   offset, length, file_size_);
-  }
+  ICEBERG_PRECHECK(!closed_, "Reader already closed");
+  ICEBERG_PRECHECK(offset >= 0, "Offset must not be negative: {}", offset);
+  ICEBERG_PRECHECK(length >= 0, "Length must not be negative: {}", length);
+  ICEBERG_PRECHECK(offset <= file_size_, "Offset {} exceeds file size {}", offset,
+                   file_size_);
+  ICEBERG_PRECHECK(length <= file_size_ - offset,
+                   "Length {} exceeds file size {} at offset {}", length, file_size_,
+                   offset);
   std::vector<std::byte> buf(length);
   ICEBERG_RETURN_UNEXPECTED(stream_->ReadFully(offset, buf));
   return buf;
 }
 
-Result<FileMetadata> PuffinReader::ReadFileMetadata() {
-  if (file_size_ < PuffinFormat::kFooterStructLength) {
-    return Invalid("Invalid file: file length {} is less than minimal footer size {}",
-                   file_size_, PuffinFormat::kFooterStructLength);
+Result<int64_t> PuffinReader::FooterSize() {
+  if (known_footer_size_.has_value()) {
+    return *known_footer_size_;
   }
 
-  // Validate header magic
+  ICEBERG_ASSIGN_OR_RAISE(auto footer_struct,
+                          ReadBytes(file_size_ - PuffinFormat::kFooterStructLength,
+                                    PuffinFormat::kFooterStructLength));
+  ICEBERG_RETURN_UNEXPECTED(
+      CheckMagic(footer_struct, PuffinFormat::kFooterStructMagicOffset));
+
+  ICEBERG_ASSIGN_OR_RAISE(auto payload_size, FooterPayloadSize(footer_struct));
+  known_footer_size_ = PuffinFormat::kFooterStartMagicLength +
+                       static_cast<int64_t>(payload_size) +
+                       PuffinFormat::kFooterStructLength;
+  return *known_footer_size_;
+}
+
+Result<std::vector<std::byte>> PuffinReader::ReadFooter(int64_t footer_size) {
+  return ReadBytes(file_size_ - footer_size, footer_size);
+}
+
+Result<FileMetadata> PuffinReader::ReadFileMetadata() {
   ICEBERG_ASSIGN_OR_RAISE(auto header_bytes, ReadBytes(0, PuffinFormat::kMagicLength));
   ICEBERG_RETURN_UNEXPECTED(CheckMagic(header_bytes));
 
-  // Read footer struct from end of file
-  auto footer_struct_offset = file_size_ - PuffinFormat::kFooterStructLength;
-  ICEBERG_ASSIGN_OR_RAISE(
-      auto footer_struct,
-      ReadBytes(footer_struct_offset, PuffinFormat::kFooterStructLength));
-
-  // Validate footer end magic
-  std::span<const std::byte> footer_end_magic(
-      footer_struct.data() + PuffinFormat::kFooterStructMagicOffset,
-      PuffinFormat::kMagicLength);
-  ICEBERG_RETURN_UNEXPECTED(CheckMagic(footer_end_magic));
-
-  // Read payload size
-  auto payload_size = ReadLittleEndian<int32_t>(
-      footer_struct.data() + PuffinFormat::kFooterStructPayloadSizeOffset);
-
-  if (payload_size < 0) {
-    return Invalid("Invalid file: negative payload size {}", payload_size);
-  }
-
-  // Calculate total footer size and validate
-  int64_t footer_size = PuffinFormat::kFooterStartMagicLength +
-                        static_cast<int64_t>(payload_size) +
-                        PuffinFormat::kFooterStructLength;
-  auto footer_offset = file_size_ - footer_size;
-  if (footer_offset < 0) {
-    return Invalid("Invalid file: footer size {} exceeds file size {}", footer_size,
-                   file_size_);
-  }
-
-  // Validate footer start magic
-  ICEBERG_ASSIGN_OR_RAISE(auto footer_start_magic,
-                          ReadBytes(footer_offset, PuffinFormat::kMagicLength));
-  ICEBERG_RETURN_UNEXPECTED(CheckMagic(footer_start_magic));
-
-  // Check flags
-  std::array<uint8_t, 4> flags{};
-  std::memcpy(flags.data(), footer_struct.data() + PuffinFormat::kFooterStructFlagsOffset,
-              4);
-  ICEBERG_RETURN_UNEXPECTED(CheckUnknownFlags(flags));
-
-  PuffinCompressionCodec footer_compression = PuffinCompressionCodec::kNone;
-  if (IsFlagSet(flags, PuffinFlag::kFooterPayloadCompressed)) {
-    footer_compression = PuffinFormat::kDefaultFooterCompressionCodec;
-  }
-
-  // Read and decompress footer payload
-  auto payload_offset = footer_offset + PuffinFormat::kFooterStartMagicLength;
-  ICEBERG_ASSIGN_OR_RAISE(auto payload_bytes, ReadBytes(payload_offset, payload_size));
-  ICEBERG_ASSIGN_OR_RAISE(auto decompressed,
-                          Decompress(footer_compression, payload_bytes));
-
-  // Parse JSON
-  std::string_view json_str(reinterpret_cast<const char*>(decompressed.data()),
-                            decompressed.size());
-  return FileMetadataFromJsonString(json_str);
+  ICEBERG_ASSIGN_OR_RAISE(auto footer_size, FooterSize());
+  ICEBERG_ASSIGN_OR_RAISE(auto footer, ReadFooter(footer_size));
+  ICEBERG_ASSIGN_OR_RAISE(auto footer_info, DecodeFooterInfo(footer, footer_size));
+  std::span<const std::byte> payload_bytes(
+      footer.data() + PuffinFormat::kFooterStartMagicLength, footer_info.payload_size);
+  return ParseFileMetadata(payload_bytes, footer_info.compression);
 }
 
 Result<std::pair<BlobMetadata, std::vector<std::byte>>> PuffinReader::ReadBlob(
     const BlobMetadata& blob_metadata) {
-  if (blob_metadata.offset < 0 || blob_metadata.length < 0 ||
-      blob_metadata.offset > file_size_ ||
-      blob_metadata.length > file_size_ - blob_metadata.offset) {
-    return Invalid("Invalid blob: offset {} + length {} exceeds file size {}",
-                   blob_metadata.offset, blob_metadata.length, file_size_);
-  }
-
   ICEBERG_ASSIGN_OR_RAISE(auto raw_data,
                           ReadBytes(blob_metadata.offset, blob_metadata.length));
 
   ICEBERG_ASSIGN_OR_RAISE(
       auto codec, PuffinCompressionCodecFromName(blob_metadata.compression_codec));
+  if (codec == PuffinCompressionCodec::kNone) {
+    return std::pair{blob_metadata, std::move(raw_data)};
+  }
+
   ICEBERG_ASSIGN_OR_RAISE(auto decompressed, Decompress(codec, raw_data));
 
   return std::pair{blob_metadata, std::move(decompressed)};
@@ -197,6 +257,15 @@ PuffinReader::ReadAll(const std::vector<BlobMetadata>& blobs) {
     results.push_back(std::move(blob_pair));
   }
   return results;
+}
+
+Status PuffinReader::Close() {
+  if (closed_) {
+    return {};
+  }
+  ICEBERG_RETURN_UNEXPECTED(stream_->Close());
+  closed_ = true;
+  return {};
 }
 
 }  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_reader.h
+++ b/src/iceberg/puffin/puffin_reader.h
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+/// \file iceberg/puffin/puffin_reader.h
+/// Puffin file reader.
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "iceberg/iceberg_export.h"
+#include "iceberg/puffin/file_metadata.h"
+#include "iceberg/result.h"
+
+namespace iceberg::puffin {
+
+/// \brief Reader for Puffin files.
+///
+/// Parses a Puffin file from an in-memory buffer. Usage:
+///   PuffinReader reader(file_data);
+///   auto metadata = reader.ReadFileMetadata();
+///   auto blob = reader.ReadBlob(metadata.value().blobs[0]);
+class ICEBERG_EXPORT PuffinReader {
+ public:
+  /// \brief Construct a reader from file data.
+  explicit PuffinReader(std::span<const std::byte> data);
+
+  /// \brief Read and return the file metadata from the footer.
+  Result<FileMetadata> ReadFileMetadata();
+
+  /// \brief Read a specific blob's data by its metadata.
+  /// \param blob_metadata The metadata describing the blob to read.
+  /// \return A pair of (BlobMetadata, decompressed data), or an error.
+  Result<std::pair<BlobMetadata, std::vector<std::byte>>> ReadBlob(
+      const BlobMetadata& blob_metadata);
+
+  /// \brief Read all blobs described in the file metadata.
+  /// \return A vector of (BlobMetadata, decompressed data) pairs, or an error.
+  Result<std::vector<std::pair<BlobMetadata, std::vector<std::byte>>>> ReadAll(
+      const std::vector<BlobMetadata>& blobs);
+
+ private:
+  std::span<const std::byte> data_;
+};
+
+}  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_reader.h
+++ b/src/iceberg/puffin/puffin_reader.h
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+/// \file iceberg/puffin/puffin_reader.h
+/// Puffin file reader.
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "iceberg/iceberg_data_export.h"
+#include "iceberg/puffin/file_metadata.h"
+#include "iceberg/result.h"
+
+namespace iceberg {
+class InputFile;
+class SeekableInputStream;
+}  // namespace iceberg
+
+namespace iceberg::puffin {
+
+/// \brief Reader for Puffin files.
+///
+/// Reads from an InputFile with seek support for efficient blob access.
+class ICEBERG_DATA_EXPORT PuffinReader {
+ public:
+  /// \brief Create a PuffinReader for the given input file.
+  /// \param input_file The input file to read from.
+  /// \param footer_size Optional known footer size hint to avoid an extra seek.
+  static Result<std::unique_ptr<PuffinReader>> Make(
+      std::unique_ptr<InputFile> input_file,
+      std::optional<int64_t> footer_size = std::nullopt);
+
+  ~PuffinReader();
+
+  /// \brief Read and return the file metadata from the footer.
+  Result<FileMetadata> ReadFileMetadata();
+
+  /// \brief Read a specific blob's data by its metadata.
+  /// \param blob_metadata The metadata describing the blob to read.
+  /// \return A pair of (BlobMetadata, decompressed data), or an error.
+  Result<std::pair<BlobMetadata, std::vector<std::byte>>> ReadBlob(
+      const BlobMetadata& blob_metadata);
+
+  /// \brief Read all blobs described in the file metadata.
+  /// \return A vector of (BlobMetadata, decompressed data) pairs, or an error.
+  Result<std::vector<std::pair<BlobMetadata, std::vector<std::byte>>>> ReadAll(
+      const std::vector<BlobMetadata>& blobs);
+
+ private:
+  PuffinReader(std::unique_ptr<SeekableInputStream> stream, int64_t file_size,
+               std::optional<int64_t> known_footer_size);
+
+  /// Opened input stream.
+  std::unique_ptr<SeekableInputStream> stream_;
+  /// Total file size.
+  int64_t file_size_;
+  /// Known footer size hint (avoids one seek if provided).
+  std::optional<int64_t> known_footer_size_;
+
+  Result<std::vector<std::byte>> ReadBytes(int64_t offset, int64_t length);
+};
+
+}  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_reader.h
+++ b/src/iceberg/puffin/puffin_reader.h
@@ -32,11 +32,7 @@
 #include "iceberg/iceberg_data_export.h"
 #include "iceberg/puffin/file_metadata.h"
 #include "iceberg/result.h"
-
-namespace iceberg {
-class InputFile;
-class SeekableInputStream;
-}  // namespace iceberg
+#include "iceberg/type_fwd.h"
 
 namespace iceberg::puffin {
 
@@ -48,9 +44,11 @@ class ICEBERG_DATA_EXPORT PuffinReader {
   /// \brief Create a PuffinReader for the given input file.
   /// \param input_file The input file to read from.
   /// \param footer_size Optional known footer size hint to avoid an extra seek.
+  /// \param file_size Optional known file size hint to avoid fetching size.
   static Result<std::unique_ptr<PuffinReader>> Make(
       std::unique_ptr<InputFile> input_file,
-      std::optional<int64_t> footer_size = std::nullopt);
+      std::optional<int64_t> footer_size = std::nullopt,
+      std::optional<int64_t> file_size = std::nullopt);
 
   ~PuffinReader();
 
@@ -68,9 +66,16 @@ class ICEBERG_DATA_EXPORT PuffinReader {
   Result<std::vector<std::pair<BlobMetadata, std::vector<std::byte>>>> ReadAll(
       const std::vector<BlobMetadata>& blobs);
 
+  /// \brief Close the underlying input stream.
+  Status Close();
+
  private:
   PuffinReader(std::unique_ptr<SeekableInputStream> stream, int64_t file_size,
                std::optional<int64_t> known_footer_size);
+
+  Result<std::vector<std::byte>> ReadBytes(int64_t offset, int64_t length);
+  Result<int64_t> FooterSize();
+  Result<std::vector<std::byte>> ReadFooter(int64_t footer_size);
 
   /// Opened input stream.
   std::unique_ptr<SeekableInputStream> stream_;
@@ -78,8 +83,8 @@ class ICEBERG_DATA_EXPORT PuffinReader {
   int64_t file_size_;
   /// Known footer size hint (avoids one seek if provided).
   std::optional<int64_t> known_footer_size_;
-
-  Result<std::vector<std::byte>> ReadBytes(int64_t offset, int64_t length);
+  /// Whether the reader has been closed.
+  bool closed_ = false;
 };
 
 }  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_writer.cc
+++ b/src/iceberg/puffin/puffin_writer.cc
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/puffin/puffin_writer.h"
+
+#include <array>
+
+#include "iceberg/puffin/json_serde_internal.h"
+#include "iceberg/puffin/puffin_format.h"
+#include "iceberg/util/endian.h"
+#include "iceberg/util/macros.h"
+
+namespace iceberg::puffin {
+
+PuffinWriter::PuffinWriter(PuffinCompressionCodec default_codec)
+    : default_codec_(default_codec) {}
+
+void PuffinWriter::WriteHeader() {
+  if (header_written_) return;
+  const auto& magic = PuffinFormat::kMagicV1;
+  buffer_.insert(buffer_.end(), reinterpret_cast<const std::byte*>(magic.data()),
+                 reinterpret_cast<const std::byte*>(magic.data() + magic.size()));
+  header_written_ = true;
+}
+
+Result<BlobMetadata> PuffinWriter::Add(const Blob& blob) {
+  if (finished_) {
+    return Invalid("Writer already finished");
+  }
+
+  WriteHeader();
+
+  auto codec = blob.requested_compression.value_or(default_codec_);
+  std::span<const std::byte> input_span(
+      reinterpret_cast<const std::byte*>(blob.data.data()), blob.data.size());
+  ICEBERG_ASSIGN_OR_RAISE(auto compressed, Compress(codec, input_span));
+
+  auto offset = static_cast<int64_t>(buffer_.size());
+  auto length = static_cast<int64_t>(compressed.size());
+  buffer_.insert(buffer_.end(), compressed.begin(), compressed.end());
+
+  auto codec_name = CodecName(codec);
+  BlobMetadata metadata{
+      .type = blob.type,
+      .input_fields = blob.input_fields,
+      .snapshot_id = blob.snapshot_id,
+      .sequence_number = blob.sequence_number,
+      .offset = offset,
+      .length = length,
+      .compression_codec = std::string(codec_name),
+      .properties = blob.properties,
+  };
+  written_blobs_metadata_.push_back(metadata);
+  return metadata;
+}
+
+Result<std::vector<std::byte>> PuffinWriter::Finish(
+    std::unordered_map<std::string, std::string> properties) {
+  if (finished_) {
+    return Invalid("Writer already finished");
+  }
+
+  WriteHeader();
+
+  FileMetadata file_metadata{
+      .blobs = written_blobs_metadata_,
+      .properties = std::move(properties),
+  };
+
+  auto footer_json = ToJsonString(file_metadata);
+  auto footer_payload = std::span<const std::byte>(
+      reinterpret_cast<const std::byte*>(footer_json.data()), footer_json.size());
+
+  // Footer start magic
+  auto footer_start = static_cast<int64_t>(buffer_.size());
+  const auto& magic = PuffinFormat::kMagicV1;
+  buffer_.insert(buffer_.end(), reinterpret_cast<const std::byte*>(magic.data()),
+                 reinterpret_cast<const std::byte*>(magic.data() + magic.size()));
+
+  // Footer payload
+  buffer_.insert(buffer_.end(), footer_payload.begin(), footer_payload.end());
+
+  // Footer struct: payload_size (4) + flags (4) + magic (4)
+  auto payload_size = static_cast<int32_t>(footer_payload.size());
+  std::array<std::byte, 4> size_buf{};
+  WriteLittleEndian(payload_size, size_buf.data());
+  buffer_.insert(buffer_.end(), size_buf.begin(), size_buf.end());
+
+  // Flags (no compression for now)
+  std::array<std::byte, 4> flags{};
+  buffer_.insert(buffer_.end(), flags.begin(), flags.end());
+
+  // Footer end magic
+  buffer_.insert(buffer_.end(), reinterpret_cast<const std::byte*>(magic.data()),
+                 reinterpret_cast<const std::byte*>(magic.data() + magic.size()));
+
+  footer_size_ = static_cast<int64_t>(buffer_.size()) - footer_start;
+  finished_ = true;
+  return std::move(buffer_);
+}
+
+const std::vector<BlobMetadata>& PuffinWriter::written_blobs_metadata() const {
+  return written_blobs_metadata_;
+}
+
+std::optional<int64_t> PuffinWriter::footer_size() const { return footer_size_; }
+
+}  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_writer.cc
+++ b/src/iceberg/puffin/puffin_writer.cc
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/puffin/puffin_writer.h"
+
+#include <array>
+
+#include "iceberg/file_io.h"
+#include "iceberg/puffin/json_serde_internal.h"
+#include "iceberg/puffin/puffin_format.h"
+#include "iceberg/util/endian.h"
+#include "iceberg/util/macros.h"
+
+namespace iceberg::puffin {
+
+PuffinWriter::PuffinWriter(std::unique_ptr<PositionOutputStream> stream,
+                           std::unordered_map<std::string, std::string> properties,
+                           PuffinCompressionCodec default_codec, bool compress_footer)
+    : stream_(std::move(stream)),
+      properties_(std::move(properties)),
+      default_codec_(default_codec),
+      compress_footer_(compress_footer) {}
+
+PuffinWriter::~PuffinWriter() = default;
+
+Result<std::unique_ptr<PuffinWriter>> PuffinWriter::Make(
+    std::unique_ptr<OutputFile> output_file,
+    std::unordered_map<std::string, std::string> properties,
+    PuffinCompressionCodec default_codec, bool compress_footer) {
+  if (!output_file) {
+    return InvalidArgument("output_file must not be null");
+  }
+  ICEBERG_ASSIGN_OR_RAISE(auto stream, output_file->CreateOrOverwrite());
+  return std::unique_ptr<PuffinWriter>(new PuffinWriter(
+      std::move(stream), std::move(properties), default_codec, compress_footer));
+}
+
+Status PuffinWriter::WriteBytes(std::span<const std::byte> data) {
+  return stream_->Write(data);
+}
+
+Status PuffinWriter::WriteMagic() {
+  const auto& magic = PuffinFormat::kMagicV1;
+  return WriteBytes(std::span<const std::byte>(
+      reinterpret_cast<const std::byte*>(magic.data()), magic.size()));
+}
+
+Status PuffinWriter::WriteHeader() {
+  if (header_written_) return {};
+  ICEBERG_RETURN_UNEXPECTED(WriteMagic());
+  header_written_ = true;
+  return {};
+}
+
+Result<BlobMetadata> PuffinWriter::Write(const Blob& blob) {
+  if (finished_) {
+    return Invalid("Writer already finished");
+  }
+
+  ICEBERG_RETURN_UNEXPECTED(WriteHeader());
+
+  auto codec = blob.requested_compression.value_or(default_codec_);
+  std::span<const std::byte> input_span(
+      reinterpret_cast<const std::byte*>(blob.data.data()), blob.data.size());
+  ICEBERG_ASSIGN_OR_RAISE(auto compressed, Compress(codec, input_span));
+
+  ICEBERG_ASSIGN_OR_RAISE(auto offset, stream_->Position());
+  ICEBERG_RETURN_UNEXPECTED(
+      WriteBytes(std::span<const std::byte>(compressed.data(), compressed.size())));
+  auto length = static_cast<int64_t>(compressed.size());
+
+  auto codec_name = CodecName(codec);
+  BlobMetadata metadata{
+      .type = blob.type,
+      .input_fields = blob.input_fields,
+      .snapshot_id = blob.snapshot_id,
+      .sequence_number = blob.sequence_number,
+      .offset = offset,
+      .length = length,
+      .compression_codec = std::string(codec_name),
+      .properties = blob.properties,
+  };
+  written_blobs_metadata_.push_back(metadata);
+  return metadata;
+}
+
+Status PuffinWriter::Finish() {
+  if (finished_) {
+    return Invalid("Writer already finished");
+  }
+
+  ICEBERG_RETURN_UNEXPECTED(WriteHeader());
+
+  FileMetadata file_metadata{
+      .blobs = written_blobs_metadata_,
+      .properties = properties_,
+  };
+
+  auto footer_json = ToJsonString(file_metadata);
+  std::vector<std::byte> footer_payload(
+      reinterpret_cast<const std::byte*>(footer_json.data()),
+      reinterpret_cast<const std::byte*>(footer_json.data() + footer_json.size()));
+
+  // Compress footer if requested
+  std::array<uint8_t, 4> flags{};
+  if (compress_footer_) {
+    ICEBERG_ASSIGN_OR_RAISE(
+        footer_payload,
+        Compress(PuffinFormat::kDefaultFooterCompressionCodec, footer_payload));
+    SetFlag(flags, PuffinFlag::kFooterPayloadCompressed);
+  }
+
+  // Footer start magic
+  ICEBERG_ASSIGN_OR_RAISE(auto footer_start, stream_->Position());
+  ICEBERG_RETURN_UNEXPECTED(WriteMagic());
+
+  // Footer payload
+  ICEBERG_RETURN_UNEXPECTED(WriteBytes(footer_payload));
+
+  // Footer struct: payload_size (4) + flags (4) + magic (4)
+  auto payload_size = static_cast<int32_t>(footer_payload.size());
+  std::array<std::byte, 4> size_buf{};
+  WriteLittleEndian(payload_size, size_buf.data());
+  ICEBERG_RETURN_UNEXPECTED(WriteBytes(size_buf));
+
+  // Flags
+  ICEBERG_RETURN_UNEXPECTED(WriteBytes(std::span<const std::byte>(
+      reinterpret_cast<const std::byte*>(flags.data()), flags.size())));
+
+  // Footer end magic
+  ICEBERG_RETURN_UNEXPECTED(WriteMagic());
+
+  ICEBERG_ASSIGN_OR_RAISE(auto end_pos, stream_->Position());
+  footer_size_ = end_pos - footer_start;
+  file_size_ = end_pos;
+  finished_ = true;
+
+  ICEBERG_RETURN_UNEXPECTED(stream_->Flush());
+  return stream_->Close();
+}
+
+const std::vector<BlobMetadata>& PuffinWriter::written_blobs_metadata() const {
+  return written_blobs_metadata_;
+}
+
+Result<int64_t> PuffinWriter::footer_size() const {
+  if (!finished_) {
+    return Invalid("Writer not finished yet");
+  }
+  return footer_size_;
+}
+
+Result<int64_t> PuffinWriter::file_size() const {
+  if (!finished_) {
+    return Invalid("Writer not finished yet");
+  }
+  return file_size_;
+}
+
+}  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_writer.cc
+++ b/src/iceberg/puffin/puffin_writer.cc
@@ -20,6 +20,7 @@
 #include "iceberg/puffin/puffin_writer.h"
 
 #include <array>
+#include <limits>
 
 #include "iceberg/file_io.h"
 #include "iceberg/puffin/json_serde_internal.h"
@@ -43,10 +44,8 @@ Result<std::unique_ptr<PuffinWriter>> PuffinWriter::Make(
     std::unique_ptr<OutputFile> output_file,
     std::unordered_map<std::string, std::string> properties,
     PuffinCompressionCodec default_codec, bool compress_footer) {
-  if (!output_file) {
-    return InvalidArgument("output_file must not be null");
-  }
-  ICEBERG_ASSIGN_OR_RAISE(auto stream, output_file->CreateOrOverwrite());
+  ICEBERG_PRECHECK(output_file, "Output file must not be null");
+  ICEBERG_ASSIGN_OR_RAISE(auto stream, output_file->Create());
   return std::unique_ptr<PuffinWriter>(new PuffinWriter(
       std::move(stream), std::move(properties), default_codec, compress_footer));
 }
@@ -69,21 +68,22 @@ Status PuffinWriter::WriteHeader() {
 }
 
 Result<BlobMetadata> PuffinWriter::Write(const Blob& blob) {
-  if (finished_) {
-    return Invalid("Writer already finished");
-  }
-
+  ICEBERG_PRECHECK(!finished_ && !footer_written_, "Writer already finished");
   ICEBERG_RETURN_UNEXPECTED(WriteHeader());
 
   auto codec = blob.requested_compression.value_or(default_codec_);
   std::span<const std::byte> input_span(
       reinterpret_cast<const std::byte*>(blob.data.data()), blob.data.size());
-  ICEBERG_ASSIGN_OR_RAISE(auto compressed, Compress(codec, input_span));
+  std::vector<std::byte> compressed;
+  auto output_span = input_span;
+  if (codec != PuffinCompressionCodec::kNone) {
+    ICEBERG_ASSIGN_OR_RAISE(compressed, Compress(codec, input_span));
+    output_span = std::span<const std::byte>(compressed.data(), compressed.size());
+  }
 
   ICEBERG_ASSIGN_OR_RAISE(auto offset, stream_->Position());
-  ICEBERG_RETURN_UNEXPECTED(
-      WriteBytes(std::span<const std::byte>(compressed.data(), compressed.size())));
-  auto length = static_cast<int64_t>(compressed.size());
+  ICEBERG_RETURN_UNEXPECTED(WriteBytes(output_span));
+  auto length = static_cast<int64_t>(output_span.size());
 
   auto codec_name = CodecName(codec);
   BlobMetadata metadata{
@@ -101,9 +101,8 @@ Result<BlobMetadata> PuffinWriter::Write(const Blob& blob) {
 }
 
 Status PuffinWriter::Finish() {
-  if (finished_) {
-    return Invalid("Writer already finished");
-  }
+  ICEBERG_PRECHECK(!finished_, "Writer already finished");
+  ICEBERG_PRECHECK(!footer_written_, "Footer already written");
 
   ICEBERG_RETURN_UNEXPECTED(WriteHeader());
 
@@ -113,18 +112,24 @@ Status PuffinWriter::Finish() {
   };
 
   auto footer_json = ToJsonString(file_metadata);
-  std::vector<std::byte> footer_payload(
-      reinterpret_cast<const std::byte*>(footer_json.data()),
-      reinterpret_cast<const std::byte*>(footer_json.data() + footer_json.size()));
+  std::span<const std::byte> footer_payload(
+      reinterpret_cast<const std::byte*>(footer_json.data()), footer_json.size());
+  std::vector<std::byte> compressed_footer_payload;
 
   // Compress footer if requested
   std::array<uint8_t, 4> flags{};
   if (compress_footer_) {
     ICEBERG_ASSIGN_OR_RAISE(
-        footer_payload,
+        compressed_footer_payload,
         Compress(PuffinFormat::kDefaultFooterCompressionCodec, footer_payload));
+    footer_payload = std::span<const std::byte>(compressed_footer_payload.data(),
+                                                compressed_footer_payload.size());
     SetFlag(flags, PuffinFlag::kFooterPayloadCompressed);
   }
+  ICEBERG_CHECK(
+      footer_payload.size() <= static_cast<size_t>(std::numeric_limits<int32_t>::max()),
+      "Footer payload is too large: {}", footer_payload.size());
+  auto payload_size = static_cast<int32_t>(footer_payload.size());
 
   // Footer start magic
   ICEBERG_ASSIGN_OR_RAISE(auto footer_start, stream_->Position());
@@ -134,7 +139,6 @@ Status PuffinWriter::Finish() {
   ICEBERG_RETURN_UNEXPECTED(WriteBytes(footer_payload));
 
   // Footer struct: payload_size (4) + flags (4) + magic (4)
-  auto payload_size = static_cast<int32_t>(footer_payload.size());
   std::array<std::byte, 4> size_buf{};
   WriteLittleEndian(payload_size, size_buf.data());
   ICEBERG_RETURN_UNEXPECTED(WriteBytes(size_buf));
@@ -148,28 +152,32 @@ Status PuffinWriter::Finish() {
 
   ICEBERG_ASSIGN_OR_RAISE(auto end_pos, stream_->Position());
   footer_size_ = end_pos - footer_start;
-  file_size_ = end_pos;
-  finished_ = true;
-
+  footer_written_ = true;
   ICEBERG_RETURN_UNEXPECTED(stream_->Flush());
-  return stream_->Close();
+  ICEBERG_RETURN_UNEXPECTED(stream_->Close());
+  ICEBERG_ASSIGN_OR_RAISE(file_size_, stream_->Position());
+  finished_ = true;
+  return {};
+}
+
+Status PuffinWriter::Close() {
+  if (finished_) {
+    return {};
+  }
+  return Finish();
 }
 
 const std::vector<BlobMetadata>& PuffinWriter::written_blobs_metadata() const {
   return written_blobs_metadata_;
 }
 
-Result<int64_t> PuffinWriter::footer_size() const {
-  if (!finished_) {
-    return Invalid("Writer not finished yet");
-  }
+Result<int64_t> PuffinWriter::FooterSize() const {
+  ICEBERG_PRECHECK(footer_written_, "Footer not written yet");
   return footer_size_;
 }
 
-Result<int64_t> PuffinWriter::file_size() const {
-  if (!finished_) {
-    return Invalid("Writer not finished yet");
-  }
+Result<int64_t> PuffinWriter::FileSize() const {
+  ICEBERG_PRECHECK(finished_, "Writer not finished yet");
   return file_size_;
 }
 

--- a/src/iceberg/puffin/puffin_writer.h
+++ b/src/iceberg/puffin/puffin_writer.h
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+/// \file iceberg/puffin/puffin_writer.h
+/// Puffin file writer.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "iceberg/iceberg_export.h"
+#include "iceberg/puffin/file_metadata.h"
+#include "iceberg/result.h"
+
+namespace iceberg::puffin {
+
+/// \brief Writer for Puffin files.
+///
+/// Builds a complete Puffin file in memory. Usage:
+///   PuffinWriter writer;
+///   writer.Add(blob1);
+///   writer.Add(blob2);
+///   auto result = writer.Finish({{"created-by", "iceberg-cpp"}});
+///   // result.value() contains the serialized file bytes
+class ICEBERG_EXPORT PuffinWriter {
+ public:
+  /// \brief Construct a writer with the given default compression codec.
+  explicit PuffinWriter(
+      PuffinCompressionCodec default_codec = PuffinCompressionCodec::kNone);
+
+  /// \brief Add a blob to be written.
+  /// \return The BlobMetadata for the written blob, or an error.
+  Result<BlobMetadata> Add(const Blob& blob);
+
+  /// \brief Finalize the file and return the serialized bytes.
+  /// \param properties File-level properties to include in the footer.
+  /// \return The complete Puffin file as a byte vector, or an error.
+  Result<std::vector<std::byte>> Finish(
+      std::unordered_map<std::string, std::string> properties = {});
+
+  /// \brief Get metadata for all blobs written so far.
+  const std::vector<BlobMetadata>& written_blobs_metadata() const;
+
+  /// \brief Get the footer size after Finish() has been called.
+  /// \return The footer size, or std::nullopt if Finish() has not been called.
+  std::optional<int64_t> footer_size() const;
+
+ private:
+  PuffinCompressionCodec default_codec_;
+  std::vector<std::byte> buffer_;
+  std::vector<BlobMetadata> written_blobs_metadata_;
+  bool header_written_ = false;
+  bool finished_ = false;
+  std::optional<int64_t> footer_size_;
+
+  void WriteHeader();
+};
+
+}  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_writer.h
+++ b/src/iceberg/puffin/puffin_writer.h
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+/// \file iceberg/puffin/puffin_writer.h
+/// Puffin file writer.
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "iceberg/iceberg_data_export.h"
+#include "iceberg/puffin/file_metadata.h"
+#include "iceberg/result.h"
+
+namespace iceberg {
+class OutputFile;
+class PositionOutputStream;
+}  // namespace iceberg
+
+namespace iceberg::puffin {
+
+/// \brief Writer for Puffin files.
+///
+/// Writes blobs and footer to an OutputFile stream.
+class ICEBERG_DATA_EXPORT PuffinWriter {
+ public:
+  /// \brief Create a PuffinWriter for the given output file.
+  /// \param output_file The output file to write to.
+  /// \param properties File-level properties to include in the footer.
+  /// \param default_codec Default compression codec for blobs.
+  /// \param compress_footer Whether to compress the footer payload.
+  static Result<std::unique_ptr<PuffinWriter>> Make(
+      std::unique_ptr<OutputFile> output_file,
+      std::unordered_map<std::string, std::string> properties = {},
+      PuffinCompressionCodec default_codec = PuffinCompressionCodec::kNone,
+      bool compress_footer = false);
+
+  ~PuffinWriter();
+
+  /// \brief Write a blob and return its metadata.
+  Result<BlobMetadata> Write(const Blob& blob);
+
+  /// \brief Finalize the file by writing the footer and closing the stream.
+  Status Finish();
+
+  /// \brief Get metadata for all blobs written so far.
+  const std::vector<BlobMetadata>& written_blobs_metadata() const;
+
+  /// \brief Get the footer size. Returns error if Finish() has not been called.
+  Result<int64_t> footer_size() const;
+
+  /// \brief Get the total file size. Returns error if Finish() has not been called.
+  Result<int64_t> file_size() const;
+
+ private:
+  PuffinWriter(std::unique_ptr<PositionOutputStream> stream,
+               std::unordered_map<std::string, std::string> properties,
+               PuffinCompressionCodec default_codec, bool compress_footer);
+
+  /// Output stream.
+  std::unique_ptr<PositionOutputStream> stream_;
+  /// File-level properties to include in the footer.
+  std::unordered_map<std::string, std::string> properties_;
+  /// Default compression codec for blobs without explicit compression.
+  PuffinCompressionCodec default_codec_;
+  /// Whether to compress the footer payload.
+  bool compress_footer_;
+  /// Metadata for all blobs written so far.
+  std::vector<BlobMetadata> written_blobs_metadata_;
+  /// Whether the header magic has been written.
+  bool header_written_ = false;
+  /// Whether Finish() has been called.
+  bool finished_ = false;
+  /// Footer size, set after Finish().
+  int64_t footer_size_ = -1;
+  /// Total file size, set after Finish().
+  int64_t file_size_ = -1;
+
+  Status WriteBytes(std::span<const std::byte> data);
+  Status WriteHeader();
+  Status WriteMagic();
+};
+
+}  // namespace iceberg::puffin

--- a/src/iceberg/puffin/puffin_writer.h
+++ b/src/iceberg/puffin/puffin_writer.h
@@ -33,11 +33,7 @@
 #include "iceberg/iceberg_data_export.h"
 #include "iceberg/puffin/file_metadata.h"
 #include "iceberg/result.h"
-
-namespace iceberg {
-class OutputFile;
-class PositionOutputStream;
-}  // namespace iceberg
+#include "iceberg/type_fwd.h"
 
 namespace iceberg::puffin {
 
@@ -65,42 +61,47 @@ class ICEBERG_DATA_EXPORT PuffinWriter {
   /// \brief Finalize the file by writing the footer and closing the stream.
   Status Finish();
 
+  /// \brief Close the writer, finalizing the file if needed.
+  Status Close();
+
   /// \brief Get metadata for all blobs written so far.
   const std::vector<BlobMetadata>& written_blobs_metadata() const;
 
-  /// \brief Get the footer size. Returns error if Finish() has not been called.
-  Result<int64_t> footer_size() const;
+  /// \brief Get the footer size. Returns error if the footer has not been written.
+  Result<int64_t> FooterSize() const;
 
-  /// \brief Get the total file size. Returns error if Finish() has not been called.
-  Result<int64_t> file_size() const;
+  /// \brief Get the total file size. Returns error if Finish() has not succeeded.
+  Result<int64_t> FileSize() const;
 
  private:
   PuffinWriter(std::unique_ptr<PositionOutputStream> stream,
                std::unordered_map<std::string, std::string> properties,
                PuffinCompressionCodec default_codec, bool compress_footer);
 
+  Status WriteBytes(std::span<const std::byte> data);
+  Status WriteHeader();
+  Status WriteMagic();
+
   /// Output stream.
   std::unique_ptr<PositionOutputStream> stream_;
   /// File-level properties to include in the footer.
   std::unordered_map<std::string, std::string> properties_;
   /// Default compression codec for blobs without explicit compression.
-  PuffinCompressionCodec default_codec_;
+  const PuffinCompressionCodec default_codec_;
   /// Whether to compress the footer payload.
-  bool compress_footer_;
+  const bool compress_footer_;
   /// Metadata for all blobs written so far.
   std::vector<BlobMetadata> written_blobs_metadata_;
   /// Whether the header magic has been written.
   bool header_written_ = false;
-  /// Whether Finish() has been called.
+  /// Whether the footer has been written.
+  bool footer_written_ = false;
+  /// Whether Finish() has succeeded.
   bool finished_ = false;
-  /// Footer size, set after Finish().
+  /// Footer size, set after the footer is written.
   int64_t footer_size_ = -1;
   /// Total file size, set after Finish().
   int64_t file_size_ = -1;
-
-  Status WriteBytes(std::span<const std::byte> data);
-  Status WriteHeader();
-  Status WriteMagic();
 };
 
 }  // namespace iceberg::puffin

--- a/src/iceberg/test/CMakeLists.txt
+++ b/src/iceberg/test/CMakeLists.txt
@@ -129,7 +129,11 @@ add_iceberg_test(util_test
 
 add_iceberg_test(roaring_test SOURCES roaring_test.cc)
 
-add_iceberg_test(puffin_test SOURCES puffin_format_test.cc puffin_json_test.cc)
+add_iceberg_test(puffin_test
+                 SOURCES
+                 puffin_format_test.cc
+                 puffin_json_test.cc
+                 puffin_reader_writer_test.cc)
 
 if(ICEBERG_BUILD_BUNDLE)
   add_iceberg_test(avro_test

--- a/src/iceberg/test/CMakeLists.txt
+++ b/src/iceberg/test/CMakeLists.txt
@@ -146,7 +146,8 @@ add_iceberg_test(puffin_test
                  USE_DATA
                  SOURCES
                  puffin_format_test.cc
-                 puffin_json_test.cc)
+                 puffin_json_test.cc
+                 puffin_reader_writer_test.cc)
 
 if(ICEBERG_BUILD_BUNDLE)
   add_iceberg_test(avro_test

--- a/src/iceberg/test/meson.build
+++ b/src/iceberg/test/meson.build
@@ -103,7 +103,11 @@ iceberg_tests = {
     },
     'roaring_test': {'sources': files('roaring_test.cc')},
     'puffin_test': {
-        'sources': files('puffin_format_test.cc', 'puffin_json_test.cc'),
+        'sources': files(
+            'puffin_format_test.cc',
+            'puffin_json_test.cc',
+            'puffin_reader_writer_test.cc',
+        ),
     },
 }
 

--- a/src/iceberg/test/meson.build
+++ b/src/iceberg/test/meson.build
@@ -109,7 +109,11 @@ iceberg_tests = {
         'use_data': true,
     },
     'puffin_test': {
-        'sources': files('puffin_format_test.cc', 'puffin_json_test.cc'),
+        'sources': files(
+            'puffin_format_test.cc',
+            'puffin_json_test.cc',
+            'puffin_reader_writer_test.cc',
+        ),
         'use_data': true,
     },
 }

--- a/src/iceberg/test/mock_io.h
+++ b/src/iceberg/test/mock_io.h
@@ -19,10 +19,25 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "iceberg/file_io.h"
+#include "iceberg/util/macros.h"
 
 namespace iceberg {
 
@@ -31,12 +46,214 @@ class MockFileIO : public FileIO {
   MockFileIO() = default;
   ~MockFileIO() override = default;
 
+  Result<std::unique_ptr<InputFile>> NewInputFile(std::string file_location) override {
+    auto file = FindFile(file_location);
+    if (!file) {
+      return NotFound("File does not exist: {}", file_location);
+    }
+    return std::make_unique<InMemoryInputFile>(std::move(file_location), std::move(file),
+                                               std::nullopt);
+  }
+
+  Result<std::unique_ptr<InputFile>> NewInputFile(std::string file_location,
+                                                  size_t length) override {
+    if (length > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
+      return InvalidArgument("File length {} exceeds int64_t max", length);
+    }
+    auto file = FindFile(file_location);
+    if (!file) {
+      return NotFound("File does not exist: {}", file_location);
+    }
+    return std::make_unique<InMemoryInputFile>(std::move(file_location), std::move(file),
+                                               static_cast<int64_t>(length));
+  }
+
+  Result<std::unique_ptr<OutputFile>> NewOutputFile(std::string file_location) override {
+    return std::make_unique<InMemoryOutputFile>(files_, std::move(file_location));
+  }
+
+  void AddFile(std::string file_location, std::span<const std::byte> data) {
+    files_->insert_or_assign(
+        std::move(file_location),
+        std::make_shared<std::vector<std::byte>>(data.begin(), data.end()));
+  }
+
+  void AddFile(std::string file_location, std::string_view data) {
+    AddFile(std::move(file_location),
+            std::as_bytes(std::span<const char>(data.data(), data.size())));
+  }
+
+  std::vector<std::byte>& FileData(const std::string& file_location) {
+    return *GetOrCreateFile(file_location);
+  }
+
+  const std::vector<std::byte>& FileData(const std::string& file_location) const {
+    return *files_->at(file_location);
+  }
+
   MOCK_METHOD((Result<std::string>), ReadFile,
               (const std::string&, std::optional<size_t>), (override));
 
   MOCK_METHOD(Status, WriteFile, (const std::string&, std::string_view), (override));
 
   MOCK_METHOD(Status, DeleteFile, (const std::string&), (override));
+
+ private:
+  using FileMap =
+      std::unordered_map<std::string, std::shared_ptr<std::vector<std::byte>>>;
+
+  class InMemoryInputStream : public SeekableInputStream {
+   public:
+    explicit InMemoryInputStream(std::shared_ptr<std::vector<std::byte>> data)
+        : data_(std::move(data)) {}
+
+    Result<int64_t> Position() const override { return position_; }
+
+    Status Seek(int64_t position) override {
+      ICEBERG_PRECHECK(!closed_, "Input stream is closed");
+      ICEBERG_PRECHECK(position >= 0, "Position must not be negative: {}", position);
+      position_ = position;
+      return {};
+    }
+
+    Result<int64_t> Read(std::span<std::byte> out) override {
+      ICEBERG_PRECHECK(!closed_, "Input stream is closed");
+      auto file_size = static_cast<int64_t>(data_->size());
+      ICEBERG_PRECHECK(position_ <= file_size, "Position {} exceeds file size {}",
+                       position_, file_size);
+      auto bytes_to_read =
+          std::min(static_cast<int64_t>(out.size()), file_size - position_);
+      if (bytes_to_read > 0) {
+        std::memcpy(out.data(), data_->data() + static_cast<size_t>(position_),
+                    static_cast<size_t>(bytes_to_read));
+        position_ += bytes_to_read;
+      }
+      return bytes_to_read;
+    }
+
+    Status ReadFully(int64_t position, std::span<std::byte> out) override {
+      ICEBERG_PRECHECK(!closed_, "Input stream is closed");
+      ICEBERG_PRECHECK(position >= 0, "Position must not be negative: {}", position);
+      auto file_size = static_cast<int64_t>(data_->size());
+      ICEBERG_PRECHECK(static_cast<int64_t>(out.size()) <= file_size - position,
+                       "Read out of bounds: offset {} + length {} exceeds file size {}",
+                       position, out.size(), file_size);
+      if (!out.empty()) {
+        std::memcpy(out.data(), data_->data() + static_cast<size_t>(position),
+                    out.size());
+      }
+      return {};
+    }
+
+    Status Close() override {
+      closed_ = true;
+      return {};
+    }
+
+   private:
+    std::shared_ptr<std::vector<std::byte>> data_;
+    int64_t position_ = 0;
+    bool closed_ = false;
+  };
+
+  class InMemoryOutputStream : public PositionOutputStream {
+   public:
+    explicit InMemoryOutputStream(std::shared_ptr<std::vector<std::byte>> data)
+        : data_(std::move(data)) {}
+
+    Result<int64_t> Position() const override {
+      return static_cast<int64_t>(data_->size());
+    }
+
+    Status Write(std::span<const std::byte> data) override {
+      ICEBERG_PRECHECK(!closed_, "Output stream is closed");
+      data_->insert(data_->end(), data.begin(), data.end());
+      return {};
+    }
+
+    Status Flush() override {
+      ICEBERG_PRECHECK(!closed_, "Output stream is closed");
+      return {};
+    }
+
+    Status Close() override {
+      closed_ = true;
+      return {};
+    }
+
+   private:
+    std::shared_ptr<std::vector<std::byte>> data_;
+    bool closed_ = false;
+  };
+
+  class InMemoryInputFile : public InputFile {
+   public:
+    InMemoryInputFile(std::string location, std::shared_ptr<std::vector<std::byte>> data,
+                      std::optional<int64_t> length)
+        : location_(std::move(location)), data_(std::move(data)), length_(length) {}
+
+    std::string_view location() const override { return location_; }
+
+    Result<int64_t> Size() const override {
+      return length_.value_or(static_cast<int64_t>(data_->size()));
+    }
+
+    Result<std::unique_ptr<SeekableInputStream>> Open() override {
+      return std::make_unique<InMemoryInputStream>(data_);
+    }
+
+   private:
+    std::string location_;
+    std::shared_ptr<std::vector<std::byte>> data_;
+    std::optional<int64_t> length_;
+  };
+
+  class InMemoryOutputFile : public OutputFile {
+   public:
+    InMemoryOutputFile(std::shared_ptr<FileMap> files, std::string location)
+        : files_(std::move(files)), location_(std::move(location)) {}
+
+    std::string_view location() const override { return location_; }
+
+    Result<std::unique_ptr<PositionOutputStream>> Create() override {
+      if (files_->contains(location_)) {
+        return AlreadyExists("File already exists: {}", location_);
+      }
+      auto file = std::make_shared<std::vector<std::byte>>();
+      files_->emplace(location_, file);
+      return std::make_unique<InMemoryOutputStream>(std::move(file));
+    }
+
+    Result<std::unique_ptr<PositionOutputStream>> CreateOrOverwrite() override {
+      auto file = std::make_shared<std::vector<std::byte>>();
+      files_->insert_or_assign(location_, file);
+      return std::make_unique<InMemoryOutputStream>(std::move(file));
+    }
+
+   private:
+    std::shared_ptr<FileMap> files_;
+    std::string location_;
+  };
+
+  std::shared_ptr<std::vector<std::byte>> FindFile(
+      const std::string& file_location) const {
+    auto file = files_->find(file_location);
+    if (file == files_->end()) {
+      return nullptr;
+    }
+    return file->second;
+  }
+
+  std::shared_ptr<std::vector<std::byte>> GetOrCreateFile(
+      const std::string& file_location) {
+    auto& file = (*files_)[file_location];
+    if (!file) {
+      file = std::make_shared<std::vector<std::byte>>();
+    }
+    return file;
+  }
+
+  std::shared_ptr<FileMap> files_ = std::make_shared<FileMap>();
 };
 
 }  // namespace iceberg

--- a/src/iceberg/test/puffin_reader_writer_test.cc
+++ b/src/iceberg/test/puffin_reader_writer_test.cc
@@ -1,0 +1,433 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "iceberg/puffin/file_metadata.h"
+#include "iceberg/puffin/puffin_reader.h"
+#include "iceberg/puffin/puffin_writer.h"
+#include "iceberg/test/matchers.h"
+
+namespace iceberg::puffin {
+
+namespace {
+
+std::vector<std::byte> ToBytes(std::initializer_list<uint8_t> values) {
+  std::vector<std::byte> result;
+  result.reserve(values.size());
+  for (auto v : values) {
+    result.push_back(static_cast<std::byte>(v));
+  }
+  return result;
+}
+
+std::vector<std::byte> ToBytes(std::string_view str) {
+  return {reinterpret_cast<const std::byte*>(str.data()),
+          reinterpret_cast<const std::byte*>(str.data() + str.size())};
+}
+
+}  // namespace
+
+// ============================================================================
+// PuffinWriter Tests
+// ============================================================================
+
+TEST(PuffinWriterTest, WriteEmptyFile) {
+  PuffinWriter writer;
+  auto result = writer.Finish();
+  ASSERT_THAT(result, IsOk());
+  auto& data = result.value();
+
+  // Header magic (4) + footer start magic (4) + JSON payload + footer struct (12)
+  EXPECT_GE(data.size(), 20u);
+  // Header magic
+  EXPECT_EQ(data[0], std::byte{0x50});
+  EXPECT_EQ(data[1], std::byte{0x46});
+  EXPECT_EQ(data[2], std::byte{0x41});
+  EXPECT_EQ(data[3], std::byte{0x31});
+  // Footer end magic
+  auto sz = data.size();
+  EXPECT_EQ(data[sz - 4], std::byte{0x50});
+  EXPECT_EQ(data[sz - 3], std::byte{0x46});
+  EXPECT_EQ(data[sz - 2], std::byte{0x41});
+  EXPECT_EQ(data[sz - 1], std::byte{0x31});
+
+  EXPECT_TRUE(writer.written_blobs_metadata().empty());
+  ASSERT_TRUE(writer.footer_size().has_value());
+}
+
+TEST(PuffinWriterTest, WriterRejectsAfterFinish) {
+  PuffinWriter writer;
+  ASSERT_THAT(writer.Finish(), IsOk());
+
+  // Double finish
+  EXPECT_THAT(writer.Finish(), IsError(ErrorKind::kInvalid));
+
+  // Add after finish
+  Blob blob{.type = "a", .snapshot_id = 1, .sequence_number = 0};
+  EXPECT_THAT(writer.Add(blob), IsError(ErrorKind::kInvalid));
+}
+
+TEST(PuffinWriterTest, WriteEmptyBlobData) {
+  PuffinWriter writer;
+  Blob blob{
+      .type = "empty-blob",
+      .input_fields = {1},
+      .snapshot_id = 1,
+      .sequence_number = 0,
+      .data = {},
+  };
+  auto meta = writer.Add(blob);
+  ASSERT_THAT(meta, IsOk());
+  EXPECT_EQ(meta.value().offset, 4);
+  EXPECT_EQ(meta.value().length, 0);
+
+  auto result = writer.Finish();
+  ASSERT_THAT(result, IsOk());
+
+  PuffinReader reader(result.value());
+  auto fm = reader.ReadFileMetadata();
+  ASSERT_THAT(fm, IsOk());
+  ASSERT_EQ(fm.value().blobs.size(), 1);
+
+  auto blob_result = reader.ReadBlob(fm.value().blobs[0]);
+  ASSERT_THAT(blob_result, IsOk());
+  EXPECT_TRUE(blob_result.value().second.empty());
+}
+
+TEST(PuffinWriterTest, WriteLargeBlob) {
+  PuffinWriter writer;
+  std::vector<uint8_t> large_data(4096);
+  for (size_t i = 0; i < large_data.size(); ++i) {
+    large_data[i] = static_cast<uint8_t>(i & 0xFF);
+  }
+  Blob blob{
+      .type = "large-blob",
+      .input_fields = {1, 2, 3},
+      .snapshot_id = 999,
+      .sequence_number = 42,
+      .data = large_data,
+  };
+  auto meta = writer.Add(blob);
+  ASSERT_THAT(meta, IsOk());
+  EXPECT_EQ(meta.value().length, 4096);
+
+  auto result = writer.Finish();
+  ASSERT_THAT(result, IsOk());
+
+  PuffinReader reader(result.value());
+  auto fm = reader.ReadFileMetadata();
+  ASSERT_THAT(fm, IsOk());
+  ASSERT_EQ(fm.value().blobs.size(), 1);
+
+  auto blob_result = reader.ReadBlob(fm.value().blobs[0]);
+  ASSERT_THAT(blob_result, IsOk());
+  auto& read_data = blob_result.value().second;
+  ASSERT_EQ(read_data.size(), 4096);
+  for (size_t i = 0; i < read_data.size(); ++i) {
+    EXPECT_EQ(read_data[i], static_cast<std::byte>(i & 0xFF))
+        << "mismatch at index " << i;
+  }
+}
+
+// ============================================================================
+// Round-Trip Tests
+// ============================================================================
+
+TEST(PuffinRoundTripTest, SingleBlob) {
+  PuffinWriter writer;
+  EXPECT_FALSE(writer.footer_size().has_value());
+
+  std::vector<uint8_t> blob_data = {0x01, 0x02, 0x03, 0x04, 0x05};
+  Blob blob{
+      .type = "test-blob",
+      .input_fields = {1, 2},
+      .snapshot_id = 42,
+      .sequence_number = 7,
+      .data = blob_data,
+  };
+  auto meta = writer.Add(blob);
+  ASSERT_THAT(meta, IsOk());
+  EXPECT_EQ(meta.value().type, "test-blob");
+  EXPECT_EQ(meta.value().offset, 4);  // after header magic
+  EXPECT_EQ(meta.value().length, 5);
+  EXPECT_EQ(writer.written_blobs_metadata().size(), 1);
+
+  auto file_result = writer.Finish({{"created-by", "test"}});
+  ASSERT_THAT(file_result, IsOk());
+  ASSERT_TRUE(writer.footer_size().has_value());
+  EXPECT_GT(writer.footer_size().value(), 0);
+
+  PuffinReader reader(file_result.value());
+  auto fm = reader.ReadFileMetadata();
+  ASSERT_THAT(fm, IsOk());
+  ASSERT_EQ(fm.value().blobs.size(), 1);
+  EXPECT_EQ(fm.value().blobs[0].type, "test-blob");
+  EXPECT_EQ(fm.value().properties.at("created-by"), "test");
+
+  auto blob_result = reader.ReadBlob(fm.value().blobs[0]);
+  ASSERT_THAT(blob_result, IsOk());
+  EXPECT_EQ(blob_result.value().second, ToBytes({0x01, 0x02, 0x03, 0x04, 0x05}));
+}
+
+TEST(PuffinRoundTripTest, MultipleBlobs) {
+  PuffinWriter writer;
+  EXPECT_TRUE(writer.written_blobs_metadata().empty());
+
+  // Add first blob (no properties)
+  std::vector<uint8_t> data1 = {'a', 'b', 'c'};
+  ASSERT_THAT(writer.Add(Blob{.type = "first",
+                              .input_fields = {1},
+                              .snapshot_id = 1,
+                              .sequence_number = 0,
+                              .data = data1}),
+              IsOk());
+  EXPECT_EQ(writer.written_blobs_metadata().size(), 1);
+
+  // Add second blob (with properties)
+  std::vector<uint8_t> data2 = {'d', 'e', 'f', 'g'};
+  auto meta2 = writer.Add(Blob{.type = "second",
+                               .input_fields = {2},
+                               .snapshot_id = 2,
+                               .sequence_number = 1,
+                               .data = data2,
+                               .properties = {{"key", "val"}}});
+  ASSERT_THAT(meta2, IsOk());
+  // Second blob starts after header (4) + first blob (3)
+  EXPECT_EQ(meta2.value().offset, 7);
+  EXPECT_EQ(meta2.value().length, 4);
+  EXPECT_EQ(writer.written_blobs_metadata().size(), 2);
+
+  EXPECT_FALSE(writer.footer_size().has_value());
+  auto file_result = writer.Finish();
+  ASSERT_THAT(file_result, IsOk());
+  ASSERT_TRUE(writer.footer_size().has_value());
+  EXPECT_GT(writer.footer_size().value(), 0);
+
+  // Read back
+  PuffinReader reader(file_result.value());
+  auto fm = reader.ReadFileMetadata();
+  ASSERT_THAT(fm, IsOk());
+  ASSERT_EQ(fm.value().blobs.size(), 2);
+
+  // Verify properties: first has none, second has one
+  EXPECT_TRUE(fm.value().blobs[0].properties.empty());
+  EXPECT_EQ(fm.value().blobs[1].properties.at("key"), "val");
+
+  // ReadAll
+  auto all = reader.ReadAll(fm.value().blobs);
+  ASSERT_THAT(all, IsOk());
+  ASSERT_EQ(all.value().size(), 2);
+  EXPECT_EQ(all.value()[0].second, ToBytes("abc"));
+  EXPECT_EQ(all.value()[1].second, ToBytes("defg"));
+}
+
+TEST(PuffinRoundTripTest, WithProperties) {
+  PuffinWriter writer;
+  std::string text = "hello puffin";
+  std::vector<uint8_t> blob_data(text.begin(), text.end());
+  ASSERT_THAT(writer.Add(Blob{.type = "text-blob",
+                              .input_fields = {1},
+                              .snapshot_id = 100,
+                              .sequence_number = 5,
+                              .data = blob_data,
+                              .properties = {{"encoding", "utf-8"}}}),
+              IsOk());
+  auto file_result = writer.Finish({{"created-by", "iceberg-cpp-test"}});
+  ASSERT_THAT(file_result, IsOk());
+
+  PuffinReader reader(file_result.value());
+  auto fm = reader.ReadFileMetadata();
+  ASSERT_THAT(fm, IsOk());
+  EXPECT_EQ(fm.value().properties.at("created-by"), "iceberg-cpp-test");
+  ASSERT_EQ(fm.value().blobs.size(), 1);
+  EXPECT_EQ(fm.value().blobs[0].type, "text-blob");
+  EXPECT_EQ(fm.value().blobs[0].properties.at("encoding"), "utf-8");
+
+  auto blob_result = reader.ReadBlob(fm.value().blobs[0]);
+  ASSERT_THAT(blob_result, IsOk());
+  EXPECT_EQ(blob_result.value().second, ToBytes("hello puffin"));
+}
+
+// ============================================================================
+// PuffinReader Error Tests
+// ============================================================================
+
+TEST(PuffinReaderTest, ReadEmptyFile) {
+  PuffinWriter writer;
+  auto result = writer.Finish();
+  ASSERT_THAT(result, IsOk());
+
+  PuffinReader reader(result.value());
+  auto fm = reader.ReadFileMetadata();
+  ASSERT_THAT(fm, IsOk());
+  EXPECT_TRUE(fm.value().blobs.empty());
+  EXPECT_TRUE(fm.value().properties.empty());
+}
+
+TEST(PuffinReaderTest, InvalidMagic) {
+  auto bad_data = ToBytes({0x00, 0x00, 0x00, 0x00});
+  PuffinReader reader(bad_data);
+  EXPECT_THAT(reader.ReadFileMetadata(), IsError(ErrorKind::kInvalid));
+}
+
+TEST(PuffinReaderTest, TruncatedFile) {
+  auto tiny = ToBytes({0x50, 0x46});
+  PuffinReader reader(tiny);
+  EXPECT_THAT(reader.ReadFileMetadata(), IsError(ErrorKind::kInvalid));
+}
+
+TEST(PuffinReaderTest, InvalidBlobOffset) {
+  PuffinWriter writer;
+  auto file_result = writer.Finish();
+  ASSERT_THAT(file_result, IsOk());
+
+  PuffinReader reader(file_result.value());
+  BlobMetadata bad_meta{
+      .type = "bad",
+      .snapshot_id = 1,
+      .sequence_number = 0,
+      .offset = 9999,
+      .length = 100,
+  };
+  EXPECT_THAT(reader.ReadBlob(bad_meta), IsError(ErrorKind::kInvalid));
+}
+
+// ============================================================================
+// Java Binary Compatibility Tests
+// ============================================================================
+
+TEST(PuffinReaderTest, JavaEmptyPuffinCompatibility) {
+  // Exact binary content of v1/empty-puffin-uncompressed.bin from Java test resources
+  auto java_empty = ToBytes({
+      0x50, 0x46, 0x41, 0x31,  // header magic
+      0x50, 0x46, 0x41, 0x31,  // footer start magic
+      0x7b, 0x22, 0x62, 0x6c, 0x6f, 0x62,
+      0x73, 0x22, 0x3a, 0x5b, 0x5d, 0x7d,  // {"blobs":[]}
+      0x0c, 0x00, 0x00, 0x00,              // payload size = 12
+      0x00, 0x00, 0x00, 0x00,              // flags = 0
+      0x50, 0x46, 0x41, 0x31,              // footer end magic
+  });
+
+  PuffinReader reader(java_empty);
+  auto fm = reader.ReadFileMetadata();
+  ASSERT_THAT(fm, IsOk());
+  EXPECT_TRUE(fm.value().blobs.empty());
+  EXPECT_TRUE(fm.value().properties.empty());
+}
+
+// Verify binary compatibility with Java's sample-metric-data-uncompressed.bin.
+// This file contains two blobs: "abcdefghi" (9 bytes) and binary data including
+// a null byte and emoji (83 bytes).
+TEST(PuffinReaderTest, JavaSampleMetricDataCompatibility) {
+  // clang-format off
+  auto java_sample = ToBytes({
+      // Header magic
+      0x50, 0x46, 0x41, 0x31,
+      // Blob 1: "abcdefghi" (9 bytes, offset=4)
+      0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69,
+      // Blob 2: "some blob \0 binary data 🤯 that is not very very very very
+      //          very very long, is it?" (83 bytes, offset=13)
+      0x73, 0x6f, 0x6d, 0x65, 0x20, 0x62, 0x6c, 0x6f, 0x62, 0x20, 0x00, 0x20,
+      0x62, 0x69, 0x6e, 0x61, 0x72, 0x79, 0x20, 0x64, 0x61, 0x74, 0x61, 0x20,
+      0xf0, 0x9f, 0xa4, 0xaf, 0x20, 0x74, 0x68, 0x61, 0x74, 0x20, 0x69, 0x73,
+      0x20, 0x6e, 0x6f, 0x74, 0x20, 0x76, 0x65, 0x72, 0x79, 0x20, 0x76, 0x65,
+      0x72, 0x79, 0x20, 0x76, 0x65, 0x72, 0x79, 0x20, 0x76, 0x65, 0x72, 0x79,
+      0x20, 0x76, 0x65, 0x72, 0x79, 0x20, 0x76, 0x65, 0x72, 0x79, 0x20, 0x6c,
+      0x6f, 0x6e, 0x67, 0x2c, 0x20, 0x69, 0x73, 0x20, 0x69, 0x74, 0x3f,
+      // Footer start magic
+      0x50, 0x46, 0x41, 0x31,
+      // Footer payload (JSON)
+      0x7b, 0x22, 0x62, 0x6c, 0x6f, 0x62, 0x73, 0x22, 0x3a, 0x5b, 0x7b, 0x22,
+      0x74, 0x79, 0x70, 0x65, 0x22, 0x3a, 0x22, 0x73, 0x6f, 0x6d, 0x65, 0x2d,
+      0x62, 0x6c, 0x6f, 0x62, 0x22, 0x2c, 0x22, 0x66, 0x69, 0x65, 0x6c, 0x64,
+      0x73, 0x22, 0x3a, 0x5b, 0x31, 0x5d, 0x2c, 0x22, 0x73, 0x6e, 0x61, 0x70,
+      0x73, 0x68, 0x6f, 0x74, 0x2d, 0x69, 0x64, 0x22, 0x3a, 0x32, 0x2c, 0x22,
+      0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x2d, 0x6e, 0x75, 0x6d,
+      0x62, 0x65, 0x72, 0x22, 0x3a, 0x31, 0x2c, 0x22, 0x6f, 0x66, 0x66, 0x73,
+      0x65, 0x74, 0x22, 0x3a, 0x34, 0x2c, 0x22, 0x6c, 0x65, 0x6e, 0x67, 0x74,
+      0x68, 0x22, 0x3a, 0x39, 0x7d, 0x2c, 0x7b, 0x22, 0x74, 0x79, 0x70, 0x65,
+      0x22, 0x3a, 0x22, 0x73, 0x6f, 0x6d, 0x65, 0x2d, 0x6f, 0x74, 0x68, 0x65,
+      0x72, 0x2d, 0x62, 0x6c, 0x6f, 0x62, 0x22, 0x2c, 0x22, 0x66, 0x69, 0x65,
+      0x6c, 0x64, 0x73, 0x22, 0x3a, 0x5b, 0x32, 0x5d, 0x2c, 0x22, 0x73, 0x6e,
+      0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x2d, 0x69, 0x64, 0x22, 0x3a, 0x32,
+      0x2c, 0x22, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x2d, 0x6e,
+      0x75, 0x6d, 0x62, 0x65, 0x72, 0x22, 0x3a, 0x31, 0x2c, 0x22, 0x6f, 0x66,
+      0x66, 0x73, 0x65, 0x74, 0x22, 0x3a, 0x31, 0x33, 0x2c, 0x22, 0x6c, 0x65,
+      0x6e, 0x67, 0x74, 0x68, 0x22, 0x3a, 0x38, 0x33, 0x7d, 0x5d, 0x2c, 0x22,
+      0x70, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74, 0x69, 0x65, 0x73, 0x22, 0x3a,
+      0x7b, 0x22, 0x63, 0x72, 0x65, 0x61, 0x74, 0x65, 0x64, 0x2d, 0x62, 0x79,
+      0x22, 0x3a, 0x22, 0x54, 0x65, 0x73, 0x74, 0x20, 0x31, 0x32, 0x33, 0x34,
+      0x22, 0x7d, 0x7d,
+      // Footer struct: payload_size (243 = 0xf3) + flags (0) + magic
+      0xf3, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      0x50, 0x46, 0x41, 0x31,
+  });
+  // clang-format on
+
+  PuffinReader reader(java_sample);
+  auto fm = reader.ReadFileMetadata();
+  ASSERT_THAT(fm, IsOk());
+  ASSERT_EQ(fm.value().blobs.size(), 2);
+  EXPECT_EQ(fm.value().properties.at("created-by"), "Test 1234");
+
+  // Blob 1: "some-blob", fields=[1], snapshot=2, seq=1
+  EXPECT_EQ(fm.value().blobs[0].type, "some-blob");
+  EXPECT_EQ(fm.value().blobs[0].input_fields, std::vector<int32_t>{1});
+  EXPECT_EQ(fm.value().blobs[0].snapshot_id, 2);
+  EXPECT_EQ(fm.value().blobs[0].sequence_number, 1);
+  EXPECT_EQ(fm.value().blobs[0].offset, 4);
+  EXPECT_EQ(fm.value().blobs[0].length, 9);
+
+  // Blob 2: "some-other-blob", fields=[2], snapshot=2, seq=1
+  EXPECT_EQ(fm.value().blobs[1].type, "some-other-blob");
+  EXPECT_EQ(fm.value().blobs[1].input_fields, std::vector<int32_t>{2});
+  EXPECT_EQ(fm.value().blobs[1].offset, 13);
+  EXPECT_EQ(fm.value().blobs[1].length, 83);
+
+  // Read blob 1 data: "abcdefghi"
+  auto blob1 = reader.ReadBlob(fm.value().blobs[0]);
+  ASSERT_THAT(blob1, IsOk());
+  EXPECT_EQ(blob1.value().second, ToBytes("abcdefghi"));
+
+  // Read blob 2 data: contains null byte and emoji
+  auto blob2 = reader.ReadBlob(fm.value().blobs[1]);
+  ASSERT_THAT(blob2, IsOk());
+  EXPECT_EQ(blob2.value().second.size(), 83);
+  // Verify null byte at position 10
+  EXPECT_EQ(blob2.value().second[10], std::byte{0x00});
+  // Verify emoji 🤯 (U+1F92F) at positions 24-27
+  EXPECT_EQ(blob2.value().second[24], std::byte{0xf0});
+  EXPECT_EQ(blob2.value().second[25], std::byte{0x9f});
+  EXPECT_EQ(blob2.value().second[26], std::byte{0xa4});
+  EXPECT_EQ(blob2.value().second[27], std::byte{0xaf});
+
+  // ReadAll should return both blobs
+  auto all = reader.ReadAll(fm.value().blobs);
+  ASSERT_THAT(all, IsOk());
+  ASSERT_EQ(all.value().size(), 2);
+}
+
+}  // namespace iceberg::puffin

--- a/src/iceberg/test/puffin_reader_writer_test.cc
+++ b/src/iceberg/test/puffin_reader_writer_test.cc
@@ -19,132 +19,60 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <memory>
+#include <span>
 #include <string>
-#include <unordered_map>
+#include <string_view>
 #include <vector>
 
 #include <gtest/gtest.h>
 
-#include "iceberg/file_io.h"
 #include "iceberg/puffin/file_metadata.h"
 #include "iceberg/puffin/puffin_reader.h"
 #include "iceberg/puffin/puffin_writer.h"
 #include "iceberg/test/matchers.h"
+#include "iceberg/test/mock_io.h"
 
 namespace iceberg::puffin {
 
 namespace {
 
-// Simple in-memory stream implementations for testing.
+struct PuffinFile {
+  MockFileIO io;
+  std::string location = "memory://test.puffin";
 
-class MemoryOutputStream : public PositionOutputStream {
- public:
-  explicit MemoryOutputStream(std::shared_ptr<std::vector<std::byte>> buffer)
-      : buffer_(std::move(buffer)) {}
-
-  Result<int64_t> Position() const override {
-    return static_cast<int64_t>(buffer_->size());
-  }
-
-  Status Write(std::span<const std::byte> data) override {
-    buffer_->insert(buffer_->end(), data.begin(), data.end());
-    return {};
-  }
-
-  Status Flush() override { return {}; }
-  Status Close() override { return {}; }
-
- private:
-  std::shared_ptr<std::vector<std::byte>> buffer_;
-};
-
-class MemoryInputStream : public SeekableInputStream {
- public:
-  explicit MemoryInputStream(std::shared_ptr<std::vector<std::byte>> buffer)
-      : buffer_(std::move(buffer)) {}
-
-  Result<int64_t> Position() const override { return position_; }
-
-  Status Seek(int64_t position) override {
-    position_ = position;
-    return {};
-  }
-
-  Result<int64_t> Read(std::span<std::byte> out) override {
-    auto available = static_cast<int64_t>(buffer_->size()) - position_;
-    auto to_read = std::min(static_cast<int64_t>(out.size()), available);
-    if (to_read > 0) {
-      std::memcpy(out.data(), buffer_->data() + position_, to_read);
-      position_ += to_read;
+  std::unique_ptr<OutputFile> Output() {
+    auto output_file = io.NewOutputFile(location);
+    EXPECT_THAT(output_file, IsOk());
+    if (!output_file) {
+      return nullptr;
     }
-    return to_read;
+    return std::move(output_file.value());
   }
 
-  Status ReadFully(int64_t position, std::span<std::byte> out) override {
-    if (position < 0 || position + static_cast<int64_t>(out.size()) >
-                            static_cast<int64_t>(buffer_->size())) {
-      return Invalid("ReadFully out of bounds");
+  std::unique_ptr<InputFile> Input() {
+    auto input_file = io.NewInputFile(location);
+    EXPECT_THAT(input_file, IsOk());
+    if (!input_file) {
+      return nullptr;
     }
-    std::memcpy(out.data(), buffer_->data() + position, out.size());
-    return {};
+    return std::move(input_file.value());
   }
 
-  Status Close() override { return {}; }
-
- private:
-  std::shared_ptr<std::vector<std::byte>> buffer_;
-  int64_t position_ = 0;
-};
-
-class MemoryOutputFile : public OutputFile {
- public:
-  explicit MemoryOutputFile(std::shared_ptr<std::vector<std::byte>> buffer)
-      : buffer_(std::move(buffer)) {}
-
-  std::string_view location() const override { return "memory://test.puffin"; }
-
-  Result<std::unique_ptr<PositionOutputStream>> Create() override {
-    return CreateOrOverwrite();
+  std::unique_ptr<InputFile> Input(int64_t file_size) {
+    auto input_file = io.NewInputFile(location, static_cast<size_t>(file_size));
+    EXPECT_THAT(input_file, IsOk());
+    if (!input_file) {
+      return nullptr;
+    }
+    return std::move(input_file.value());
   }
 
-  Result<std::unique_ptr<PositionOutputStream>> CreateOrOverwrite() override {
-    buffer_->clear();
-    return std::make_unique<MemoryOutputStream>(buffer_);
-  }
+  std::vector<std::byte>& Data() { return io.FileData(location); }
 
- private:
-  std::shared_ptr<std::vector<std::byte>> buffer_;
-};
+  const std::vector<std::byte>& Data() const { return io.FileData(location); }
 
-class MemoryInputFile : public InputFile {
- public:
-  explicit MemoryInputFile(std::shared_ptr<std::vector<std::byte>> buffer)
-      : buffer_(std::move(buffer)) {}
-
-  std::string_view location() const override { return "memory://test.puffin"; }
-
-  Result<int64_t> Size() const override { return static_cast<int64_t>(buffer_->size()); }
-
-  Result<std::unique_ptr<SeekableInputStream>> Open() override {
-    return std::make_unique<MemoryInputStream>(buffer_);
-  }
-
- private:
-  std::shared_ptr<std::vector<std::byte>> buffer_;
-};
-
-// Helper to create a shared buffer and output/input file pair.
-struct MemoryFile {
-  std::shared_ptr<std::vector<std::byte>> buffer =
-      std::make_shared<std::vector<std::byte>>();
-
-  std::unique_ptr<OutputFile> output() {
-    return std::make_unique<MemoryOutputFile>(buffer);
-  }
-
-  std::unique_ptr<InputFile> input() { return std::make_unique<MemoryInputFile>(buffer); }
+  void SetData(std::span<const std::byte> bytes) { io.AddFile(location, bytes); }
 };
 
 std::vector<std::byte> ToBytes(std::string_view str) {
@@ -154,23 +82,17 @@ std::vector<std::byte> ToBytes(std::string_view str) {
 
 }  // namespace
 
-// ============================================================================
-// PuffinWriter Tests
-// ============================================================================
-
 TEST(PuffinWriterTest, WriteEmptyFile) {
-  MemoryFile file;
-  ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
+  PuffinFile file;
+  ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.Output()));
   ASSERT_THAT(writer->Finish(), IsOk());
 
-  auto& data = *file.buffer;
+  auto& data = file.Data();
   EXPECT_GE(data.size(), 20u);
-  // Header magic
   EXPECT_EQ(data[0], std::byte{0x50});
   EXPECT_EQ(data[1], std::byte{0x46});
   EXPECT_EQ(data[2], std::byte{0x41});
   EXPECT_EQ(data[3], std::byte{0x31});
-  // Footer end magic
   auto sz = data.size();
   EXPECT_EQ(data[sz - 4], std::byte{0x50});
   EXPECT_EQ(data[sz - 3], std::byte{0x46});
@@ -178,43 +100,61 @@ TEST(PuffinWriterTest, WriteEmptyFile) {
   EXPECT_EQ(data[sz - 1], std::byte{0x31});
 
   EXPECT_TRUE(writer->written_blobs_metadata().empty());
-  ICEBERG_UNWRAP_OR_FAIL(auto fsize, writer->file_size());
+  ICEBERG_UNWRAP_OR_FAIL(auto fsize, writer->FileSize());
   EXPECT_EQ(fsize, static_cast<int64_t>(data.size()));
 }
 
 TEST(PuffinWriterTest, WriterRejectsAfterFinish) {
-  MemoryFile file;
-  ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
+  PuffinFile file;
+  ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.Output()));
   ASSERT_THAT(writer->Finish(), IsOk());
 
-  // Double finish
-  EXPECT_THAT(writer->Finish(), IsError(ErrorKind::kInvalid));
+  EXPECT_THAT(writer->Finish(), IsError(ErrorKind::kInvalidArgument));
 
-  // Write after finish
   Blob blob{.type = "a", .snapshot_id = 1, .sequence_number = 0};
-  EXPECT_THAT(writer->Write(blob), IsError(ErrorKind::kInvalid));
+  EXPECT_THAT(writer->Write(blob), IsError(ErrorKind::kInvalidArgument));
 }
 
 TEST(PuffinWriterTest, MakeRejectsNullOutput) {
   EXPECT_THAT(PuffinWriter::Make(nullptr), IsError(ErrorKind::kInvalidArgument));
 }
 
-TEST(PuffinWriterTest, SizesBeforeFinishReturnError) {
-  MemoryFile file;
-  ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
-  EXPECT_THAT(writer->footer_size(), IsError(ErrorKind::kInvalid));
-  EXPECT_THAT(writer->file_size(), IsError(ErrorKind::kInvalid));
+TEST(PuffinWriterTest, MakeDoesNotOverwriteExistingFile) {
+  PuffinFile file;
+  file.Data().push_back(std::byte{0x42});
+
+  EXPECT_THAT(PuffinWriter::Make(file.Output()), IsError(ErrorKind::kAlreadyExists));
+  ASSERT_EQ(file.Data().size(), 1);
+  EXPECT_EQ(file.Data().front(), std::byte{0x42});
 }
 
-// ============================================================================
-// Round-Trip Tests
-// ============================================================================
+TEST(PuffinWriterTest, SizesBeforeFinishReturnError) {
+  PuffinFile file;
+  ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.Output()));
+  EXPECT_THAT(writer->FooterSize(), IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(writer->FileSize(), IsError(ErrorKind::kInvalidArgument));
+}
+
+TEST(PuffinWriterTest, CloseImplicitlyFinishesFile) {
+  PuffinFile file;
+  ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.Output()));
+
+  ASSERT_THAT(writer->Close(), IsOk());
+  EXPECT_THAT(writer->Close(), IsOk());
+
+  ICEBERG_UNWRAP_OR_FAIL(auto fsize, writer->FileSize());
+  EXPECT_EQ(fsize, static_cast<int64_t>(file.Data().size()));
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.Input()));
+  ICEBERG_UNWRAP_OR_FAIL(auto fm, reader->ReadFileMetadata());
+  EXPECT_TRUE(fm.blobs.empty());
+}
 
 TEST(PuffinRoundTripTest, SingleBlob) {
-  MemoryFile file;
+  PuffinFile file;
   {
     ICEBERG_UNWRAP_OR_FAIL(auto writer,
-                           PuffinWriter::Make(file.output(), {{"created-by", "test"}}));
+                           PuffinWriter::Make(file.Output(), {{"created-by", "test"}}));
     std::vector<uint8_t> blob_data = {0x01, 0x02, 0x03, 0x04, 0x05};
     ICEBERG_UNWRAP_OR_FAIL(auto meta, writer->Write(Blob{.type = "test-blob",
                                                          .input_fields = {1, 2},
@@ -222,14 +162,14 @@ TEST(PuffinRoundTripTest, SingleBlob) {
                                                          .sequence_number = 7,
                                                          .data = blob_data}));
     EXPECT_EQ(meta.type, "test-blob");
-    EXPECT_EQ(meta.offset, 4);  // after header magic
+    EXPECT_EQ(meta.offset, 4);
     EXPECT_EQ(meta.length, 5);
     ASSERT_THAT(writer->Finish(), IsOk());
-    ICEBERG_UNWRAP_OR_FAIL(auto fsize, writer->file_size());
+    ICEBERG_UNWRAP_OR_FAIL(auto fsize, writer->FileSize());
     EXPECT_GT(fsize, 0);
   }
 
-  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.input()));
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.Input()));
   ICEBERG_UNWRAP_OR_FAIL(auto fm, reader->ReadFileMetadata());
   ASSERT_EQ(fm.blobs.size(), 1);
   EXPECT_EQ(fm.blobs[0].type, "test-blob");
@@ -242,9 +182,9 @@ TEST(PuffinRoundTripTest, SingleBlob) {
 }
 
 TEST(PuffinRoundTripTest, MultipleBlobs) {
-  MemoryFile file;
+  PuffinFile file;
   {
-    ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
+    ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.Output()));
     ICEBERG_UNWRAP_OR_FAIL(auto m1, writer->Write(Blob{.type = "first",
                                                        .input_fields = {1},
                                                        .snapshot_id = 1,
@@ -256,12 +196,12 @@ TEST(PuffinRoundTripTest, MultipleBlobs) {
                                                        .sequence_number = 1,
                                                        .data = {'d', 'e', 'f', 'g'},
                                                        .properties = {{"key", "val"}}}));
-    EXPECT_EQ(m2.offset, 7);  // header(4) + first blob(3)
+    EXPECT_EQ(m2.offset, 7);
     EXPECT_EQ(m2.length, 4);
     ASSERT_THAT(writer->Finish(), IsOk());
   }
 
-  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.input()));
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.Input()));
   ICEBERG_UNWRAP_OR_FAIL(auto fm, reader->ReadFileMetadata());
   ASSERT_EQ(fm.blobs.size(), 2);
   EXPECT_TRUE(fm.blobs[0].properties.empty());
@@ -274,11 +214,11 @@ TEST(PuffinRoundTripTest, MultipleBlobs) {
 }
 
 TEST(PuffinRoundTripTest, WithProperties) {
-  MemoryFile file;
+  PuffinFile file;
   {
     ICEBERG_UNWRAP_OR_FAIL(
         auto writer,
-        PuffinWriter::Make(file.output(), {{"created-by", "iceberg-cpp-test"}}));
+        PuffinWriter::Make(file.Output(), {{"created-by", "iceberg-cpp-test"}}));
     std::string text = "hello puffin";
     std::vector<uint8_t> blob_data(text.begin(), text.end());
     ASSERT_THAT(writer->Write(Blob{.type = "text-blob",
@@ -291,7 +231,7 @@ TEST(PuffinRoundTripTest, WithProperties) {
     ASSERT_THAT(writer->Finish(), IsOk());
   }
 
-  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.input()));
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.Input()));
   ICEBERG_UNWRAP_OR_FAIL(auto fm, reader->ReadFileMetadata());
   EXPECT_EQ(fm.properties.at("created-by"), "iceberg-cpp-test");
   ASSERT_EQ(fm.blobs.size(), 1);
@@ -301,65 +241,59 @@ TEST(PuffinRoundTripTest, WithProperties) {
   EXPECT_EQ(blob_result.second, ToBytes("hello puffin"));
 }
 
-// ============================================================================
-// PuffinReader Error Tests
-// ============================================================================
-
 TEST(PuffinReaderTest, MakeRejectsNullInput) {
   EXPECT_THAT(PuffinReader::Make(nullptr), IsError(ErrorKind::kInvalidArgument));
 }
 
-TEST(PuffinReaderTest, InvalidMagic) {
-  auto buffer = std::make_shared<std::vector<std::byte>>(16, std::byte{0x00});
-  auto input = std::make_unique<MemoryInputFile>(buffer);
-  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(std::move(input)));
-  EXPECT_THAT(reader->ReadFileMetadata(), IsError(ErrorKind::kInvalid));
-}
-
-TEST(PuffinReaderTest, TruncatedFile) {
-  auto buffer = std::make_shared<std::vector<std::byte>>(2, std::byte{0x50});
-  auto input = std::make_unique<MemoryInputFile>(buffer);
-  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(std::move(input)));
-  EXPECT_THAT(reader->ReadFileMetadata(), IsError(ErrorKind::kInvalid));
-}
-
-TEST(PuffinReaderTest, InvalidBlobOffset) {
-  MemoryFile file;
+TEST(PuffinReaderTest, MakeUsesKnownFileSizeAndFooterSize) {
+  PuffinFile file;
+  int64_t footer_size = 0;
+  int64_t file_size = 0;
   {
-    ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
+    ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.Output()));
     ASSERT_THAT(writer->Finish(), IsOk());
+    ICEBERG_UNWRAP_OR_FAIL(footer_size, writer->FooterSize());
+    ICEBERG_UNWRAP_OR_FAIL(file_size, writer->FileSize());
   }
 
-  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.input()));
-  BlobMetadata bad_meta{.type = "bad",
-                        .snapshot_id = 1,
-                        .sequence_number = 0,
-                        .offset = 9999,
-                        .length = 100};
-  EXPECT_THAT(reader->ReadBlob(bad_meta), IsError(ErrorKind::kInvalid));
+  ICEBERG_UNWRAP_OR_FAIL(
+      auto reader, PuffinReader::Make(file.Input(file_size), footer_size, file_size));
+  ICEBERG_UNWRAP_OR_FAIL(auto fm, reader->ReadFileMetadata());
+  EXPECT_TRUE(fm.blobs.empty());
+}
+
+TEST(PuffinReaderTest, KnownFooterSizeMismatchIsRejected) {
+  PuffinFile file;
+  int64_t footer_size = 0;
+  int64_t file_size = 0;
+  {
+    ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.Output()));
+    ASSERT_THAT(writer->Finish(), IsOk());
+    ICEBERG_UNWRAP_OR_FAIL(footer_size, writer->FooterSize());
+    ICEBERG_UNWRAP_OR_FAIL(file_size, writer->FileSize());
+  }
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader,
+                         PuffinReader::Make(file.Input(), footer_size - 1, file_size));
+  EXPECT_THAT(reader->ReadFileMetadata(), IsError(ErrorKind::kInvalidArgument));
 }
 
 TEST(PuffinReaderTest, UnknownFlagsRejected) {
-  // Build a valid puffin file then tamper with flags
-  MemoryFile file;
+  PuffinFile file;
   {
-    ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
+    ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.Output()));
     ASSERT_THAT(writer->Finish(), IsOk());
   }
-  // Set unknown flag bit in the footer struct (flags are at offset -8 from end)
-  auto& data = *file.buffer;
-  data[data.size() - 8] = std::byte{0x02};  // bit 1 is unknown
+  auto& data = file.Data();
+  data[data.size() - 8] = std::byte{0x02};
 
-  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.input()));
-  EXPECT_THAT(reader->ReadFileMetadata(), IsError(ErrorKind::kInvalid));
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.Input()));
+  EXPECT_THAT(reader->ReadFileMetadata(), IsError(ErrorKind::kInvalidArgument));
 }
 
-// ============================================================================
-// Java Binary Compatibility Tests
-// ============================================================================
-
-TEST(PuffinReaderTest, JavaEmptyPuffinCompatibility) {
-  auto buffer = std::make_shared<std::vector<std::byte>>(std::vector<std::byte>{
+TEST(PuffinReaderTest, EmptyPuffinCompatibility) {
+  PuffinFile file;
+  std::vector<std::byte> data{
       std::byte{0x50}, std::byte{0x46}, std::byte{0x41}, std::byte{0x31}, std::byte{0x50},
       std::byte{0x46}, std::byte{0x41}, std::byte{0x31}, std::byte{0x7b}, std::byte{0x22},
       std::byte{0x62}, std::byte{0x6c}, std::byte{0x6f}, std::byte{0x62}, std::byte{0x73},
@@ -367,10 +301,10 @@ TEST(PuffinReaderTest, JavaEmptyPuffinCompatibility) {
       std::byte{0x0c}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00},
       std::byte{0x00}, std::byte{0x00}, std::byte{0x00}, std::byte{0x50}, std::byte{0x46},
       std::byte{0x41}, std::byte{0x31},
-  });
+  };
+  file.SetData(data);
 
-  auto input = std::make_unique<MemoryInputFile>(buffer);
-  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(std::move(input)));
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.Input()));
   ICEBERG_UNWRAP_OR_FAIL(auto fm, reader->ReadFileMetadata());
   EXPECT_TRUE(fm.blobs.empty());
   EXPECT_TRUE(fm.properties.empty());

--- a/src/iceberg/test/puffin_reader_writer_test.cc
+++ b/src/iceberg/test/puffin_reader_writer_test.cc
@@ -1,0 +1,379 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "iceberg/file_io.h"
+#include "iceberg/puffin/file_metadata.h"
+#include "iceberg/puffin/puffin_reader.h"
+#include "iceberg/puffin/puffin_writer.h"
+#include "iceberg/test/matchers.h"
+
+namespace iceberg::puffin {
+
+namespace {
+
+// Simple in-memory stream implementations for testing.
+
+class MemoryOutputStream : public PositionOutputStream {
+ public:
+  explicit MemoryOutputStream(std::shared_ptr<std::vector<std::byte>> buffer)
+      : buffer_(std::move(buffer)) {}
+
+  Result<int64_t> Position() const override {
+    return static_cast<int64_t>(buffer_->size());
+  }
+
+  Status Write(std::span<const std::byte> data) override {
+    buffer_->insert(buffer_->end(), data.begin(), data.end());
+    return {};
+  }
+
+  Status Flush() override { return {}; }
+  Status Close() override { return {}; }
+
+ private:
+  std::shared_ptr<std::vector<std::byte>> buffer_;
+};
+
+class MemoryInputStream : public SeekableInputStream {
+ public:
+  explicit MemoryInputStream(std::shared_ptr<std::vector<std::byte>> buffer)
+      : buffer_(std::move(buffer)) {}
+
+  Result<int64_t> Position() const override { return position_; }
+
+  Status Seek(int64_t position) override {
+    position_ = position;
+    return {};
+  }
+
+  Result<int64_t> Read(std::span<std::byte> out) override {
+    auto available = static_cast<int64_t>(buffer_->size()) - position_;
+    auto to_read = std::min(static_cast<int64_t>(out.size()), available);
+    if (to_read > 0) {
+      std::memcpy(out.data(), buffer_->data() + position_, to_read);
+      position_ += to_read;
+    }
+    return to_read;
+  }
+
+  Status ReadFully(int64_t position, std::span<std::byte> out) override {
+    if (position < 0 || position + static_cast<int64_t>(out.size()) >
+                            static_cast<int64_t>(buffer_->size())) {
+      return Invalid("ReadFully out of bounds");
+    }
+    std::memcpy(out.data(), buffer_->data() + position, out.size());
+    return {};
+  }
+
+  Status Close() override { return {}; }
+
+ private:
+  std::shared_ptr<std::vector<std::byte>> buffer_;
+  int64_t position_ = 0;
+};
+
+class MemoryOutputFile : public OutputFile {
+ public:
+  explicit MemoryOutputFile(std::shared_ptr<std::vector<std::byte>> buffer)
+      : buffer_(std::move(buffer)) {}
+
+  std::string_view location() const override { return "memory://test.puffin"; }
+
+  Result<std::unique_ptr<PositionOutputStream>> Create() override {
+    return CreateOrOverwrite();
+  }
+
+  Result<std::unique_ptr<PositionOutputStream>> CreateOrOverwrite() override {
+    buffer_->clear();
+    return std::make_unique<MemoryOutputStream>(buffer_);
+  }
+
+ private:
+  std::shared_ptr<std::vector<std::byte>> buffer_;
+};
+
+class MemoryInputFile : public InputFile {
+ public:
+  explicit MemoryInputFile(std::shared_ptr<std::vector<std::byte>> buffer)
+      : buffer_(std::move(buffer)) {}
+
+  std::string_view location() const override { return "memory://test.puffin"; }
+
+  Result<int64_t> Size() const override { return static_cast<int64_t>(buffer_->size()); }
+
+  Result<std::unique_ptr<SeekableInputStream>> Open() override {
+    return std::make_unique<MemoryInputStream>(buffer_);
+  }
+
+ private:
+  std::shared_ptr<std::vector<std::byte>> buffer_;
+};
+
+// Helper to create a shared buffer and output/input file pair.
+struct MemoryFile {
+  std::shared_ptr<std::vector<std::byte>> buffer =
+      std::make_shared<std::vector<std::byte>>();
+
+  std::unique_ptr<OutputFile> output() {
+    return std::make_unique<MemoryOutputFile>(buffer);
+  }
+
+  std::unique_ptr<InputFile> input() { return std::make_unique<MemoryInputFile>(buffer); }
+};
+
+std::vector<std::byte> ToBytes(std::string_view str) {
+  return {reinterpret_cast<const std::byte*>(str.data()),
+          reinterpret_cast<const std::byte*>(str.data() + str.size())};
+}
+
+}  // namespace
+
+// ============================================================================
+// PuffinWriter Tests
+// ============================================================================
+
+TEST(PuffinWriterTest, WriteEmptyFile) {
+  MemoryFile file;
+  ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
+  ASSERT_THAT(writer->Finish(), IsOk());
+
+  auto& data = *file.buffer;
+  EXPECT_GE(data.size(), 20u);
+  // Header magic
+  EXPECT_EQ(data[0], std::byte{0x50});
+  EXPECT_EQ(data[1], std::byte{0x46});
+  EXPECT_EQ(data[2], std::byte{0x41});
+  EXPECT_EQ(data[3], std::byte{0x31});
+  // Footer end magic
+  auto sz = data.size();
+  EXPECT_EQ(data[sz - 4], std::byte{0x50});
+  EXPECT_EQ(data[sz - 3], std::byte{0x46});
+  EXPECT_EQ(data[sz - 2], std::byte{0x41});
+  EXPECT_EQ(data[sz - 1], std::byte{0x31});
+
+  EXPECT_TRUE(writer->written_blobs_metadata().empty());
+  ICEBERG_UNWRAP_OR_FAIL(auto fsize, writer->file_size());
+  EXPECT_EQ(fsize, static_cast<int64_t>(data.size()));
+}
+
+TEST(PuffinWriterTest, WriterRejectsAfterFinish) {
+  MemoryFile file;
+  ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
+  ASSERT_THAT(writer->Finish(), IsOk());
+
+  // Double finish
+  EXPECT_THAT(writer->Finish(), IsError(ErrorKind::kInvalid));
+
+  // Write after finish
+  Blob blob{.type = "a", .snapshot_id = 1, .sequence_number = 0};
+  EXPECT_THAT(writer->Write(blob), IsError(ErrorKind::kInvalid));
+}
+
+TEST(PuffinWriterTest, MakeRejectsNullOutput) {
+  EXPECT_THAT(PuffinWriter::Make(nullptr), IsError(ErrorKind::kInvalidArgument));
+}
+
+TEST(PuffinWriterTest, SizesBeforeFinishReturnError) {
+  MemoryFile file;
+  ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
+  EXPECT_THAT(writer->footer_size(), IsError(ErrorKind::kInvalid));
+  EXPECT_THAT(writer->file_size(), IsError(ErrorKind::kInvalid));
+}
+
+// ============================================================================
+// Round-Trip Tests
+// ============================================================================
+
+TEST(PuffinRoundTripTest, SingleBlob) {
+  MemoryFile file;
+  {
+    ICEBERG_UNWRAP_OR_FAIL(auto writer,
+                           PuffinWriter::Make(file.output(), {{"created-by", "test"}}));
+    std::vector<uint8_t> blob_data = {0x01, 0x02, 0x03, 0x04, 0x05};
+    ICEBERG_UNWRAP_OR_FAIL(auto meta, writer->Write(Blob{.type = "test-blob",
+                                                         .input_fields = {1, 2},
+                                                         .snapshot_id = 42,
+                                                         .sequence_number = 7,
+                                                         .data = blob_data}));
+    EXPECT_EQ(meta.type, "test-blob");
+    EXPECT_EQ(meta.offset, 4);  // after header magic
+    EXPECT_EQ(meta.length, 5);
+    ASSERT_THAT(writer->Finish(), IsOk());
+    ICEBERG_UNWRAP_OR_FAIL(auto fsize, writer->file_size());
+    EXPECT_GT(fsize, 0);
+  }
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.input()));
+  ICEBERG_UNWRAP_OR_FAIL(auto fm, reader->ReadFileMetadata());
+  ASSERT_EQ(fm.blobs.size(), 1);
+  EXPECT_EQ(fm.blobs[0].type, "test-blob");
+  EXPECT_EQ(fm.properties.at("created-by"), "test");
+
+  ICEBERG_UNWRAP_OR_FAIL(auto blob_result, reader->ReadBlob(fm.blobs[0]));
+  std::vector<std::byte> expected = {std::byte{0x01}, std::byte{0x02}, std::byte{0x03},
+                                     std::byte{0x04}, std::byte{0x05}};
+  EXPECT_EQ(blob_result.second, expected);
+}
+
+TEST(PuffinRoundTripTest, MultipleBlobs) {
+  MemoryFile file;
+  {
+    ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
+    ICEBERG_UNWRAP_OR_FAIL(auto m1, writer->Write(Blob{.type = "first",
+                                                       .input_fields = {1},
+                                                       .snapshot_id = 1,
+                                                       .sequence_number = 0,
+                                                       .data = {'a', 'b', 'c'}}));
+    ICEBERG_UNWRAP_OR_FAIL(auto m2, writer->Write(Blob{.type = "second",
+                                                       .input_fields = {2},
+                                                       .snapshot_id = 2,
+                                                       .sequence_number = 1,
+                                                       .data = {'d', 'e', 'f', 'g'},
+                                                       .properties = {{"key", "val"}}}));
+    EXPECT_EQ(m2.offset, 7);  // header(4) + first blob(3)
+    EXPECT_EQ(m2.length, 4);
+    ASSERT_THAT(writer->Finish(), IsOk());
+  }
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.input()));
+  ICEBERG_UNWRAP_OR_FAIL(auto fm, reader->ReadFileMetadata());
+  ASSERT_EQ(fm.blobs.size(), 2);
+  EXPECT_TRUE(fm.blobs[0].properties.empty());
+  EXPECT_EQ(fm.blobs[1].properties.at("key"), "val");
+
+  ICEBERG_UNWRAP_OR_FAIL(auto all, reader->ReadAll(fm.blobs));
+  ASSERT_EQ(all.size(), 2);
+  EXPECT_EQ(all[0].second, ToBytes("abc"));
+  EXPECT_EQ(all[1].second, ToBytes("defg"));
+}
+
+TEST(PuffinRoundTripTest, WithProperties) {
+  MemoryFile file;
+  {
+    ICEBERG_UNWRAP_OR_FAIL(
+        auto writer,
+        PuffinWriter::Make(file.output(), {{"created-by", "iceberg-cpp-test"}}));
+    std::string text = "hello puffin";
+    std::vector<uint8_t> blob_data(text.begin(), text.end());
+    ASSERT_THAT(writer->Write(Blob{.type = "text-blob",
+                                   .input_fields = {1},
+                                   .snapshot_id = 100,
+                                   .sequence_number = 5,
+                                   .data = blob_data,
+                                   .properties = {{"encoding", "utf-8"}}}),
+                IsOk());
+    ASSERT_THAT(writer->Finish(), IsOk());
+  }
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.input()));
+  ICEBERG_UNWRAP_OR_FAIL(auto fm, reader->ReadFileMetadata());
+  EXPECT_EQ(fm.properties.at("created-by"), "iceberg-cpp-test");
+  ASSERT_EQ(fm.blobs.size(), 1);
+  EXPECT_EQ(fm.blobs[0].properties.at("encoding"), "utf-8");
+
+  ICEBERG_UNWRAP_OR_FAIL(auto blob_result, reader->ReadBlob(fm.blobs[0]));
+  EXPECT_EQ(blob_result.second, ToBytes("hello puffin"));
+}
+
+// ============================================================================
+// PuffinReader Error Tests
+// ============================================================================
+
+TEST(PuffinReaderTest, MakeRejectsNullInput) {
+  EXPECT_THAT(PuffinReader::Make(nullptr), IsError(ErrorKind::kInvalidArgument));
+}
+
+TEST(PuffinReaderTest, InvalidMagic) {
+  auto buffer = std::make_shared<std::vector<std::byte>>(16, std::byte{0x00});
+  auto input = std::make_unique<MemoryInputFile>(buffer);
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(std::move(input)));
+  EXPECT_THAT(reader->ReadFileMetadata(), IsError(ErrorKind::kInvalid));
+}
+
+TEST(PuffinReaderTest, TruncatedFile) {
+  auto buffer = std::make_shared<std::vector<std::byte>>(2, std::byte{0x50});
+  auto input = std::make_unique<MemoryInputFile>(buffer);
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(std::move(input)));
+  EXPECT_THAT(reader->ReadFileMetadata(), IsError(ErrorKind::kInvalid));
+}
+
+TEST(PuffinReaderTest, InvalidBlobOffset) {
+  MemoryFile file;
+  {
+    ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
+    ASSERT_THAT(writer->Finish(), IsOk());
+  }
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.input()));
+  BlobMetadata bad_meta{.type = "bad",
+                        .snapshot_id = 1,
+                        .sequence_number = 0,
+                        .offset = 9999,
+                        .length = 100};
+  EXPECT_THAT(reader->ReadBlob(bad_meta), IsError(ErrorKind::kInvalid));
+}
+
+TEST(PuffinReaderTest, UnknownFlagsRejected) {
+  // Build a valid puffin file then tamper with flags
+  MemoryFile file;
+  {
+    ICEBERG_UNWRAP_OR_FAIL(auto writer, PuffinWriter::Make(file.output()));
+    ASSERT_THAT(writer->Finish(), IsOk());
+  }
+  // Set unknown flag bit in the footer struct (flags are at offset -8 from end)
+  auto& data = *file.buffer;
+  data[data.size() - 8] = std::byte{0x02};  // bit 1 is unknown
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(file.input()));
+  EXPECT_THAT(reader->ReadFileMetadata(), IsError(ErrorKind::kInvalid));
+}
+
+// ============================================================================
+// Java Binary Compatibility Tests
+// ============================================================================
+
+TEST(PuffinReaderTest, JavaEmptyPuffinCompatibility) {
+  auto buffer = std::make_shared<std::vector<std::byte>>(std::vector<std::byte>{
+      std::byte{0x50}, std::byte{0x46}, std::byte{0x41}, std::byte{0x31}, std::byte{0x50},
+      std::byte{0x46}, std::byte{0x41}, std::byte{0x31}, std::byte{0x7b}, std::byte{0x22},
+      std::byte{0x62}, std::byte{0x6c}, std::byte{0x6f}, std::byte{0x62}, std::byte{0x73},
+      std::byte{0x22}, std::byte{0x3a}, std::byte{0x5b}, std::byte{0x5d}, std::byte{0x7d},
+      std::byte{0x0c}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00},
+      std::byte{0x00}, std::byte{0x00}, std::byte{0x00}, std::byte{0x50}, std::byte{0x46},
+      std::byte{0x41}, std::byte{0x31},
+  });
+
+  auto input = std::make_unique<MemoryInputFile>(buffer);
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, PuffinReader::Make(std::move(input)));
+  ICEBERG_UNWRAP_OR_FAIL(auto fm, reader->ReadFileMetadata());
+  EXPECT_TRUE(fm.blobs.empty());
+  EXPECT_TRUE(fm.properties.empty());
+}
+
+}  // namespace iceberg::puffin

--- a/src/iceberg/type_fwd.h
+++ b/src/iceberg/type_fwd.h
@@ -188,6 +188,11 @@ class FileIO;
 class Reader;
 class Writer;
 
+class InputFile;
+class OutputFile;
+class PositionOutputStream;
+class SeekableInputStream;
+
 /// \brief Row-based data structures.
 class ArrayLike;
 class MapLike;


### PR DESCRIPTION
- PuffinWriter: in-memory writer that builds complete Puffin files
  - Add() writes blobs with optional compression
  - Finish() serializes footer with JSON metadata
  - Tracks BlobMetadata for all written blobs
- PuffinReader: in-memory reader that parses Puffin files
  - ReadFileMetadata() parses footer and validates magic bytes
  - ReadBlob() reads and decompresses individual blobs
  - ReadAll() reads all blobs from metadata
- Expose Compress/Decompress as public API in puffin_format.h
- Register new sources in CMake and Meson build systems
- Add comprehensive tests