### PR TITLE
Revert "chore: remove spdlog dependency (#459)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ If you experience network issues when downloading dependencies, you can customiz
 - `ICEBERG_NANOARROW_URL`: Nanoarrow tarball URL
 - `ICEBERG_CROARING_URL`: CRoaring tarball URL
 - `ICEBERG_NLOHMANN_JSON_URL`: nlohmann-json tarball URL
+- `ICEBERG_SPDLOG_URL`: spdlog tarball URL
 - `ICEBERG_CPR_URL`: cpr tarball URL
 
 Example:

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -31,6 +31,7 @@ set(ICEBERG_ARROW_INSTALL_INTERFACE_LIBS)
 # ICEBERG_NANOARROW_URL      - Nanoarrow tarball URL
 # ICEBERG_CROARING_URL       - CRoaring tarball URL
 # ICEBERG_NLOHMANN_JSON_URL  - nlohmann-json tarball URL
+# ICEBERG_SPDLOG_URL         - spdlog tarball URL
 # ICEBERG_CPR_URL            - cpr tarball URL
 #
 # Example usage:
@@ -438,6 +439,61 @@ function(resolve_nlohmann_json_dependency)
 endfunction()
 
 # ----------------------------------------------------------------------
+# spdlog
+
+function(resolve_spdlog_dependency)
+  prepare_fetchcontent()
+
+  find_package(Threads REQUIRED)
+
+  set(SPDLOG_USE_STD_FORMAT
+      ON
+      CACHE BOOL "" FORCE)
+  set(SPDLOG_BUILD_PIC
+      ON
+      CACHE BOOL "" FORCE)
+
+  if(DEFINED ENV{ICEBERG_SPDLOG_URL})
+    set(SPDLOG_URL "$ENV{ICEBERG_SPDLOG_URL}")
+  else()
+    set(SPDLOG_URL "https://github.com/gabime/spdlog/archive/refs/tags/v1.15.3.tar.gz")
+  endif()
+
+  fetchcontent_declare(spdlog
+                       ${FC_DECLARE_COMMON_OPTIONS}
+                       URL ${SPDLOG_URL}
+                           FIND_PACKAGE_ARGS
+                           NAMES
+                           spdlog
+                           CONFIG)
+  fetchcontent_makeavailable(spdlog)
+
+  if(spdlog_SOURCE_DIR)
+    set_target_properties(spdlog PROPERTIES OUTPUT_NAME "iceberg_vendored_spdlog"
+                                            POSITION_INDEPENDENT_CODE ON)
+    target_link_libraries(spdlog INTERFACE Threads::Threads)
+    install(TARGETS spdlog
+            EXPORT iceberg_targets
+            RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"
+            ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
+            LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
+    set(SPDLOG_VENDORED TRUE)
+  else()
+    set(SPDLOG_VENDORED FALSE)
+    list(APPEND ICEBERG_SYSTEM_DEPENDENCIES spdlog)
+  endif()
+
+  list(APPEND ICEBERG_SYSTEM_DEPENDENCIES Threads)
+
+  set(ICEBERG_SYSTEM_DEPENDENCIES
+      ${ICEBERG_SYSTEM_DEPENDENCIES}
+      PARENT_SCOPE)
+  set(SPDLOG_VENDORED
+      ${SPDLOG_VENDORED}
+      PARENT_SCOPE)
+endfunction()
+
+# ----------------------------------------------------------------------
 # zlib
 
 function(resolve_zlib_dependency)
@@ -614,6 +670,7 @@ resolve_zlib_dependency()
 resolve_nanoarrow_dependency()
 resolve_croaring_dependency()
 resolve_nlohmann_json_dependency()
+resolve_spdlog_dependency()
 
 if(ICEBERG_BUILD_BUNDLE)
   resolve_arrow_dependency()

--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -139,22 +139,24 @@ list(APPEND
      ICEBERG_STATIC_BUILD_INTERFACE_LIBS
      "$<IF:$<BOOL:${NANOARROW_VENDORED}>,nanoarrow::nanoarrow_static,$<IF:$<TARGET_EXISTS:nanoarrow::nanoarrow_static>,nanoarrow::nanoarrow_static,nanoarrow::nanoarrow_shared>>"
      nlohmann_json::nlohmann_json
+     spdlog::spdlog
      ZLIB::ZLIB)
 list(APPEND
      ICEBERG_SHARED_BUILD_INTERFACE_LIBS
      "$<IF:$<BOOL:${NANOARROW_VENDORED}>,nanoarrow::nanoarrow_static,$<IF:$<TARGET_EXISTS:nanoarrow::nanoarrow_shared>,nanoarrow::nanoarrow_shared,nanoarrow::nanoarrow_static>>"
      nlohmann_json::nlohmann_json
+     spdlog::spdlog
      ZLIB::ZLIB)
 list(APPEND
      ICEBERG_STATIC_INSTALL_INTERFACE_LIBS
      "$<IF:$<BOOL:${NANOARROW_VENDORED}>,iceberg::nanoarrow_static,$<IF:$<TARGET_EXISTS:nanoarrow::nanoarrow_static>,nanoarrow::nanoarrow_static,nanoarrow::nanoarrow_shared>>"
      "$<IF:$<BOOL:${NLOHMANN_JSON_VENDORED}>,iceberg::nlohmann_json,$<IF:$<TARGET_EXISTS:nlohmann_json::nlohmann_json>,nlohmann_json::nlohmann_json,nlohmann_json::nlohmann_json>>"
-)
+     "$<IF:$<BOOL:${SPDLOG_VENDORED}>,iceberg::spdlog,spdlog::spdlog>")
 list(APPEND
      ICEBERG_SHARED_INSTALL_INTERFACE_LIBS
      "$<IF:$<BOOL:${NANOARROW_VENDORED}>,iceberg::nanoarrow_static,$<IF:$<TARGET_EXISTS:nanoarrow::nanoarrow_shared>,nanoarrow::nanoarrow_shared,nanoarrow::nanoarrow_static>>"
      "$<IF:$<BOOL:${NLOHMANN_JSON_VENDORED}>,iceberg::nlohmann_json,$<IF:$<TARGET_EXISTS:nlohmann_json::nlohmann_json>,nlohmann_json::nlohmann_json,nlohmann_json::nlohmann_json>>"
-)
+     "$<IF:$<BOOL:${SPDLOG_VENDORED}>,iceberg::spdlog,spdlog::spdlog>")
 
 add_iceberg_lib(iceberg
                 SOURCES

--- a/src/iceberg/meson.build
+++ b/src/iceberg/meson.build
@@ -180,9 +180,10 @@ croaring_needs_static = (
 croaring_dep = dependency('croaring', static: croaring_needs_static)
 nanoarrow_dep = dependency('nanoarrow')
 nlohmann_json_dep = dependency('nlohmann_json')
+spdlog_dep = dependency('spdlog')
 zlib_dep = dependency('zlib')
 
-iceberg_deps = [nanoarrow_dep, nlohmann_json_dep, zlib_dep]
+iceberg_deps = [nanoarrow_dep, nlohmann_json_dep, spdlog_dep, zlib_dep]
 
 iceberg_lib = library(
     'iceberg',

--- a/subprojects/spdlog.wrap
+++ b/subprojects/spdlog.wrap
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = spdlog-1.15.3
+source_url = https://github.com/gabime/spdlog/archive/refs/tags/v1.15.3.tar.gz
+source_filename = spdlog-1.15.3.tar.gz
+source_hash = 15a04e69c222eb6c01094b5c7ff8a249b36bb22788d72519646fb85feb267e67
+patch_filename = spdlog_1.15.3-4_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/spdlog_1.15.3-4/get_patch
+patch_hash = ccdc72f3d965980d5edd1a56129a9b7fa5f7c86f31e4ecf2dba6a6068829d4e2
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/spdlog_1.15.3-4/spdlog-1.15.3.tar.gz
+wrapdb_version = 1.15.3-4
+
+[provide]
+spdlog = spdlog_dep


### PR DESCRIPTION
## What
Re-adds spdlog (v1.15.3, configured with SPDLOG_USE_STD_FORMAT) as a build dependency, reverting #459.

## Why
#459 removed spdlog because nothing used it at the time, with the note that it could be added back "when it is actually needed." It is now needed: this is the foundation for the upcoming logging system for iceberg-cpp. Restoring the dependency wiring in its own change keeps that follow-up focused purely on the logger itself.
