### PR TITLE
ci: update pre-commit workflow permissions to write

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,7 +26,7 @@ on:
       - '!dependabot/**'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Change `contents` permission from `read` to `write` in the pre-commit workflow.