### PR TITLE
build: sync Meson project version with CMake

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 project(
     'iceberg',
     'cpp',
-    version: '0.2.0',
+    version: '0.3.0',
     license: 'Apache-2.0',
     meson_version: '>=1.3.0',
     default_options: [


### PR DESCRIPTION
## Summary

Update the Meson project version from 0.2.0 to 0.3.0 to match the CMake project version.
