### PR TITLE
doc: bump minimum Clang version to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ C++ implementation of [Apache Iceberg™](https://iceberg.apache.org/).
 
 **Required:**
 
-- C++23 compliant compiler (GCC 14+, Clang 16+, MSVC 2022+)
+- C++23 compliant compiler (GCC 14+, Clang 18+, MSVC 2022+)
 - CMake 3.25+ or Meson 1.5+
 - [Ninja](https://ninja-build.org/) (recommended build backend)
 

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -99,7 +99,7 @@ You must install the following to run the script:
     * `shasum` or `sha512sum`
     * `tar`
     * `cmake` (3.25 or higher)
-    * C++23 compliant compiler (GCC 14+, Clang 16+, MSVC 2022+)
+    * C++23 compliant compiler (GCC 14+, Clang 18+, MSVC 2022+)
 
 To verify a RC, run the following:
 

--- a/mkdocs/docs/getting-started.md
+++ b/mkdocs/docs/getting-started.md
@@ -23,7 +23,7 @@
 
 **Required:**
 
-- C++23 compliant compiler (GCC 14+, Clang 16+, MSVC 2022+)
+- C++23 compliant compiler (GCC 14+, Clang 18+, MSVC 2022+)
 - CMake 3.25+ or Meson 1.5+
 - [Ninja](https://ninja-build.org/) (recommended build backend)
 

--- a/mkdocs/docs/verify-rc.md
+++ b/mkdocs/docs/verify-rc.md
@@ -28,7 +28,7 @@ When a release candidate (RC) is published for a vote, community members are enc
 - `shasum` or `sha512sum`
 - `tar`
 - CMake 3.25+
-- C++23 compliant compiler (GCC 14+, Clang 16+, MSVC 2022+)
+- C++23 compliant compiler (GCC 14+, Clang 18+, MSVC 2022+)
 
 ## Verification Steps
 


### PR DESCRIPTION
ErrorCollector uses the C++23 "deducing this" feature (P0847 / explicit object parameters), which is first supported in Clang 18.

For example, the following code compiles with Clang 18+ but fails with Clang 17:

https://godbolt.org/z/17YebzKo4