### PR TITLE
fix(ci): fix macOS ci to use provided fmt

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -105,6 +105,13 @@ jobs:
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
 
+      - name: Install fmt on macOS
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        shell: bash
+        run: |
+          brew install fmt
+          echo "CMAKE_PREFIX_PATH=$(brew --prefix fmt):${CMAKE_PREFIX_PATH:-}" >> "${GITHUB_ENV}"
+
       - name: Verify
         run: |
           tar_gz=$(echo apache-iceberg-cpp-*.tar.gz)

--- a/.github/workflows/s3_test.yml
+++ b/.github/workflows/s3_test.yml
@@ -73,6 +73,12 @@ jobs:
         run: |
           echo "CC=${{ matrix.CC }}" >> $GITHUB_ENV
           echo "CXX=${{ matrix.CXX }}" >> $GITHUB_ENV
+      - name: Install fmt on macOS
+        if: ${{ startsWith(matrix.runs-on, 'macos') }}
+        shell: bash
+        run: |
+          brew install fmt
+          echo "CMAKE_PREFIX_PATH=$(brew --prefix fmt):${CMAKE_PREFIX_PATH:-}" >> "${GITHUB_ENV}"
       - name: Start MinIO
         shell: bash
         run: bash ci/scripts/start_minio.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Install fmt
+        shell: bash
+        run: |
+          brew install fmt
+          echo "CMAKE_PREFIX_PATH=$(brew --prefix fmt):${CMAKE_PREFIX_PATH:-}" >> "${GITHUB_ENV}"
       - name: Build Iceberg
         shell: bash
         run: ci/scripts/build_iceberg.sh $(pwd)

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -248,6 +248,11 @@ function(resolve_avro_dependency)
     set(AVRO_VENDORED TRUE)
     set_target_properties(avrocpp_s PROPERTIES OUTPUT_NAME "iceberg_vendored_avrocpp")
     set_target_properties(avrocpp_s PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+      # Work around AppleClang 21 rejecting fmt's consteval format-string checks
+      # while compiling vendored avro-cpp in C++23 mode.
+      target_compile_definitions(avrocpp_s PUBLIC FMT_USE_CONSTEVAL=0)
+    endif()
     install(TARGETS avrocpp_s
             EXPORT iceberg_targets
             RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -251,7 +251,7 @@ function(resolve_avro_dependency)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
       # Work around AppleClang 21 rejecting fmt's consteval format-string checks
       # while compiling vendored avro-cpp in C++23 mode.
-      target_compile_definitions(avrocpp_s PRIVATE FMT_CONSTEVAL=)
+      target_compile_definitions(avrocpp_s PUBLIC FMT_CONSTEVAL=)
     endif()
     install(TARGETS avrocpp_s
             EXPORT iceberg_targets

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -251,7 +251,7 @@ function(resolve_avro_dependency)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
       # Work around AppleClang 21 rejecting fmt's consteval format-string checks
       # while compiling vendored avro-cpp in C++23 mode.
-      target_compile_definitions(avrocpp_s PUBLIC FMT_USE_CONSTEVAL=0)
+      target_compile_definitions(avrocpp_s PUBLIC FMT_CONSTEVAL=)
     endif()
     install(TARGETS avrocpp_s
             EXPORT iceberg_targets

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -251,7 +251,7 @@ function(resolve_avro_dependency)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
       # Work around AppleClang 21 rejecting fmt's consteval format-string checks
       # while compiling vendored avro-cpp in C++23 mode.
-      target_compile_definitions(avrocpp_s PUBLIC FMT_CONSTEVAL=)
+      target_compile_definitions(avrocpp_s PRIVATE FMT_CONSTEVAL=)
     endif()
     install(TARGETS avrocpp_s
             EXPORT iceberg_targets

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -248,11 +248,6 @@ function(resolve_avro_dependency)
     set(AVRO_VENDORED TRUE)
     set_target_properties(avrocpp_s PROPERTIES OUTPUT_NAME "iceberg_vendored_avrocpp")
     set_target_properties(avrocpp_s PROPERTIES POSITION_INDEPENDENT_CODE ON)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-      # Work around AppleClang 21 rejecting fmt's consteval format-string checks
-      # while compiling vendored avro-cpp in C++23 mode.
-      target_compile_definitions(avrocpp_s PUBLIC FMT_CONSTEVAL=)
-    endif()
     install(TARGETS avrocpp_s
             EXPORT iceberg_targets
             RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"


### PR DESCRIPTION
## Summary

Fix the S3 build on macOS 26 / AppleClang by disabling fmt's consteval format-string checks for vendored avro-cpp.

## Problem

The S3 CI job on AArch64 macOS 26 fails while compiling vendored avro-cpp:

```text
fmt/format-inl.h: error: call to consteval function ... is not a constant expression
```

https://github.com/apache/iceberg-cpp/actions/runs/26262392739/job/77298497335?pr=669