### PR TITLE
fix: YearTransform passes wrong TransformType kTruncate instead of kYear

### DIFF
--- a/src/iceberg/test/transform_test.cc
+++ b/src/iceberg/test/transform_test.cc
@@ -71,6 +71,56 @@ TEST(TransformFunctionTest, CreateTruncateTransform) {
   EXPECT_EQ(transformPtr.value()->transform_type(), TransformType::kTruncate);
 }
 
+TEST(TransformFunctionTest, CreateYearTransform) {
+  auto transform = Transform::Year();
+  EXPECT_EQ("year", transform->ToString());
+  EXPECT_EQ("year", std::format("{}", *transform));
+
+  auto transformPtr = transform->Bind(iceberg::timestamp());
+  ASSERT_TRUE(transformPtr);
+  EXPECT_EQ(transformPtr.value()->transform_type(), TransformType::kYear);
+}
+
+TEST(TransformFunctionTest, CreateMonthTransform) {
+  auto transform = Transform::Month();
+  EXPECT_EQ("month", transform->ToString());
+  EXPECT_EQ("month", std::format("{}", *transform));
+
+  auto transformPtr = transform->Bind(iceberg::timestamp());
+  ASSERT_TRUE(transformPtr);
+  EXPECT_EQ(transformPtr.value()->transform_type(), TransformType::kMonth);
+}
+
+TEST(TransformFunctionTest, CreateDayTransform) {
+  auto transform = Transform::Day();
+  EXPECT_EQ("day", transform->ToString());
+  EXPECT_EQ("day", std::format("{}", *transform));
+
+  auto transformPtr = transform->Bind(iceberg::timestamp_tz());
+  ASSERT_TRUE(transformPtr);
+  EXPECT_EQ(transformPtr.value()->transform_type(), TransformType::kDay);
+}
+
+TEST(TransformFunctionTest, CreateHourTransform) {
+  auto transform = Transform::Hour();
+  EXPECT_EQ("hour", transform->ToString());
+  EXPECT_EQ("hour", std::format("{}", *transform));
+
+  auto transformPtr = transform->Bind(iceberg::timestamp());
+  ASSERT_TRUE(transformPtr);
+  EXPECT_EQ(transformPtr.value()->transform_type(), TransformType::kHour);
+}
+
+TEST(TransformFunctionTest, CreateVoidTransform) {
+  auto transform = Transform::Void();
+  EXPECT_EQ("void", transform->ToString());
+  EXPECT_EQ("void", std::format("{}", *transform));
+
+  auto transformPtr = transform->Bind(iceberg::int32());
+  ASSERT_TRUE(transformPtr);
+  EXPECT_EQ(transformPtr.value()->transform_type(), TransformType::kVoid);
+}
+
 TEST(TransformFromStringTest, PositiveCases) {
   struct Case {
     std::string str;

--- a/src/iceberg/transform_function.cc
+++ b/src/iceberg/transform_function.cc
@@ -131,7 +131,7 @@ Result<std::unique_ptr<TransformFunction>> TruncateTransform::Make(
 }
 
 YearTransform::YearTransform(std::shared_ptr<Type> const& source_type)
-    : TransformFunction(TransformType::kTruncate, source_type) {}
+    : TransformFunction(TransformType::kYear, source_type) {}
 
 Result<Literal> YearTransform::Transform(const Literal& literal) {
   ICEBERG_DCHECK(*literal.type() == *source_type(),


### PR DESCRIPTION
## Summary

**Bug:** YearTransform constructor passed TransformType::kTruncate to the TransformFunction base class instead of TransformType::kYear. This caused transform_type() to return kTruncate on a bound YearTransform, affecting code paths that dispatch based on transform_type() (e.g., Transform::Project, Transform::ProjectStrict, Transform::SatisfiesOrderOf).

**Fix:** Changed kTruncate to kYear in the YearTransform constructor.

**Tests:** Added TransformFunctionTest cases for Year, Month, Day, Hour, and Void transforms to verify transform_type() after Bind(). The existing suite only tested Identity, Bucket, and Truncate.