### PR TITLE
fix(cmake): use consistent generator expressions to link libraries

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -26,5 +26,7 @@ find_package(iceberg CONFIG REQUIRED COMPONENTS bundle rest)
 
 add_executable(demo_example demo_example.cc)
 
-target_link_libraries(demo_example PRIVATE iceberg::iceberg_bundle_shared
-                                           iceberg::iceberg_rest_shared)
+target_link_libraries(demo_example
+                      PRIVATE "$<IF:$<TARGET_EXISTS:iceberg::iceberg_bundle_shared>,iceberg::iceberg_bundle_shared,iceberg::iceberg_bundle_static>"
+                              "$<IF:$<TARGET_EXISTS:iceberg::iceberg_rest_shared>,iceberg::iceberg_rest_shared,iceberg::iceberg_rest_static>"
+)

--- a/src/iceberg/test/CMakeLists.txt
+++ b/src/iceberg/test/CMakeLists.txt
@@ -46,13 +46,17 @@ function(add_iceberg_test test_name)
   target_sources(${test_name} PRIVATE ${ARG_SOURCES})
 
   if(ARG_USE_BUNDLE)
-    target_link_libraries(${test_name} PRIVATE iceberg_bundle_static GTest::gmock_main)
+    target_link_libraries(${test_name}
+                          PRIVATE "$<IF:$<TARGET_EXISTS:iceberg_bundle_static>,iceberg_bundle_static,iceberg_bundle_shared>"
+                                  GTest::gmock_main)
   elseif(ARG_USE_DATA)
     target_link_libraries(${test_name}
                           PRIVATE "$<IF:$<TARGET_EXISTS:iceberg_data_static>,iceberg_data_static,iceberg_data_shared>"
                                   GTest::gmock_main)
   else()
-    target_link_libraries(${test_name} PRIVATE iceberg_static GTest::gmock_main)
+    target_link_libraries(${test_name}
+                          PRIVATE "$<IF:$<TARGET_EXISTS:iceberg_static>,iceberg_static,iceberg_shared>"
+                                  GTest::gmock_main)
   endif()
 
   if(MSVC_TOOLCHAIN)


### PR DESCRIPTION
also resolves a comment left in https://github.com/apache/iceberg-cpp/pull/635#discussion_r3178277652