### PR TITLE
fix(rest): use "ref" field name for AssertRefSnapshotId requirement

### DIFF
--- a/src/iceberg/json_serde.cc
+++ b/src/iceberg/json_serde.cc
@@ -207,6 +207,7 @@ constexpr std::string_view kSortOrderId = "sort-order-id";
 constexpr std::string_view kSnapshot = "snapshot";
 constexpr std::string_view kSnapshotIds = "snapshot-ids";
 constexpr std::string_view kRefName = "ref-name";
+constexpr std::string_view kRef = "ref";
 constexpr std::string_view kUpdates = "updates";
 constexpr std::string_view kRemovals = "removals";
 
@@ -1505,7 +1506,8 @@ nlohmann::json ToJson(const TableRequirement& requirement) {
       const auto& r =
           internal::checked_cast<const table::AssertRefSnapshotID&>(requirement);
       json[kType] = kRequirementAssertRefSnapshotID;
-      json[kRefName] = r.ref_name();
+      // REST spec names this field "ref", not "ref-name".
+      json[kRef] = r.ref_name();
       if (r.snapshot_id().has_value()) {
         json[kSnapshotId] = r.snapshot_id().value();
       } else {
@@ -1702,7 +1704,7 @@ Result<std::unique_ptr<TableRequirement>> TableRequirementFromJson(
     return std::make_unique<table::AssertUUID>(std::move(uuid));
   }
   if (type == kRequirementAssertRefSnapshotID) {
-    ICEBERG_ASSIGN_OR_RAISE(auto ref_name, GetJsonValue<std::string>(json, kRefName));
+    ICEBERG_ASSIGN_OR_RAISE(auto ref_name, GetJsonValue<std::string>(json, kRef));
     ICEBERG_ASSIGN_OR_RAISE(auto snapshot_id_opt,
                             GetJsonValueOptional<int64_t>(json, kSnapshotId));
     return std::make_unique<table::AssertRefSnapshotID>(std::move(ref_name),

--- a/src/iceberg/test/json_serde_test.cc
+++ b/src/iceberg/test/json_serde_test.cc
@@ -681,7 +681,7 @@ TEST(TableRequirementJsonTest, TableRequirementAssertUUID) {
 TEST(TableRequirementJsonTest, TableRequirementAssertRefSnapshotID) {
   table::AssertRefSnapshotID req("main", 123456789);
   nlohmann::json expected =
-      R"({"type":"assert-ref-snapshot-id","ref-name":"main","snapshot-id":123456789})"_json;
+      R"({"type":"assert-ref-snapshot-id","ref":"main","snapshot-id":123456789})"_json;
 
   EXPECT_EQ(ToJson(req), expected);
   auto parsed = TableRequirementFromJson(expected);
@@ -693,13 +693,21 @@ TEST(TableRequirementJsonTest, TableRequirementAssertRefSnapshotID) {
 TEST(TableRequirementJsonTest, TableRequirementAssertRefSnapshotIDWithNull) {
   table::AssertRefSnapshotID req("main", std::nullopt);
   nlohmann::json expected =
-      R"({"type":"assert-ref-snapshot-id","ref-name":"main","snapshot-id":null})"_json;
+      R"({"type":"assert-ref-snapshot-id","ref":"main","snapshot-id":null})"_json;
 
   EXPECT_EQ(ToJson(req), expected);
   auto parsed = TableRequirementFromJson(expected);
   ASSERT_THAT(parsed, IsOk());
   EXPECT_EQ(*internal::checked_cast<table::AssertRefSnapshotID*>(parsed.value().get()),
             req);
+}
+
+TEST(TableRequirementJsonTest, TableRequirementAssertRefSnapshotIDRejectsRefName) {
+  nlohmann::json legacy =
+      R"({"type":"assert-ref-snapshot-id","ref-name":"main","snapshot-id":123456789})"_json;
+  auto result = TableRequirementFromJson(legacy);
+  EXPECT_THAT(result, IsError(ErrorKind::kJsonParseError));
+  EXPECT_THAT(result, HasErrorMessage("Missing 'ref'"));
 }
 
 TEST(TableRequirementJsonTest, TableRequirementAssertLastAssignedFieldId) {


### PR DESCRIPTION
The `AssertRefSnapshotId` table requirement was serialized and deserialized with the JSON field name `ref-name`. Per the Iceberg REST OpenAPI spec (`rest-catalog-open-api.yaml`), this requirement's field is named `ref`. Only the `SetSnapshotRef` / `RemoveSnapshotRef` *updates* use `ref-name`