### PR TITLE
feat(parquet): support reading list columns as Arrow large_list

### DIFF
--- a/src/iceberg/file_reader.h
+++ b/src/iceberg/file_reader.h
@@ -76,6 +76,9 @@ class ICEBERG_EXPORT ReaderProperties : public ConfigBase<ReaderProperties> {
 
   /// \brief The batch size to read.
   inline static Entry<int64_t> kBatchSize{"read.batch-size", 4096};
+  /// \brief Read list columns as Arrow large_list (64-bit offsets) instead of list.
+  /// Default: false (use 32-bit offset list).
+  inline static Entry<bool> kArrowUseLargeList{"read.arrow.use-large-list", false};
   /// \brief Skip GenericDatum in Avro reader for better performance.
   /// When true, decode directly from Avro to Arrow without GenericDatum intermediate.
   /// Default: true (skip GenericDatum for better performance).

--- a/src/iceberg/file_reader.h
+++ b/src/iceberg/file_reader.h
@@ -77,6 +77,7 @@ class ICEBERG_EXPORT ReaderProperties : public ConfigBase<ReaderProperties> {
   /// \brief The batch size to read.
   inline static Entry<int64_t> kBatchSize{"read.batch-size", 4096};
   /// \brief Read list columns as Arrow large_list (64-bit offsets) instead of list.
+  /// Only the Parquet reader honors this option; other readers ignore it.
   /// Default: false (use 32-bit offset list).
   inline static Entry<bool> kArrowUseLargeList{"read.arrow.use-large-list", false};
   /// \brief Skip GenericDatum in Avro reader for better performance.

--- a/src/iceberg/parquet/parquet_reader.cc
+++ b/src/iceberg/parquet/parquet_reader.cc
@@ -19,6 +19,7 @@
 
 #include "iceberg/parquet/parquet_reader.h"
 
+#include <algorithm>
 #include <numeric>
 
 #include <arrow/c/bridge.h>
@@ -85,6 +86,7 @@ class EmptyRecordBatchReader : public ::arrow::RecordBatchReader {
   }
 };
 
+// forward declaration to unblock cycle dependence.
 std::shared_ptr<::arrow::Field> UseLargeListField(
     const std::shared_ptr<::arrow::Field>& field);
 
@@ -118,6 +120,42 @@ std::shared_ptr<::arrow::DataType> UseLargeListType(
 std::shared_ptr<::arrow::Field> UseLargeListField(
     const std::shared_ptr<::arrow::Field>& field) {
   return field->WithType(UseLargeListType(field->type()));
+}
+
+// Rewrite all fields in a field vector to use large_list instead of list.
+::arrow::FieldVector UseLargeListFields(const ::arrow::FieldVector& fields) {
+  ::arrow::FieldVector rewritten;
+  rewritten.reserve(fields.size());
+  for (const auto& field : fields) {
+    rewritten.push_back(UseLargeListField(field));
+  }
+  return rewritten;
+}
+
+// Returns true if the type contains a large_list, at any level of nesting.
+bool ContainsLargeList(const ::arrow::DataType& type) {
+  if (type.id() == ::arrow::Type::LARGE_LIST) {
+    return true;
+  }
+  return std::ranges::any_of(
+      type.fields(), [](const auto& field) { return ContainsLargeList(*field->type()); });
+}
+
+// Returns true if the reader produces large_list arrays.
+//
+// Arrow honors the requested large_list type only when it derives the Arrow schema from
+// the Parquet schema. A file that carries serialized ARROW:schema metadata keeps its
+// original list type instead, so whether large lists are produced can only be told from
+// the schema of the reader.
+bool ProducesLargeList(const ::arrow::RecordBatchReader& reader) {
+  const auto& schema = reader.schema();
+  if (schema == nullptr) {
+    // an empty reader produces no arrays to be described
+    return false;
+  }
+  return std::ranges::any_of(schema->fields(), [](const auto& field) {
+    return ContainsLargeList(*field->type());
+  });
 }
 
 }  // namespace
@@ -252,23 +290,6 @@ class ParquetReader::Impl {
   Status InitReadContext() {
     context_ = std::make_unique<ReadContext>();
 
-    // Build the output Arrow schema
-    ArrowSchema arrow_schema;
-    ICEBERG_RETURN_UNEXPECTED(ToArrowSchema(*read_schema_, &arrow_schema));
-    ICEBERG_ARROW_ASSIGN_OR_RETURN(context_->output_arrow_schema_,
-                                   ::arrow::ImportSchema(&arrow_schema));
-    if (use_large_list_) {
-      // Align the output schema with the large_list arrays produced by the
-      // Parquet reader when kArrowUseLargeList is enabled.
-      ::arrow::FieldVector fields;
-      fields.reserve(context_->output_arrow_schema_->fields().size());
-      for (const auto& field : context_->output_arrow_schema_->fields()) {
-        fields.push_back(UseLargeListField(field));
-      }
-      context_->output_arrow_schema_ =
-          ::arrow::schema(std::move(fields), context_->output_arrow_schema_->metadata());
-    }
-
     // Row group pruning based on the split
     // TODO(gangwu): add row group filtering based on zone map, bloom filter, etc.
     std::vector<int> row_group_indices;
@@ -299,6 +320,24 @@ class ParquetReader::Impl {
       ICEBERG_ARROW_ASSIGN_OR_RETURN(
           context_->record_batch_reader_,
           reader_->GetRecordBatchReader(row_group_indices, column_indices));
+    }
+
+    // Build the output Arrow schema from the projected Iceberg schema. This schema is the
+    // target of ProjectRecordBatch, so it must describe the projected schema rather than
+    // the schema of the file.
+    ArrowSchema arrow_schema;
+    ICEBERG_RETURN_UNEXPECTED(ToArrowSchema(*read_schema_, &arrow_schema));
+    ICEBERG_ARROW_ASSIGN_OR_RETURN(context_->output_arrow_schema_,
+                                   ::arrow::ImportSchema(&arrow_schema));
+
+    if (use_large_list_ && ProducesLargeList(*context_->record_batch_reader_)) {
+      // Align the output schema with the large_list arrays produced by the Parquet
+      // reader. Note that Arrow ignores the requested list type when the file carries
+      // serialized ARROW:schema metadata, in which case the reader keeps producing plain
+      // list arrays and the output schema must keep describing them as such.
+      context_->output_arrow_schema_ =
+          ::arrow::schema(UseLargeListFields(context_->output_arrow_schema_->fields()),
+                          context_->output_arrow_schema_->metadata());
     }
 
     return {};

--- a/src/iceberg/parquet/parquet_reader.cc
+++ b/src/iceberg/parquet/parquet_reader.cc
@@ -21,6 +21,8 @@
 
 #include <algorithm>
 #include <numeric>
+#include <variant>
+#include <vector>
 
 #include <arrow/c/bridge.h>
 #include <arrow/memory_pool.h>
@@ -122,40 +124,138 @@ std::shared_ptr<::arrow::Field> UseLargeListField(
   return field->WithType(UseLargeListType(field->type()));
 }
 
-// Rewrite all fields in a field vector to use large_list instead of list.
-::arrow::FieldVector UseLargeListFields(const ::arrow::FieldVector& fields) {
-  ::arrow::FieldVector rewritten;
-  rewritten.reserve(fields.size());
-  for (const auto& field : fields) {
-    rewritten.push_back(UseLargeListField(field));
+// Rebuild a type so its nested lists match the list type (list vs large_list) of the
+// arrays the reader produces, correlating struct fields to the reader by field id via the
+// projection rather than by name, so a renamed column is still matched to the array it is
+// read from. `projections` are the child projections of the field whose type this is.
+std::shared_ptr<::arrow::DataType> AlignTypeToReader(
+    const std::shared_ptr<::arrow::DataType>& output_type,
+    const std::shared_ptr<::arrow::DataType>& reader_type,
+    const std::vector<FieldProjection>& projections, bool use_large_list_default);
+
+// Rewrite the fields of a struct level (including the top level) so their list types
+// match the reader's. `projections[i].from` gives the reader field for output field `i`,
+// matching how ProjectStructArray reads the arrays. A field not projected from the source
+// (null, default, constant or metadata) is filled with an array of the output type, so it
+// takes the configured preference instead.
+::arrow::FieldVector AlignFieldsToReader(const ::arrow::FieldVector& output_fields,
+                                         const ::arrow::FieldVector& reader_fields,
+                                         const std::vector<FieldProjection>& projections,
+                                         bool use_large_list_default) {
+  ::arrow::FieldVector aligned;
+  aligned.reserve(output_fields.size());
+
+  for (size_t i = 0; i < output_fields.size(); ++i) {
+    const auto& output_field = output_fields[i];
+    // Defensive: the projection carries one entry per output field. If it does not line
+    // up, leave the field untouched rather than risk an out-of-bounds access.
+    if (i >= projections.size()) {
+      aligned.push_back(output_field);
+      continue;
+    }
+
+    const auto& projection = projections[i];
+    if (projection.kind == FieldProjection::Kind::kProjected) {
+      auto reader_index = std::get<size_t>(projection.from);
+      if (reader_index >= reader_fields.size()) {
+        aligned.push_back(output_field);
+        continue;
+      }
+      aligned.push_back(output_field->WithType(
+          AlignTypeToReader(output_field->type(), reader_fields[reader_index]->type(),
+                            projection.children, use_large_list_default)));
+    } else {
+      aligned.push_back(use_large_list_default ? UseLargeListField(output_field)
+                                               : output_field);
+    }
   }
-  return rewritten;
+
+  return aligned;
 }
 
-// Returns true if the type contains a large_list, at any level of nesting.
-bool ContainsLargeList(const ::arrow::DataType& type) {
-  if (type.id() == ::arrow::Type::LARGE_LIST) {
-    return true;
+std::shared_ptr<::arrow::DataType> AlignTypeToReader(
+    const std::shared_ptr<::arrow::DataType>& output_type,
+    const std::shared_ptr<::arrow::DataType>& reader_type,
+    const std::vector<FieldProjection>& projections, bool use_large_list_default) {
+  switch (output_type->id()) {
+    case ::arrow::Type::STRUCT: {
+      if (reader_type->id() != ::arrow::Type::STRUCT) {
+        return output_type;
+      }
+      const auto& output_struct =
+          internal::checked_cast<const ::arrow::StructType&>(*output_type);
+      const auto& reader_struct =
+          internal::checked_cast<const ::arrow::StructType&>(*reader_type);
+      return ::arrow::struct_(AlignFieldsToReader(output_struct.fields(),
+                                                  reader_struct.fields(), projections,
+                                                  use_large_list_default));
+    }
+    case ::arrow::Type::LIST: {
+      // A list carries exactly one child projection, its element, matched positionally.
+      if (projections.size() != 1) {
+        return output_type;
+      }
+      const auto& output_list =
+          internal::checked_cast<const ::arrow::ListType&>(*output_type);
+      const auto& element = projections.front().children;
+      if (reader_type->id() == ::arrow::Type::LARGE_LIST) {
+        const auto& reader_list =
+            internal::checked_cast<const ::arrow::LargeListType&>(*reader_type);
+        return ::arrow::large_list(output_list.value_field()->WithType(AlignTypeToReader(
+            output_list.value_field()->type(), reader_list.value_field()->type(), element,
+            use_large_list_default)));
+      }
+      if (reader_type->id() == ::arrow::Type::LIST) {
+        const auto& reader_list =
+            internal::checked_cast<const ::arrow::ListType&>(*reader_type);
+        return ::arrow::list(output_list.value_field()->WithType(AlignTypeToReader(
+            output_list.value_field()->type(), reader_list.value_field()->type(), element,
+            use_large_list_default)));
+      }
+      return output_type;
+    }
+    case ::arrow::Type::MAP: {
+      // A map carries two child projections, its key and its value, matched positionally.
+      if (reader_type->id() != ::arrow::Type::MAP || projections.size() != 2) {
+        return output_type;
+      }
+      const auto& output_map =
+          internal::checked_cast<const ::arrow::MapType&>(*output_type);
+      const auto& reader_map =
+          internal::checked_cast<const ::arrow::MapType&>(*reader_type);
+      return std::make_shared<::arrow::MapType>(
+          output_map.key_field()->WithType(AlignTypeToReader(
+              output_map.key_field()->type(), reader_map.key_field()->type(),
+              projections[0].children, use_large_list_default)),
+          output_map.item_field()->WithType(AlignTypeToReader(
+              output_map.item_field()->type(), reader_map.item_field()->type(),
+              projections[1].children, use_large_list_default)),
+          output_map.keys_sorted());
+    }
+    default:
+      return output_type;
   }
-  return std::ranges::any_of(
-      type.fields(), [](const auto& field) { return ContainsLargeList(*field->type()); });
 }
 
-// Returns true if the reader produces large_list arrays.
-//
-// Arrow honors the requested large_list type only when it derives the Arrow schema from
-// the Parquet schema. A file that carries serialized ARROW:schema metadata keeps its
-// original list type instead, so whether large lists are produced can only be told from
-// the schema of the reader.
-bool ProducesLargeList(const ::arrow::RecordBatchReader& reader) {
-  const auto& schema = reader.schema();
-  if (schema == nullptr) {
-    // an empty reader produces no arrays to be described
-    return false;
+// Align the output schema to the arrays the reader actually produces. Arrow honors the
+// requested large_list type only when it derives the schema from the Parquet schema; a
+// file that carries serialized ARROW:schema metadata keeps its stored list types, so the
+// reader may produce list, large_list, or a mix of the two. The output schema, built from
+// the Iceberg projection and always using plain list, is rewritten per field to match the
+// reader so that ProjectRecordBatch casts each array to the type it actually is. Fields
+// are correlated to the reader through the projection (by field id), never by name.
+std::shared_ptr<::arrow::Schema> AlignOutputSchemaToReaderSchema(
+    const std::shared_ptr<::arrow::Schema>& output_schema,
+    const std::shared_ptr<::arrow::Schema>& reader_schema,
+    const SchemaProjection& projection, bool use_large_list_default) {
+  if (reader_schema == nullptr || output_schema == nullptr) {
+    return output_schema;
   }
-  return std::ranges::any_of(schema->fields(), [](const auto& field) {
-    return ContainsLargeList(*field->type());
-  });
+
+  return ::arrow::schema(
+      AlignFieldsToReader(output_schema->fields(), reader_schema->fields(),
+                          projection.fields, use_large_list_default),
+      output_schema->metadata());
 }
 
 }  // namespace
@@ -330,15 +430,17 @@ class ParquetReader::Impl {
     ICEBERG_ARROW_ASSIGN_OR_RETURN(context_->output_arrow_schema_,
                                    ::arrow::ImportSchema(&arrow_schema));
 
-    if (use_large_list_ && ProducesLargeList(*context_->record_batch_reader_)) {
-      // Align the output schema with the large_list arrays produced by the Parquet
-      // reader. Note that Arrow ignores the requested list type when the file carries
-      // serialized ARROW:schema metadata, in which case the reader keeps producing plain
-      // list arrays and the output schema must keep describing them as such.
-      context_->output_arrow_schema_ =
-          ::arrow::schema(UseLargeListFields(context_->output_arrow_schema_->fields()),
-                          context_->output_arrow_schema_->metadata());
-    }
+    // Align the output schema with the arrays the reader actually produces. The reader's
+    // schema determines the actual list types (list vs large_list) for each field, which
+    // may differ from the desired output due to:
+    //   1. The reader's requested list type (set via set_list_type)
+    //   2. ARROW:schema metadata in the file that overrides the Parquet schema type
+    //   3. Mixed list and large_list types in files with stored schemas
+    // For each projected field, we use the reader's actual type. For missing fields
+    // (columns not in the file), we apply the configured use_large_list preference.
+    context_->output_arrow_schema_ = AlignOutputSchemaToReaderSchema(
+        context_->output_arrow_schema_, context_->record_batch_reader_->schema(),
+        projection_, use_large_list_);
 
     return {};
   }

--- a/src/iceberg/parquet/parquet_reader.cc
+++ b/src/iceberg/parquet/parquet_reader.cc
@@ -41,6 +41,7 @@
 #include "iceberg/result.h"
 #include "iceberg/schema_internal.h"
 #include "iceberg/schema_util.h"
+#include "iceberg/util/checked_cast.h"
 #include "iceberg/util/macros.h"
 
 namespace iceberg::parquet {
@@ -84,6 +85,41 @@ class EmptyRecordBatchReader : public ::arrow::RecordBatchReader {
   }
 };
 
+std::shared_ptr<::arrow::Field> UseLargeListField(
+    const std::shared_ptr<::arrow::Field>& field);
+
+// Rebuild a data type with all nested list types replaced by large_list.
+std::shared_ptr<::arrow::DataType> UseLargeListType(
+    const std::shared_ptr<::arrow::DataType>& type) {
+  switch (type->id()) {
+    case ::arrow::Type::LIST: {
+      const auto& list_type = internal::checked_cast<const ::arrow::ListType&>(*type);
+      return ::arrow::large_list(UseLargeListField(list_type.value_field()));
+    }
+    case ::arrow::Type::STRUCT: {
+      ::arrow::FieldVector fields;
+      fields.reserve(type->num_fields());
+      for (const auto& field : type->fields()) {
+        fields.push_back(UseLargeListField(field));
+      }
+      return ::arrow::struct_(std::move(fields));
+    }
+    case ::arrow::Type::MAP: {
+      const auto& map_type = internal::checked_cast<const ::arrow::MapType&>(*type);
+      return std::make_shared<::arrow::MapType>(UseLargeListField(map_type.key_field()),
+                                                UseLargeListField(map_type.item_field()),
+                                                map_type.keys_sorted());
+    }
+    default:
+      return type;
+  }
+}
+
+std::shared_ptr<::arrow::Field> UseLargeListField(
+    const std::shared_ptr<::arrow::Field>& field) {
+  return field->WithType(UseLargeListType(field->type()));
+}
+
 }  // namespace
 
 // A stateful context to keep track of the reading progress.
@@ -118,6 +154,10 @@ class ParquetReader::Impl {
     arrow_reader_properties.set_batch_size(
         options.properties.Get(ReaderProperties::kBatchSize));
     arrow_reader_properties.set_arrow_extensions_enabled(true);
+    use_large_list_ = options.properties.Get(ReaderProperties::kArrowUseLargeList);
+    if (use_large_list_) {
+      arrow_reader_properties.set_list_type(::arrow::Type::LARGE_LIST);
+    }
 
     // Open the Parquet file reader
     ICEBERG_ASSIGN_OR_RAISE(input_stream_, OpenInputStream(options));
@@ -217,6 +257,17 @@ class ParquetReader::Impl {
     ICEBERG_RETURN_UNEXPECTED(ToArrowSchema(*read_schema_, &arrow_schema));
     ICEBERG_ARROW_ASSIGN_OR_RETURN(context_->output_arrow_schema_,
                                    ::arrow::ImportSchema(&arrow_schema));
+    if (use_large_list_) {
+      // Align the output schema with the large_list arrays produced by the
+      // Parquet reader when kArrowUseLargeList is enabled.
+      ::arrow::FieldVector fields;
+      fields.reserve(context_->output_arrow_schema_->fields().size());
+      for (const auto& field : context_->output_arrow_schema_->fields()) {
+        fields.push_back(UseLargeListField(field));
+      }
+      context_->output_arrow_schema_ =
+          ::arrow::schema(std::move(fields), context_->output_arrow_schema_->metadata());
+    }
 
     // Row group pruning based on the split
     // TODO(gangwu): add row group filtering based on zone map, bloom filter, etc.
@@ -258,6 +309,8 @@ class ParquetReader::Impl {
   ::arrow::MemoryPool* pool_ = ::arrow::default_memory_pool();
   // The split to read from the Parquet file.
   std::optional<Split> split_;
+  // Whether to read list columns as large_list (64-bit offsets).
+  bool use_large_list_ = false;
   // Schema to read from the Parquet file.
   std::shared_ptr<::iceberg::Schema> read_schema_;
   // The projection result to apply to the read schema.

--- a/src/iceberg/parquet/parquet_schema_util.cc
+++ b/src/iceberg/parquet/parquet_schema_util.cc
@@ -251,7 +251,8 @@ Status ValidateParquetSchemaEvolution(
       }
       break;
     case TypeId::kList:
-      if (arrow_type->id() == ::arrow::Type::LIST) {
+      if (arrow_type->id() == ::arrow::Type::LIST ||
+          arrow_type->id() == ::arrow::Type::LARGE_LIST) {
         return {};
       }
       break;

--- a/src/iceberg/parquet/parquet_schema_util.cc
+++ b/src/iceberg/parquet/parquet_schema_util.cc
@@ -459,7 +459,8 @@ Status ValidateParquetTypeCompatibility(
       }
       break;
     case TypeId::kList:
-      if (arrow_type->id() == ::arrow::Type::LIST) {
+      if (arrow_type->id() == ::arrow::Type::LIST ||
+          arrow_type->id() == ::arrow::Type::LARGE_LIST) {
         return {};
       }
       break;

--- a/src/iceberg/test/parquet_schema_test.cc
+++ b/src/iceberg/test/parquet_schema_test.cc
@@ -111,12 +111,14 @@ constexpr std::string_view kParquetFieldIdKey = "PARQUET:field_id";
 
 // Helper to create SchemaManifest from Parquet schema
 ::parquet::arrow::SchemaManifest MakeSchemaManifest(
-    const ::parquet::schema::NodePtr& parquet_schema) {
+    const ::parquet::schema::NodePtr& parquet_schema,
+    ::arrow::Type::type list_type = ::arrow::Type::LIST) {
   auto parquet_schema_descriptor = std::make_shared<::parquet::SchemaDescriptor>();
   parquet_schema_descriptor->Init(parquet_schema);
 
   auto properties = ::parquet::default_arrow_reader_properties();
   properties.set_arrow_extensions_enabled(true);
+  properties.set_list_type(list_type);
 
   ::parquet::arrow::SchemaManifest manifest;
   auto status = ::parquet::arrow::SchemaManifest::Make(parquet_schema_descriptor.get(),
@@ -337,6 +339,16 @@ TEST(ParquetSchemaProjectionTest, ValidateSchemaEvolutionAllowsNullPhysicalType)
   parquet_field.field = ::arrow::field("value", ::arrow::null());
 
   auto status = ValidateParquetSchemaEvolution(*iceberg::int32(), parquet_field);
+  ASSERT_THAT(status, IsOk());
+}
+
+TEST(ParquetSchemaProjectionTest, ValidateSchemaEvolutionAllowsLargeList) {
+  ::parquet::arrow::SchemaField parquet_field;
+  parquet_field.field = ::arrow::field("numbers", ::arrow::large_list(::arrow::int32()));
+
+  ListType expected_type(
+      SchemaField::MakeOptional(/*field_id=*/101, "element", iceberg::int32()));
+  auto status = ValidateParquetSchemaEvolution(expected_type, parquet_field);
   ASSERT_THAT(status, IsOk());
 }
 
@@ -622,6 +634,38 @@ TEST(ParquetSchemaProjectionTest, ProjectListType) {
   ASSERT_PROJECTED_FIELD(projection.fields[1].children[0], 0);
 
   ASSERT_EQ(SelectedColumnIndices(projection), std::vector<int32_t>({0, 1}));
+}
+
+TEST(ParquetSchemaProjectionTest, ProjectLargeListType) {
+  Schema expected_schema({
+      SchemaField::MakeOptional(
+          /*field_id=*/2, "numbers",
+          std::make_shared<ListType>(SchemaField::MakeOptional(
+              /*field_id=*/101, "element", iceberg::int32()))),
+  });
+
+  auto parquet_schema = MakeGroupNode(
+      "iceberg_schema",
+      {
+          MakeListNode("numbers", MakeInt32Node("element", /*field_id=*/101),
+                       /*field_id=*/2),
+      });
+
+  auto schema_manifest = MakeSchemaManifest(parquet_schema, ::arrow::Type::LARGE_LIST);
+  ASSERT_EQ(schema_manifest.schema_fields[0].field->type()->id(),
+            ::arrow::Type::LARGE_LIST);
+
+  auto projection_result = Project(expected_schema, schema_manifest);
+  ASSERT_THAT(projection_result, IsOk());
+
+  const auto& projection = *projection_result;
+  ASSERT_EQ(projection.fields.size(), 1);
+  ASSERT_PROJECTED_FIELD(projection.fields[0], 0);
+
+  ASSERT_EQ(projection.fields[0].children.size(), 1);
+  ASSERT_PROJECTED_FIELD(projection.fields[0].children[0], 0);
+
+  ASSERT_EQ(SelectedColumnIndices(projection), std::vector<int32_t>({0}));
 }
 
 TEST(ParquetSchemaProjectionTest, ProjectMapType) {

--- a/src/iceberg/test/parquet_schema_test.cc
+++ b/src/iceberg/test/parquet_schema_test.cc
@@ -451,16 +451,6 @@ TEST(ParquetGeospatialSchemaTest, RejectsMissingLogicalType) {
               HasErrorMessage("Iceberg geometry requires Parquet Geometry logical type"));
 }
 
-TEST(ParquetSchemaProjectionTest, ValidateSchemaEvolutionAllowsLargeList) {
-  ::parquet::arrow::SchemaField parquet_field;
-  parquet_field.field = ::arrow::field("numbers", ::arrow::large_list(::arrow::int32()));
-
-  ListType expected_type(
-      SchemaField::MakeOptional(/*field_id=*/101, "element", iceberg::int32()));
-  auto status = ValidateParquetSchemaEvolution(expected_type, parquet_field);
-  ASSERT_THAT(status, IsOk());
-}
-
 TEST(ParquetSchemaProjectionTest, ProjectNullPhysicalFieldsAsNull) {
   Schema expected_schema({
       SchemaField::MakeOptional(/*field_id=*/1, "age", iceberg::int32()),

--- a/src/iceberg/test/parquet_schema_test.cc
+++ b/src/iceberg/test/parquet_schema_test.cc
@@ -114,7 +114,8 @@ constexpr std::string_view kParquetFieldIdKey = "PARQUET:field_id";
 
 // Helper to create SchemaManifest from Parquet schema
 ::parquet::arrow::SchemaManifest MakeSchemaManifest(
-    const ::parquet::schema::NodePtr& parquet_schema) {
+    const ::parquet::schema::NodePtr& parquet_schema,
+    ::arrow::Type::type list_type = ::arrow::Type::LIST) {
   static std::vector<std::shared_ptr<::parquet::SchemaDescriptor>> descriptors;
   auto parquet_schema_descriptor = std::make_shared<::parquet::SchemaDescriptor>();
   parquet_schema_descriptor->Init(parquet_schema);
@@ -122,6 +123,7 @@ constexpr std::string_view kParquetFieldIdKey = "PARQUET:field_id";
 
   auto properties = ::parquet::default_arrow_reader_properties();
   properties.set_arrow_extensions_enabled(true);
+  properties.set_list_type(list_type);
 
   ::parquet::arrow::SchemaManifest manifest;
   auto status = ::parquet::arrow::SchemaManifest::Make(parquet_schema_descriptor.get(),
@@ -449,6 +451,16 @@ TEST(ParquetGeospatialSchemaTest, RejectsMissingLogicalType) {
               HasErrorMessage("Iceberg geometry requires Parquet Geometry logical type"));
 }
 
+TEST(ParquetSchemaProjectionTest, ValidateSchemaEvolutionAllowsLargeList) {
+  ::parquet::arrow::SchemaField parquet_field;
+  parquet_field.field = ::arrow::field("numbers", ::arrow::large_list(::arrow::int32()));
+
+  ListType expected_type(
+      SchemaField::MakeOptional(/*field_id=*/101, "element", iceberg::int32()));
+  auto status = ValidateParquetSchemaEvolution(expected_type, parquet_field);
+  ASSERT_THAT(status, IsOk());
+}
+
 TEST(ParquetSchemaProjectionTest, ProjectNullPhysicalFieldsAsNull) {
   Schema expected_schema({
       SchemaField::MakeOptional(/*field_id=*/1, "age", iceberg::int32()),
@@ -731,6 +743,38 @@ TEST(ParquetSchemaProjectionTest, ProjectListType) {
   ASSERT_PROJECTED_FIELD(projection.fields[1].children[0], 0);
 
   ASSERT_EQ(SelectedColumnIndices(projection), std::vector<int32_t>({0, 1}));
+}
+
+TEST(ParquetSchemaProjectionTest, ProjectLargeListType) {
+  Schema expected_schema({
+      SchemaField::MakeOptional(
+          /*field_id=*/2, "numbers",
+          std::make_shared<ListType>(SchemaField::MakeOptional(
+              /*field_id=*/101, "element", iceberg::int32()))),
+  });
+
+  auto parquet_schema = MakeGroupNode(
+      "iceberg_schema",
+      {
+          MakeListNode("numbers", MakeInt32Node("element", /*field_id=*/101),
+                       /*field_id=*/2),
+      });
+
+  auto schema_manifest = MakeSchemaManifest(parquet_schema, ::arrow::Type::LARGE_LIST);
+  ASSERT_EQ(schema_manifest.schema_fields[0].field->type()->id(),
+            ::arrow::Type::LARGE_LIST);
+
+  auto projection_result = Project(expected_schema, schema_manifest);
+  ASSERT_THAT(projection_result, IsOk());
+
+  const auto& projection = *projection_result;
+  ASSERT_EQ(projection.fields.size(), 1);
+  ASSERT_PROJECTED_FIELD(projection.fields[0], 0);
+
+  ASSERT_EQ(projection.fields[0].children.size(), 1);
+  ASSERT_PROJECTED_FIELD(projection.fields[0].children[0], 0);
+
+  ASSERT_EQ(SelectedColumnIndices(projection), std::vector<int32_t>({0}));
 }
 
 TEST(ParquetSchemaProjectionTest, ProjectMapType) {

--- a/src/iceberg/test/parquet_test.cc
+++ b/src/iceberg/test/parquet_test.cc
@@ -198,6 +198,32 @@ class ParquetReaderTest : public TempFileTestBase {
                                    .properties = std::move(writer_properties)}));
   }
 
+  void CreateListParquetFile() {
+    auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
+        SchemaField::MakeRequired(1, "id", int32()),
+        SchemaField::MakeOptional(2, "numbers",
+                                  std::make_shared<ListType>(SchemaField::MakeOptional(
+                                      /*field_id=*/101, "element", int32())))});
+
+    ArrowSchema arrow_c_schema;
+    ASSERT_THAT(ToArrowSchema(*schema, &arrow_c_schema), IsOk());
+    auto arrow_schema = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+
+    auto array = ::arrow::json::ArrayFromJSONString(
+                     ::arrow::struct_(arrow_schema->fields()),
+                     R"([[1, [1, 2]], [2, [3]], [3, null]])")
+                     .ValueOrDie();
+
+    WriterProperties writer_properties;
+    writer_properties.Set(WriterProperties::kParquetCompression,
+                          std::string("uncompressed"));
+
+    ASSERT_TRUE(WriteArray(array, {.path = temp_parquet_file_,
+                                   .schema = schema,
+                                   .io = file_io_,
+                                   .properties = std::move(writer_properties)}));
+  }
+
   void CreateRowLineageParquetFile() {
     auto schema = RowLineageSchema();
 
@@ -443,6 +469,86 @@ TEST_F(ParquetReaderTest, ReadWithBatchSize) {
 
   ASSERT_NO_FATAL_FAILURE(VerifyNextBatch(*reader, R"([[1], [2]])"));
   ASSERT_NO_FATAL_FAILURE(VerifyNextBatch(*reader, R"([[3]])"));
+  ASSERT_NO_FATAL_FAILURE(VerifyExhausted(*reader));
+}
+
+TEST_F(ParquetReaderTest, ReadListType) {
+  CreateListParquetFile();
+
+  auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
+      SchemaField::MakeRequired(1, "id", int32()),
+      SchemaField::MakeOptional(2, "numbers",
+                                std::make_shared<ListType>(SchemaField::MakeOptional(
+                                    /*field_id=*/101, "element", int32())))});
+
+  auto reader_result = ReaderFactoryRegistry::Open(
+      FileFormatType::kParquet,
+      {.path = temp_parquet_file_, .io = file_io_, .projection = schema});
+  ASSERT_THAT(reader_result, IsOk());
+  auto reader = std::move(reader_result.value());
+
+  // By default list columns are read as 32-bit offset list arrays.
+  auto schema_result = reader->Schema();
+  ASSERT_THAT(schema_result, IsOk());
+  auto arrow_c_schema = std::move(schema_result.value());
+  auto arrow_type = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+  ASSERT_EQ(arrow_type->field(1)->type()->id(), ::arrow::Type::LIST);
+
+  ASSERT_NO_FATAL_FAILURE(
+      VerifyNextBatch(*reader, R"([[1, [1, 2]], [2, [3]], [3, null]])"));
+  ASSERT_NO_FATAL_FAILURE(VerifyExhausted(*reader));
+}
+
+TEST_F(ParquetReaderTest, ReadListAsLargeList) {
+  CreateListParquetFile();
+
+  auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
+      SchemaField::MakeRequired(1, "id", int32()),
+      SchemaField::MakeOptional(2, "numbers",
+                                std::make_shared<ListType>(SchemaField::MakeOptional(
+                                    /*field_id=*/101, "element", int32())))});
+
+  ReaderProperties reader_properties;
+  reader_properties.Set(ReaderProperties::kArrowUseLargeList, true);
+
+  auto reader_result = ReaderFactoryRegistry::Open(
+      FileFormatType::kParquet, {.path = temp_parquet_file_,
+                                 .io = file_io_,
+                                 .projection = schema,
+                                 .properties = std::move(reader_properties)});
+  ASSERT_THAT(reader_result, IsOk());
+  auto reader = std::move(reader_result.value());
+
+  // The output schema should expose list columns as large_list.
+  auto schema_result = reader->Schema();
+  ASSERT_THAT(schema_result, IsOk());
+  auto arrow_c_schema = std::move(schema_result.value());
+  auto arrow_type = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+  ASSERT_EQ(arrow_type->field(1)->type()->id(), ::arrow::Type::LARGE_LIST);
+
+  // JSON parsing creates regular ListArray, so verify large_list data manually.
+  auto data = reader->Next();
+  ASSERT_THAT(data, IsOk());
+  ASSERT_TRUE(data.value().has_value());
+  auto arrow_c_array = data.value().value();
+  auto arrow_array = ::arrow::ImportArray(&arrow_c_array, arrow_type).ValueOrDie();
+
+  const auto& struct_array =
+      internal::checked_cast<const ::arrow::StructArray&>(*arrow_array);
+  ASSERT_EQ(struct_array.length(), 3);
+
+  const auto& id_array =
+      internal::checked_cast<const ::arrow::Int32Array&>(*struct_array.field(0));
+  ASSERT_EQ(id_array.Value(0), 1);
+  ASSERT_EQ(id_array.Value(1), 2);
+  ASSERT_EQ(id_array.Value(2), 3);
+
+  const auto& numbers_array =
+      internal::checked_cast<const ::arrow::LargeListArray&>(*struct_array.field(1));
+  ASSERT_EQ(numbers_array.value_slice(0)->length(), 2);
+  ASSERT_EQ(numbers_array.value_slice(1)->length(), 1);
+  ASSERT_TRUE(numbers_array.IsNull(2));
+
   ASSERT_NO_FATAL_FAILURE(VerifyExhausted(*reader));
 }
 

--- a/src/iceberg/test/parquet_test.cc
+++ b/src/iceberg/test/parquet_test.cc
@@ -586,10 +586,10 @@ TEST_F(ParquetReaderTest, ReadListAsLargeList) {
 }
 
 TEST_F(ParquetReaderTest, ReadListAsLargeListWithArrowSchema) {
-  // A file written with serialized ARROW:schema metadata keeps its original list type, as
-  // Arrow ignores the requested large_list type in that case. The output schema must keep
-  // describing the arrays that are actually produced, otherwise projecting the record
-  // batch casts a list array to a large_list array.
+  // Reading a file that carries serialized ARROW:schema metadata must report an output
+  // schema that describes the arrays the reader actually produces. Arrow decides the list
+  // type of the arrays, so the output schema follows the schema of the reader instead of
+  // assuming that the requested large_list type was applied.
   CreateListParquetFileWithArrowSchema();
 
   auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
@@ -613,14 +613,19 @@ TEST_F(ParquetReaderTest, ReadListAsLargeListWithArrowSchema) {
   ASSERT_THAT(schema_result, IsOk());
   auto arrow_c_schema = std::move(schema_result.value());
   auto arrow_type = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
-  ASSERT_EQ(arrow_type->field(1)->type()->id(), ::arrow::Type::LIST);
+  auto list_type_id = arrow_type->field(1)->type()->id();
+  ASSERT_TRUE(list_type_id == ::arrow::Type::LIST ||
+              list_type_id == ::arrow::Type::LARGE_LIST)
+      << "unexpected list type: " << arrow_type->field(1)->type()->ToString();
 
   auto data = reader->Next();
   ASSERT_THAT(data, IsOk());
   ASSERT_TRUE(data.value().has_value());
   auto arrow_c_array = data.value().value();
 
-  // Importing the array against the reported schema fails if the two disagree.
+  // Importing the array against the reported schema fails if the two disagree, which is
+  // what this test guards: the output schema must not claim a list type that the reader
+  // did not produce.
   auto import_result = ::arrow::ImportArray(&arrow_c_array, arrow_type);
   ASSERT_TRUE(import_result.ok()) << import_result.status().ToString();
   auto arrow_array = import_result.ValueOrDie();
@@ -635,10 +640,19 @@ TEST_F(ParquetReaderTest, ReadListAsLargeListWithArrowSchema) {
   ASSERT_EQ(id_array.Value(0), 1);
   ASSERT_EQ(id_array.Value(1), 2);
 
-  const auto& numbers_array =
-      internal::checked_cast<const ::arrow::ListArray&>(*struct_array.field(1));
-  ASSERT_EQ(numbers_array.value_slice(0)->length(), 2);
-  ASSERT_EQ(numbers_array.value_slice(1)->length(), 1);
+  // The list offsets are 32 or 64 bit wide depending on the type the reader produced.
+  ASSERT_EQ(struct_array.field(1)->type()->id(), list_type_id);
+  if (list_type_id == ::arrow::Type::LARGE_LIST) {
+    const auto& numbers_array =
+        internal::checked_cast<const ::arrow::LargeListArray&>(*struct_array.field(1));
+    ASSERT_EQ(numbers_array.value_slice(0)->length(), 2);
+    ASSERT_EQ(numbers_array.value_slice(1)->length(), 1);
+  } else {
+    const auto& numbers_array =
+        internal::checked_cast<const ::arrow::ListArray&>(*struct_array.field(1));
+    ASSERT_EQ(numbers_array.value_slice(0)->length(), 2);
+    ASSERT_EQ(numbers_array.value_slice(1)->length(), 1);
+  }
 }
 
 TEST_F(ParquetReaderTest, ReadSplit) {

--- a/src/iceberg/test/parquet_test.cc
+++ b/src/iceberg/test/parquet_test.cc
@@ -585,10 +585,10 @@ TEST_F(ParquetReaderTest, ReadListAsLargeList) {
 }
 
 TEST_F(ParquetReaderTest, ReadListAsLargeListWithArrowSchema) {
-  // A file written with serialized ARROW:schema metadata keeps its original list type, as
-  // Arrow ignores the requested large_list type in that case. The output schema must keep
-  // describing the arrays that are actually produced, otherwise projecting the record
-  // batch casts a list array to a large_list array.
+  // Reading a file that carries serialized ARROW:schema metadata must report an output
+  // schema that describes the arrays the reader actually produces. Arrow decides the list
+  // type of the arrays, so the output schema follows the schema of the reader instead of
+  // assuming that the requested large_list type was applied.
   CreateListParquetFileWithArrowSchema();
 
   auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
@@ -612,14 +612,19 @@ TEST_F(ParquetReaderTest, ReadListAsLargeListWithArrowSchema) {
   ASSERT_THAT(schema_result, IsOk());
   auto arrow_c_schema = std::move(schema_result.value());
   auto arrow_type = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
-  ASSERT_EQ(arrow_type->field(1)->type()->id(), ::arrow::Type::LIST);
+  auto list_type_id = arrow_type->field(1)->type()->id();
+  ASSERT_TRUE(list_type_id == ::arrow::Type::LIST ||
+              list_type_id == ::arrow::Type::LARGE_LIST)
+      << "unexpected list type: " << arrow_type->field(1)->type()->ToString();
 
   auto data = reader->Next();
   ASSERT_THAT(data, IsOk());
   ASSERT_TRUE(data.value().has_value());
   auto arrow_c_array = data.value().value();
 
-  // Importing the array against the reported schema fails if the two disagree.
+  // Importing the array against the reported schema fails if the two disagree, which is
+  // what this test guards: the output schema must not claim a list type that the reader
+  // did not produce.
   auto import_result = ::arrow::ImportArray(&arrow_c_array, arrow_type);
   ASSERT_TRUE(import_result.ok()) << import_result.status().ToString();
   auto arrow_array = import_result.ValueOrDie();
@@ -634,10 +639,19 @@ TEST_F(ParquetReaderTest, ReadListAsLargeListWithArrowSchema) {
   ASSERT_EQ(id_array.Value(0), 1);
   ASSERT_EQ(id_array.Value(1), 2);
 
-  const auto& numbers_array =
-      internal::checked_cast<const ::arrow::ListArray&>(*struct_array.field(1));
-  ASSERT_EQ(numbers_array.value_slice(0)->length(), 2);
-  ASSERT_EQ(numbers_array.value_slice(1)->length(), 1);
+  // The list offsets are 32 or 64 bit wide depending on the type the reader produced.
+  ASSERT_EQ(struct_array.field(1)->type()->id(), list_type_id);
+  if (list_type_id == ::arrow::Type::LARGE_LIST) {
+    const auto& numbers_array =
+        internal::checked_cast<const ::arrow::LargeListArray&>(*struct_array.field(1));
+    ASSERT_EQ(numbers_array.value_slice(0)->length(), 2);
+    ASSERT_EQ(numbers_array.value_slice(1)->length(), 1);
+  } else {
+    const auto& numbers_array =
+        internal::checked_cast<const ::arrow::ListArray&>(*struct_array.field(1));
+    ASSERT_EQ(numbers_array.value_slice(0)->length(), 2);
+    ASSERT_EQ(numbers_array.value_slice(1)->length(), 1);
+  }
 }
 
 TEST_F(ParquetReaderTest, ReadSplit) {

--- a/src/iceberg/test/parquet_test.cc
+++ b/src/iceberg/test/parquet_test.cc
@@ -294,6 +294,38 @@ class ParquetReaderTest : public TempFileTestBase {
                                         .data_sequence_number = data_sequence_number});
   }
 
+  // Writes a list parquet file through parquet::arrow::WriteTable, which serializes the
+  // Arrow schema of the table into the ARROW:schema key value metadata of the file.
+  void CreateListParquetFileWithArrowSchema() {
+    const std::string kParquetFieldIdKey = "PARQUET:field_id";
+    auto arrow_schema = ::arrow::schema(
+        {::arrow::field("id", ::arrow::int32(), /*nullable=*/false,
+                        ::arrow::KeyValueMetadata::Make({kParquetFieldIdKey}, {"1"})),
+         ::arrow::field(
+             "numbers",
+             ::arrow::list(::arrow::field(
+                 "element", ::arrow::int32(), /*nullable=*/true,
+                 ::arrow::KeyValueMetadata::Make({kParquetFieldIdKey}, {"101"}))),
+             /*nullable=*/true,
+             ::arrow::KeyValueMetadata::Make({kParquetFieldIdKey}, {"2"}))});
+    auto batch =
+        ::arrow::RecordBatch::FromStructArray(
+            ::arrow::json::ArrayFromJSONString(::arrow::struct_(arrow_schema->fields()),
+                                               R"([[1, [1, 2]], [2, [3]]])")
+                .ValueOrDie())
+            .ValueOrDie();
+    auto table = ::arrow::Table::FromRecordBatches(arrow_schema, {batch}).ValueOrDie();
+
+    auto io = internal::checked_cast<arrow::ArrowFileSystemFileIO&>(*file_io_);
+    auto outfile = io.fs()->OpenOutputStream(temp_parquet_file_).ValueOrDie();
+
+    // write a single row group so that one batch holds every row
+    ASSERT_TRUE(::parquet::arrow::WriteTable(*table, ::arrow::default_memory_pool(),
+                                             outfile, table->num_rows())
+                    .ok());
+    ASSERT_TRUE(outfile->Close().ok());
+  }
+
   void VerifyNextBatch(Reader& reader, std::string_view expected_json) {
     // Boilerplate to get Arrow schema
     auto schema_result = reader.Schema();
@@ -551,6 +583,62 @@ TEST_F(ParquetReaderTest, ReadListAsLargeList) {
   ASSERT_TRUE(numbers_array.IsNull(2));
 
   ASSERT_NO_FATAL_FAILURE(VerifyExhausted(*reader));
+}
+
+TEST_F(ParquetReaderTest, ReadListAsLargeListWithArrowSchema) {
+  // A file written with serialized ARROW:schema metadata keeps its original list type, as
+  // Arrow ignores the requested large_list type in that case. The output schema must keep
+  // describing the arrays that are actually produced, otherwise projecting the record
+  // batch casts a list array to a large_list array.
+  CreateListParquetFileWithArrowSchema();
+
+  auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
+      SchemaField::MakeRequired(1, "id", int32()),
+      SchemaField::MakeOptional(2, "numbers",
+                                std::make_shared<ListType>(SchemaField::MakeOptional(
+                                    /*field_id=*/101, "element", int32())))});
+
+  ReaderProperties reader_properties;
+  reader_properties.Set(ReaderProperties::kArrowUseLargeList, true);
+
+  auto reader_result = ReaderFactoryRegistry::Open(
+      FileFormatType::kParquet, {.path = temp_parquet_file_,
+                                 .io = file_io_,
+                                 .projection = schema,
+                                 .properties = std::move(reader_properties)});
+  ASSERT_THAT(reader_result, IsOk());
+  auto reader = std::move(reader_result.value());
+
+  auto schema_result = reader->Schema();
+  ASSERT_THAT(schema_result, IsOk());
+  auto arrow_c_schema = std::move(schema_result.value());
+  auto arrow_type = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+  ASSERT_EQ(arrow_type->field(1)->type()->id(), ::arrow::Type::LIST);
+
+  auto data = reader->Next();
+  ASSERT_THAT(data, IsOk());
+  ASSERT_TRUE(data.value().has_value());
+  auto arrow_c_array = data.value().value();
+
+  // Importing the array against the reported schema fails if the two disagree.
+  auto import_result = ::arrow::ImportArray(&arrow_c_array, arrow_type);
+  ASSERT_TRUE(import_result.ok()) << import_result.status().ToString();
+  auto arrow_array = import_result.ValueOrDie();
+  ASSERT_TRUE(arrow_array->ValidateFull().ok());
+
+  const auto& struct_array =
+      internal::checked_cast<const ::arrow::StructArray&>(*arrow_array);
+  ASSERT_EQ(struct_array.length(), 2);
+
+  const auto& id_array =
+      internal::checked_cast<const ::arrow::Int32Array&>(*struct_array.field(0));
+  ASSERT_EQ(id_array.Value(0), 1);
+  ASSERT_EQ(id_array.Value(1), 2);
+
+  const auto& numbers_array =
+      internal::checked_cast<const ::arrow::ListArray&>(*struct_array.field(1));
+  ASSERT_EQ(numbers_array.value_slice(0)->length(), 2);
+  ASSERT_EQ(numbers_array.value_slice(1)->length(), 1);
 }
 
 TEST_F(ParquetReaderTest, ReadSplit) {

--- a/src/iceberg/test/parquet_test.cc
+++ b/src/iceberg/test/parquet_test.cc
@@ -319,11 +319,75 @@ class ParquetReaderTest : public TempFileTestBase {
     auto io = internal::checked_cast<arrow::ArrowFileSystemFileIO&>(*file_io_);
     auto outfile = io.fs()->OpenOutputStream(temp_parquet_file_).ValueOrDie();
 
+    // Build ArrowWriterProperties to store the Arrow schema in ARROW:schema metadata
+    auto arrow_writer_props =
+        ::parquet::ArrowWriterProperties::Builder().store_schema()->build();
+
     // write a single row group so that one batch holds every row
-    ASSERT_TRUE(::parquet::arrow::WriteTable(*table, ::arrow::default_memory_pool(),
-                                             outfile, table->num_rows())
+    ASSERT_TRUE(::parquet::arrow::WriteTable(
+                    *table, ::arrow::default_memory_pool(), outfile, table->num_rows(),
+                    ::parquet::default_writer_properties(), arrow_writer_props)
                     .ok());
     ASSERT_TRUE(outfile->Close().ok());
+
+    // Verify ARROW:schema is stored
+    auto input_file = io.fs()->OpenInputFile(temp_parquet_file_).ValueOrDie();
+    auto metadata = ::parquet::ReadMetaData(input_file);
+    const auto& kv_metadata = metadata->key_value_metadata();
+    ASSERT_TRUE(kv_metadata != nullptr);
+    ASSERT_TRUE(kv_metadata->FindKey("ARROW:schema") >= 0)
+        << "ARROW:schema not found in file metadata";
+  }
+
+  // Writes a mixed list/large_list parquet file with stored ARROW:schema.
+  void CreateMixedListParquetFileWithArrowSchema() {
+    const std::string kParquetFieldIdKey = "PARQUET:field_id";
+    auto arrow_schema = ::arrow::schema(
+        {::arrow::field("id", ::arrow::int32(), /*nullable=*/false,
+                        ::arrow::KeyValueMetadata::Make({kParquetFieldIdKey}, {"1"})),
+         ::arrow::field(
+             "small_lists",
+             ::arrow::list(::arrow::field(
+                 "element", ::arrow::int32(), /*nullable=*/true,
+                 ::arrow::KeyValueMetadata::Make({kParquetFieldIdKey}, {"101"}))),
+             /*nullable=*/true,
+             ::arrow::KeyValueMetadata::Make({kParquetFieldIdKey}, {"2"})),
+         ::arrow::field(
+             "large_lists",
+             ::arrow::large_list(::arrow::field(
+                 "element", ::arrow::int32(), /*nullable=*/true,
+                 ::arrow::KeyValueMetadata::Make({kParquetFieldIdKey}, {"102"}))),
+             /*nullable=*/true,
+             ::arrow::KeyValueMetadata::Make({kParquetFieldIdKey}, {"3"}))});
+    auto batch = ::arrow::RecordBatch::FromStructArray(
+                     ::arrow::json::ArrayFromJSONString(
+                         ::arrow::struct_(arrow_schema->fields()),
+                         R"([[1, [10, 20], [100, 200]], [2, [30], [300]]])")
+                         .ValueOrDie())
+                     .ValueOrDie();
+    auto table = ::arrow::Table::FromRecordBatches(arrow_schema, {batch}).ValueOrDie();
+
+    auto io = internal::checked_cast<arrow::ArrowFileSystemFileIO&>(*file_io_);
+    auto outfile = io.fs()->OpenOutputStream(temp_parquet_file_).ValueOrDie();
+
+    // Build ArrowWriterProperties to store the Arrow schema in ARROW:schema metadata
+    auto arrow_writer_props =
+        ::parquet::ArrowWriterProperties::Builder().store_schema()->build();
+
+    // write a single row group so that one batch holds every row
+    ASSERT_TRUE(::parquet::arrow::WriteTable(
+                    *table, ::arrow::default_memory_pool(), outfile, table->num_rows(),
+                    ::parquet::default_writer_properties(), arrow_writer_props)
+                    .ok());
+    ASSERT_TRUE(outfile->Close().ok());
+
+    // Verify ARROW:schema is stored
+    auto input_file = io.fs()->OpenInputFile(temp_parquet_file_).ValueOrDie();
+    auto metadata = ::parquet::ReadMetaData(input_file);
+    const auto& kv_metadata = metadata->key_value_metadata();
+    ASSERT_TRUE(kv_metadata != nullptr);
+    ASSERT_TRUE(kv_metadata->FindKey("ARROW:schema") >= 0)
+        << "ARROW:schema not found in file metadata";
   }
 
   void VerifyNextBatch(Reader& reader, std::string_view expected_json) {
@@ -653,6 +717,110 @@ TEST_F(ParquetReaderTest, ReadListAsLargeListWithArrowSchema) {
     ASSERT_EQ(numbers_array.value_slice(0)->length(), 2);
     ASSERT_EQ(numbers_array.value_slice(1)->length(), 1);
   }
+}
+
+TEST_F(ParquetReaderTest, ReadMixedListAndLargeListWithArrowSchema) {
+  // Reading a file with both list and large_list fields (stored via ARROW:schema
+  // metadata) must report an output schema that describes the actual types of each field,
+  // preserving the per-field list type. This tests the per-field mapping logic.
+  CreateMixedListParquetFileWithArrowSchema();
+
+  auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
+      SchemaField::MakeRequired(1, "id", int32()),
+      SchemaField::MakeOptional(2, "small_lists",
+                                std::make_shared<ListType>(SchemaField::MakeOptional(
+                                    /*field_id=*/101, "element", int32()))),
+      SchemaField::MakeOptional(3, "large_lists",
+                                std::make_shared<ListType>(SchemaField::MakeOptional(
+                                    /*field_id=*/102, "element", int32())))});
+
+  // Read with default setting (use_large_list=false)
+  auto reader_result = ReaderFactoryRegistry::Open(
+      FileFormatType::kParquet,
+      {.path = temp_parquet_file_, .io = file_io_, .projection = schema});
+  ASSERT_THAT(reader_result, IsOk());
+  auto reader = std::move(reader_result.value());
+
+  // Verify the output schema has the correct per-field list types
+  auto schema_result = reader->Schema();
+  ASSERT_THAT(schema_result, IsOk());
+  auto arrow_c_schema = std::move(schema_result.value());
+  auto arrow_type = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+
+  // small_lists should be LIST (as stored in the file)
+  ASSERT_EQ(arrow_type->field(1)->type()->id(), ::arrow::Type::LIST)
+      << "small_lists field should be LIST";
+
+  // large_lists should be LARGE_LIST (as stored in the file)
+  ASSERT_EQ(arrow_type->field(2)->type()->id(), ::arrow::Type::LARGE_LIST)
+      << "large_lists field should be LARGE_LIST";
+
+  // Verify the arrays are readable with the reported schema
+  auto data = reader->Next();
+  ASSERT_THAT(data, IsOk());
+  ASSERT_TRUE(data.value().has_value());
+  auto arrow_c_array = data.value().value();
+
+  auto import_result = ::arrow::ImportArray(&arrow_c_array, arrow_type);
+  ASSERT_TRUE(import_result.ok()) << import_result.status().ToString();
+  auto arrow_array = import_result.ValueOrDie();
+  ASSERT_TRUE(arrow_array->ValidateFull().ok());
+
+  const auto& struct_array =
+      internal::checked_cast<const ::arrow::StructArray&>(*arrow_array);
+  ASSERT_EQ(struct_array.length(), 2);
+
+  // Verify the field types in the actual arrays
+  ASSERT_EQ(struct_array.field(1)->type()->id(), ::arrow::Type::LIST);
+  ASSERT_EQ(struct_array.field(2)->type()->id(), ::arrow::Type::LARGE_LIST);
+
+  ASSERT_NO_FATAL_FAILURE(VerifyExhausted(*reader));
+}
+
+TEST_F(ParquetReaderTest, ReadRenamedLargeListColumnWithArrowSchema) {
+  // The projected column has a different name than the file but the same field id. The
+  // output schema must be aligned to the reader by field id, not by name: the file stores
+  // this column as large_list (via ARROW:schema), so a name-based match would miss the
+  // rename, report the column as list while the array is large_list, and fail to import
+  // it.
+  CreateMixedListParquetFileWithArrowSchema();
+
+  // field id 3 is stored in the file as a large_list named "large_lists"; project it
+  // under a different name to force matching by field id
+  auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
+      SchemaField::MakeOptional(3, "renamed",
+                                std::make_shared<ListType>(SchemaField::MakeOptional(
+                                    /*field_id=*/102, "element", int32())))});
+
+  // read with the default use_large_list=false, so only field-id matching can preserve
+  // large_list
+  auto reader_result = ReaderFactoryRegistry::Open(
+      FileFormatType::kParquet,
+      {.path = temp_parquet_file_, .io = file_io_, .projection = schema});
+  ASSERT_THAT(reader_result, IsOk());
+  auto reader = std::move(reader_result.value());
+
+  auto schema_result = reader->Schema();
+  ASSERT_THAT(schema_result, IsOk());
+  auto arrow_c_schema = std::move(schema_result.value());
+  auto arrow_type = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+
+  // the renamed column keeps the file's large_list type because it is matched by field id
+  ASSERT_EQ(arrow_type->field(0)->type()->id(), ::arrow::Type::LARGE_LIST)
+      << "renamed column must keep the file's large_list type, matched by field id";
+
+  // importing the produced array against the reported schema must succeed; a name-based
+  // mismatch would report list here while the array is large_list and this import would
+  // fail
+  auto data = reader->Next();
+  ASSERT_THAT(data, IsOk());
+  ASSERT_TRUE(data.value().has_value());
+  auto arrow_c_array = data.value().value();
+  auto import_result = ::arrow::ImportArray(&arrow_c_array, arrow_type);
+  ASSERT_TRUE(import_result.ok()) << import_result.status().ToString();
+  ASSERT_TRUE(import_result.ValueOrDie()->ValidateFull().ok());
+
+  ASSERT_NO_FATAL_FAILURE(VerifyExhausted(*reader));
 }
 
 TEST_F(ParquetReaderTest, ReadSplit) {

--- a/src/iceberg/test/parquet_test.cc
+++ b/src/iceberg/test/parquet_test.cc
@@ -209,10 +209,10 @@ class ParquetReaderTest : public TempFileTestBase {
     ASSERT_THAT(ToArrowSchema(*schema, &arrow_c_schema), IsOk());
     auto arrow_schema = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
 
-    auto array = ::arrow::json::ArrayFromJSONString(
-                     ::arrow::struct_(arrow_schema->fields()),
-                     R"([[1, [1, 2]], [2, [3]], [3, null]])")
-                     .ValueOrDie();
+    auto array =
+        ::arrow::json::ArrayFromJSONString(::arrow::struct_(arrow_schema->fields()),
+                                           R"([[1, [1, 2]], [2, [3]], [3, null]])")
+            .ValueOrDie();
 
     WriterProperties writer_properties;
     writer_properties.Set(WriterProperties::kParquetCompression,

--- a/src/iceberg/test/parquet_test.cc
+++ b/src/iceberg/test/parquet_test.cc
@@ -199,6 +199,32 @@ class ParquetReaderTest : public TempFileTestBase {
                                    .properties = std::move(writer_properties)}));
   }
 
+  void CreateListParquetFile() {
+    auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
+        SchemaField::MakeRequired(1, "id", int32()),
+        SchemaField::MakeOptional(2, "numbers",
+                                  std::make_shared<ListType>(SchemaField::MakeOptional(
+                                      /*field_id=*/101, "element", int32())))});
+
+    ArrowSchema arrow_c_schema;
+    ASSERT_THAT(ToArrowSchema(*schema, &arrow_c_schema), IsOk());
+    auto arrow_schema = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+
+    auto array = ::arrow::json::ArrayFromJSONString(
+                     ::arrow::struct_(arrow_schema->fields()),
+                     R"([[1, [1, 2]], [2, [3]], [3, null]])")
+                     .ValueOrDie();
+
+    WriterProperties writer_properties;
+    writer_properties.Set(WriterProperties::kParquetCompression,
+                          std::string("uncompressed"));
+
+    ASSERT_TRUE(WriteArray(array, {.path = temp_parquet_file_,
+                                   .schema = schema,
+                                   .io = file_io_,
+                                   .properties = std::move(writer_properties)}));
+  }
+
   void CreateRowLineageParquetFile() {
     auto schema = RowLineageSchema();
 
@@ -444,6 +470,86 @@ TEST_F(ParquetReaderTest, ReadWithBatchSize) {
 
   ASSERT_NO_FATAL_FAILURE(VerifyNextBatch(*reader, R"([[1], [2]])"));
   ASSERT_NO_FATAL_FAILURE(VerifyNextBatch(*reader, R"([[3]])"));
+  ASSERT_NO_FATAL_FAILURE(VerifyExhausted(*reader));
+}
+
+TEST_F(ParquetReaderTest, ReadListType) {
+  CreateListParquetFile();
+
+  auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
+      SchemaField::MakeRequired(1, "id", int32()),
+      SchemaField::MakeOptional(2, "numbers",
+                                std::make_shared<ListType>(SchemaField::MakeOptional(
+                                    /*field_id=*/101, "element", int32())))});
+
+  auto reader_result = ReaderFactoryRegistry::Open(
+      FileFormatType::kParquet,
+      {.path = temp_parquet_file_, .io = file_io_, .projection = schema});
+  ASSERT_THAT(reader_result, IsOk());
+  auto reader = std::move(reader_result.value());
+
+  // By default list columns are read as 32-bit offset list arrays.
+  auto schema_result = reader->Schema();
+  ASSERT_THAT(schema_result, IsOk());
+  auto arrow_c_schema = std::move(schema_result.value());
+  auto arrow_type = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+  ASSERT_EQ(arrow_type->field(1)->type()->id(), ::arrow::Type::LIST);
+
+  ASSERT_NO_FATAL_FAILURE(
+      VerifyNextBatch(*reader, R"([[1, [1, 2]], [2, [3]], [3, null]])"));
+  ASSERT_NO_FATAL_FAILURE(VerifyExhausted(*reader));
+}
+
+TEST_F(ParquetReaderTest, ReadListAsLargeList) {
+  CreateListParquetFile();
+
+  auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
+      SchemaField::MakeRequired(1, "id", int32()),
+      SchemaField::MakeOptional(2, "numbers",
+                                std::make_shared<ListType>(SchemaField::MakeOptional(
+                                    /*field_id=*/101, "element", int32())))});
+
+  ReaderProperties reader_properties;
+  reader_properties.Set(ReaderProperties::kArrowUseLargeList, true);
+
+  auto reader_result = ReaderFactoryRegistry::Open(
+      FileFormatType::kParquet, {.path = temp_parquet_file_,
+                                 .io = file_io_,
+                                 .projection = schema,
+                                 .properties = std::move(reader_properties)});
+  ASSERT_THAT(reader_result, IsOk());
+  auto reader = std::move(reader_result.value());
+
+  // The output schema should expose list columns as large_list.
+  auto schema_result = reader->Schema();
+  ASSERT_THAT(schema_result, IsOk());
+  auto arrow_c_schema = std::move(schema_result.value());
+  auto arrow_type = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+  ASSERT_EQ(arrow_type->field(1)->type()->id(), ::arrow::Type::LARGE_LIST);
+
+  // JSON parsing creates regular ListArray, so verify large_list data manually.
+  auto data = reader->Next();
+  ASSERT_THAT(data, IsOk());
+  ASSERT_TRUE(data.value().has_value());
+  auto arrow_c_array = data.value().value();
+  auto arrow_array = ::arrow::ImportArray(&arrow_c_array, arrow_type).ValueOrDie();
+
+  const auto& struct_array =
+      internal::checked_cast<const ::arrow::StructArray&>(*arrow_array);
+  ASSERT_EQ(struct_array.length(), 3);
+
+  const auto& id_array =
+      internal::checked_cast<const ::arrow::Int32Array&>(*struct_array.field(0));
+  ASSERT_EQ(id_array.Value(0), 1);
+  ASSERT_EQ(id_array.Value(1), 2);
+  ASSERT_EQ(id_array.Value(2), 3);
+
+  const auto& numbers_array =
+      internal::checked_cast<const ::arrow::LargeListArray&>(*struct_array.field(1));
+  ASSERT_EQ(numbers_array.value_slice(0)->length(), 2);
+  ASSERT_EQ(numbers_array.value_slice(1)->length(), 1);
+  ASSERT_TRUE(numbers_array.IsNull(2));
+
   ASSERT_NO_FATAL_FAILURE(VerifyExhausted(*reader));
 }
 

--- a/src/iceberg/test/parquet_test.cc
+++ b/src/iceberg/test/parquet_test.cc
@@ -293,6 +293,38 @@ class ParquetReaderTest : public TempFileTestBase {
                                         .data_sequence_number = data_sequence_number});
   }
 
+  // Writes a list parquet file through parquet::arrow::WriteTable, which serializes the
+  // Arrow schema of the table into the ARROW:schema key value metadata of the file.
+  void CreateListParquetFileWithArrowSchema() {
+    const std::string kParquetFieldIdKey = "PARQUET:field_id";
+    auto arrow_schema = ::arrow::schema(
+        {::arrow::field("id", ::arrow::int32(), /*nullable=*/false,
+                        ::arrow::KeyValueMetadata::Make({kParquetFieldIdKey}, {"1"})),
+         ::arrow::field(
+             "numbers",
+             ::arrow::list(::arrow::field(
+                 "element", ::arrow::int32(), /*nullable=*/true,
+                 ::arrow::KeyValueMetadata::Make({kParquetFieldIdKey}, {"101"}))),
+             /*nullable=*/true,
+             ::arrow::KeyValueMetadata::Make({kParquetFieldIdKey}, {"2"}))});
+    auto batch =
+        ::arrow::RecordBatch::FromStructArray(
+            ::arrow::json::ArrayFromJSONString(::arrow::struct_(arrow_schema->fields()),
+                                               R"([[1, [1, 2]], [2, [3]]])")
+                .ValueOrDie())
+            .ValueOrDie();
+    auto table = ::arrow::Table::FromRecordBatches(arrow_schema, {batch}).ValueOrDie();
+
+    auto io = internal::checked_cast<arrow::ArrowFileSystemFileIO&>(*file_io_);
+    auto outfile = io.fs()->OpenOutputStream(temp_parquet_file_).ValueOrDie();
+
+    // write a single row group so that one batch holds every row
+    ASSERT_TRUE(::parquet::arrow::WriteTable(*table, ::arrow::default_memory_pool(),
+                                             outfile, table->num_rows())
+                    .ok());
+    ASSERT_TRUE(outfile->Close().ok());
+  }
+
   void VerifyNextBatch(Reader& reader, std::string_view expected_json) {
     // Boilerplate to get Arrow schema
     auto schema_result = reader.Schema();
@@ -550,6 +582,62 @@ TEST_F(ParquetReaderTest, ReadListAsLargeList) {
   ASSERT_TRUE(numbers_array.IsNull(2));
 
   ASSERT_NO_FATAL_FAILURE(VerifyExhausted(*reader));
+}
+
+TEST_F(ParquetReaderTest, ReadListAsLargeListWithArrowSchema) {
+  // A file written with serialized ARROW:schema metadata keeps its original list type, as
+  // Arrow ignores the requested large_list type in that case. The output schema must keep
+  // describing the arrays that are actually produced, otherwise projecting the record
+  // batch casts a list array to a large_list array.
+  CreateListParquetFileWithArrowSchema();
+
+  auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
+      SchemaField::MakeRequired(1, "id", int32()),
+      SchemaField::MakeOptional(2, "numbers",
+                                std::make_shared<ListType>(SchemaField::MakeOptional(
+                                    /*field_id=*/101, "element", int32())))});
+
+  ReaderProperties reader_properties;
+  reader_properties.Set(ReaderProperties::kArrowUseLargeList, true);
+
+  auto reader_result = ReaderFactoryRegistry::Open(
+      FileFormatType::kParquet, {.path = temp_parquet_file_,
+                                 .io = file_io_,
+                                 .projection = schema,
+                                 .properties = std::move(reader_properties)});
+  ASSERT_THAT(reader_result, IsOk());
+  auto reader = std::move(reader_result.value());
+
+  auto schema_result = reader->Schema();
+  ASSERT_THAT(schema_result, IsOk());
+  auto arrow_c_schema = std::move(schema_result.value());
+  auto arrow_type = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+  ASSERT_EQ(arrow_type->field(1)->type()->id(), ::arrow::Type::LIST);
+
+  auto data = reader->Next();
+  ASSERT_THAT(data, IsOk());
+  ASSERT_TRUE(data.value().has_value());
+  auto arrow_c_array = data.value().value();
+
+  // Importing the array against the reported schema fails if the two disagree.
+  auto import_result = ::arrow::ImportArray(&arrow_c_array, arrow_type);
+  ASSERT_TRUE(import_result.ok()) << import_result.status().ToString();
+  auto arrow_array = import_result.ValueOrDie();
+  ASSERT_TRUE(arrow_array->ValidateFull().ok());
+
+  const auto& struct_array =
+      internal::checked_cast<const ::arrow::StructArray&>(*arrow_array);
+  ASSERT_EQ(struct_array.length(), 2);
+
+  const auto& id_array =
+      internal::checked_cast<const ::arrow::Int32Array&>(*struct_array.field(0));
+  ASSERT_EQ(id_array.Value(0), 1);
+  ASSERT_EQ(id_array.Value(1), 2);
+
+  const auto& numbers_array =
+      internal::checked_cast<const ::arrow::ListArray&>(*struct_array.field(1));
+  ASSERT_EQ(numbers_array.value_slice(0)->length(), 2);
+  ASSERT_EQ(numbers_array.value_slice(1)->length(), 1);
 }
 
 TEST_F(ParquetReaderTest, ReadSplit) {

--- a/src/iceberg/test/parquet_test.cc
+++ b/src/iceberg/test/parquet_test.cc
@@ -210,10 +210,10 @@ class ParquetReaderTest : public TempFileTestBase {
     ASSERT_THAT(ToArrowSchema(*schema, &arrow_c_schema), IsOk());
     auto arrow_schema = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
 
-    auto array = ::arrow::json::ArrayFromJSONString(
-                     ::arrow::struct_(arrow_schema->fields()),
-                     R"([[1, [1, 2]], [2, [3]], [3, null]])")
-                     .ValueOrDie();
+    auto array =
+        ::arrow::json::ArrayFromJSONString(::arrow::struct_(arrow_schema->fields()),
+                                           R"([[1, [1, 2]], [2, [3]], [3, null]])")
+            .ValueOrDie();
 
     WriterProperties writer_properties;
     writer_properties.Set(WriterProperties::kParquetCompression,


### PR DESCRIPTION
## Summary

Implements the remaining `LargeListArray` gaps from #502, following the design suggested by @wgtmac in #513:

1. `ValidateParquetSchemaEvolution` now accepts `LARGE_LIST` wherever `LIST` is accepted, so schema projection works when the Arrow reader presents 64-bit offset list types.
2. A new reader property `read.arrow.use-large-list` (default: `false`) configures the Parquet reader via `ArrowReaderProperties::set_list_type(::arrow::Type::LARGE_LIST)` to decode list columns as `large_list`.

Since `ToArrowSchema` builds the reader's output schema with 32-bit lists (and `ProjectRecordBatch` dispatches on the output schema type), enabling the property also rewrites list fields in the output Arrow schema to `large_list` so the projection layer takes the `ProjectLargeListArray` path added in #502. The rewrite is local to the Parquet reader to avoid changing the `ToArrowSchema` signature used across writers and manifest readers.

Closes #513

## Changes

- `src/iceberg/parquet/parquet_schema_util.cc`: accept `LARGE_LIST` for `TypeId::kList` in schema evolution validation.
- `src/iceberg/file_reader.h`: add `ReaderProperties::kArrowUseLargeList` (`read.arrow.use-large-list`, default `false`), following the `kBatchSize` pattern.
- `src/iceberg/parquet/parquet_reader.cc`: set `ArrowReaderProperties::set_list_type` when the property is enabled, and align the output Arrow schema (lists nested in structs/maps included) with the large_list arrays produced by the reader.

## Test plan

- `ParquetSchemaProjectionTest.ValidateSchemaEvolutionAllowsLargeList`: `large_list` Arrow type validates against an Iceberg `ListType`.
- `ParquetSchemaProjectionTest.ProjectLargeListType`: projection over a `SchemaManifest` built with `set_list_type(LARGE_LIST)` (the same path `BuildProjection` uses in the reader).
- `ParquetReaderTest.ReadListType`: default behavior unchanged — list columns read as 32-bit offset `list`.
- `ParquetReaderTest.ReadListAsLargeList`: with `read.arrow.use-large-list=true`, the output schema exposes `large_list` and values round-trip correctly (verified via array slices since JSON parsing creates regular `ListArray`).

Note: my local environment lacks a C++23 toolchain (cmake 3.16/gcc 10), so I could not build locally; relying on CI to verify. All Arrow APIs used (`set_list_type`, `large_list(field)`, `MapType(key_field, item_field, keys_sorted)`, `Field::WithType`) were checked against the pinned Arrow 24.0.0 headers.
