### PR TITLE
ci: use ilammy/msvc-dev-cmd for Windows MSVC environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+      - name: Set up MSVC Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: x64
       - name: Install dependencies
         shell: pwsh
         run: |
@@ -133,14 +137,14 @@ jobs:
           SCCACHE_GHA_ENABLED: "true"
         run: |
           $ErrorActionPreference = "Stop"
-          cmd /c "call `"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat`" x64 && bash -lc `"ci/scripts/build_iceberg.sh `$(pwd) OFF ON`""
+          bash -lc 'ci/scripts/build_iceberg.sh $(pwd) OFF ON'
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           sccache --show-stats
       - name: Build Example
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
-          cmd /c "call `"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat`" x64 && bash -lc `"ci/scripts/build_example.sh `$(pwd)/example`""
+          bash -lc 'ci/scripts/build_example.sh $(pwd)/example'
   meson:
     name: Meson - ${{ matrix.title }}
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
Replace hardcoded vcvarsall.bat path with the Apache-approved ilammy/msvc-dev-cmd action so builds work across VS image layouts.