### PR TITLE
fix: avoid stale gh run watch in RC release script

### DIFF
--- a/dev/release/release_rc.sh
+++ b/dev/release/release_rc.sh
@@ -44,6 +44,8 @@ rc=$2
 : "${RELEASE_PUSH_TAG:=${RELEASE_DEFAULT}}"
 : "${RELEASE_SIGN:=${RELEASE_DEFAULT}}"
 : "${RELEASE_UPLOAD:=${RELEASE_DEFAULT}}"
+: "${RELEASE_WATCH:=${RELEASE_DEFAULT}}"
+: "${RELEASE_WATCH_INTERVAL:=30}"
 
 cd "${SOURCE_TOP_DIR}"
 
@@ -81,7 +83,7 @@ if [ "${RELEASE_SIGN}" -gt 0 ]; then
   repository="${repository%.git}"
 
   echo "Looking for GitHub Actions workflow on ${repository}:${rc_tag}"
-  run_id=""
+  run_id="${RELEASE_RUN_ID:-}"
   while [ -z "${run_id}" ]; do
     echo "Waiting for run to start..."
     run_id=$(gh run list \
@@ -93,7 +95,33 @@ if [ "${RELEASE_SIGN}" -gt 0 ]; then
   done
 
   echo "Found GitHub Actions workflow with ID: ${run_id}"
-  gh run watch --repo "${repository}" --exit-status "${run_id}"
+  if [ "${RELEASE_WATCH}" -gt 0 ]; then
+    gh run watch --repo "${repository}" --exit-status "${run_id}"
+  else
+    while true; do
+      run_status=$(gh run view \
+        --repo "${repository}" \
+        --json 'status,conclusion' \
+        --jq '.status + " " + (.conclusion // "")' \
+        "${run_id}")
+      echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') GitHub Actions workflow status: ${run_status}"
+      gh run view \
+        --repo "${repository}" \
+        --json jobs \
+        --jq '.jobs[] | "  " + .name + ": " + .status + " " + (.conclusion // "")' \
+        "${run_id}"
+      case "${run_status}" in
+        "completed success")
+          break
+          ;;
+        completed\ *)
+          echo "GitHub Actions workflow did not complete successfully: ${run_status}"
+          exit 1
+          ;;
+      esac
+      sleep "${RELEASE_WATCH_INTERVAL}"
+    done
+  fi
 
   mkdir -p "${rc_id}"
 


### PR DESCRIPTION
Allow release_rc.sh to resume from an existing GitHub Actions run by setting RELEASE_RUN_ID, and add RELEASE_WATCH=0 to poll run/job status with plain gh run view output instead of gh run watch.

This avoids getting stuck on stale gh run watch terminal output while keeping the default release flow unchanged.