### PR TITLE
feat(logging): add logging macros (4/6)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,7 +33,11 @@ project(
 cpp = meson.get_compiler('cpp')
 # Hide two noisy MSVC warnings (C4251/C4275) about standard-library types used in
 # our public classes. They're harmless because the whole library ships as one DLL.
-args = cpp.get_supported_arguments(['/bigobj', '/wd4251', '/wd4275'])
+# /Zc:preprocessor: MSVC's conforming preprocessor, required for the __VA_OPT__
+# used by the logging macros. get_supported_arguments drops these on non-MSVC.
+args = cpp.get_supported_arguments(
+    ['/bigobj', '/wd4251', '/wd4275', '/Zc:preprocessor'],
+)
 add_project_arguments(args, language: 'cpp')
 
 subdir('src')

--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -193,6 +193,18 @@ add_iceberg_lib(iceberg
                 OUTPUTS
                 ICEBERG_LIBRARIES)
 
+# The logging macros in the public logger.h use __VA_OPT__, which MSVC's
+# traditional preprocessor rejects. Require the conforming preprocessor PUBLICly
+# so both these library targets (logger.cc includes logger.h) and downstream
+# consumers of the installed header get it on MSVC.
+if(MSVC_TOOLCHAIN)
+  foreach(_iceberg_lib iceberg_shared iceberg_static)
+    if(TARGET ${_iceberg_lib})
+      target_compile_options(${_iceberg_lib} PUBLIC /Zc:preprocessor)
+    endif()
+  endforeach()
+endif()
+
 set(ICEBERG_DATA_SOURCES
     data/data_writer.cc
     data/delete_filter.cc

--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -193,10 +193,10 @@ add_iceberg_lib(iceberg
                 OUTPUTS
                 ICEBERG_LIBRARIES)
 
-# The logging macros in the public logger.h use __VA_OPT__, which MSVC's
-# traditional preprocessor rejects. Require the conforming preprocessor PUBLICly
-# so both these library targets (logger.cc includes logger.h) and downstream
-# consumers of the installed header get it on MSVC.
+# The logging macros in the installed public header log_macros.h use __VA_OPT__,
+# which MSVC's traditional preprocessor rejects. Require the conforming
+# preprocessor PUBLICly so downstream consumers that include log_macros.h get it
+# on MSVC (and any library TU that includes it does too).
 if(MSVC_TOOLCHAIN)
   foreach(_iceberg_lib iceberg_shared iceberg_static)
     if(TARGET ${_iceberg_lib})

--- a/src/iceberg/logging/log_macros.h
+++ b/src/iceberg/logging/log_macros.h
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+/// \file iceberg/logging/log_macros.h
+/// \brief Iceberg-prefixed logging macros (ICEBERG_LOG_*).
+///
+/// Kept out of logger.h so consumers of the C++ logging API (Logger, Log(),
+/// ScopedLogger) are not forced to pull in these macros or the conforming
+/// preprocessor they require. Include this header to use the macros; include
+/// short_log_macros.h for the bare LOG_* aliases.
+
+#include <cstdlib>
+#include <format>
+#include <memory>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "iceberg/logging/log_level.h"
+#include "iceberg/logging/logger.h"
+
+namespace iceberg::internal {
+
+/// \brief Runtime (non-literal) format-string helper for ICEBERG_LOG_RUNTIME_FMT.
+///
+/// std::format requires a compile-time format string; this routes a runtime
+/// string through std::vformat. Args are bound as named lvalues and the
+/// arg-store is held in a named variable so it outlives the vformat call
+/// (C++23 make_format_args rejects rvalues -- P2905 / LWG3631).
+template <typename... Args>
+std::string VFormat(std::string_view fmt, Args&&... args) {
+  auto store = std::make_format_args(args...);
+  return std::vformat(fmt, store);
+}
+
+/// \brief Gate on \p logger.ShouldLog, then format (via \p make_message) and emit.
+///
+/// \p make_message is a callable returning the formatted std::string; it is
+/// invoked only after the level passes ShouldLog, so a disabled log never
+/// evaluates its format arguments. Never throws: a std::formatter that throws
+/// (any type) routes to EmitFormatError, so the noexcept logging contract holds.
+template <typename MakeMessage>
+void EmitIfEnabled(Logger& logger, LogLevel level, const std::source_location& location,
+                   MakeMessage&& make_message) noexcept {
+  if (!logger.ShouldLog(level)) return;
+  try {
+    Emit(logger, level, location, std::forward<MakeMessage>(make_message)());
+  } catch (...) {
+    EmitFormatError(logger, level, location);
+  }
+}
+
+/// \brief Emit to the current (scoped-or-default) logger if enabled.
+template <typename MakeMessage>
+void LogToCurrent(LogLevel level, const std::source_location& location,
+                  MakeMessage&& make_message) noexcept {
+  const std::shared_ptr<Logger>& logger = CurrentLogger();
+  if (logger) {
+    EmitIfEnabled(*logger, level, location, std::forward<MakeMessage>(make_message));
+  }
+}
+
+/// \brief Runtime-level variant against the current logger: emit if enabled, then
+/// flush + abort when level == kFatal (using the same acquired logger).
+template <typename MakeMessage>
+void LogToCurrentRuntime(LogLevel level, const std::source_location& location,
+                         MakeMessage&& make_message) noexcept {
+  const std::shared_ptr<Logger>& logger = CurrentLogger();
+  if (logger) {
+    EmitIfEnabled(*logger, level, location, std::forward<MakeMessage>(make_message));
+  }
+  if (level == LogLevel::kFatal) {
+    if (logger) logger->Flush();
+    std::abort();
+  }
+}
+
+/// \brief Runtime-level variant against an explicit logger: emit if enabled, then
+/// flush + abort when level == kFatal.
+template <typename MakeMessage>
+void LogToExplicitRuntime(Logger& logger, LogLevel level,
+                          const std::source_location& location,
+                          MakeMessage&& make_message) noexcept {
+  EmitIfEnabled(logger, level, location, std::forward<MakeMessage>(make_message));
+  if (level == LogLevel::kFatal) {
+    logger.Flush();
+    std::abort();
+  }
+}
+
+/// \brief Fatal path: acquire the effective (scoped-or-default) logger ONCE, emit
+/// if enabled, flush that same logger, then abort. Never returns.
+template <typename MakeMessage>
+[[noreturn]] void LogFatal(const std::source_location& location,
+                           MakeMessage&& make_message) noexcept {
+  auto logger = GetCurrentLogger();
+  if (logger) {
+    EmitIfEnabled(*logger, LogLevel::kFatal, location,
+                  std::forward<MakeMessage>(make_message));
+    logger->Flush();
+  }
+  std::abort();
+}
+
+}  // namespace iceberg::internal
+
+// ---------------------------------------------------------------------------
+// Logging macros.
+//
+// Every macro takes a std::format string followed by its arguments. The
+// rendered line depends on the active backend (see cerr_logger.h for the
+// std::cerr layout, or the spdlog pattern); the examples below show the call
+// site and, for the default CerrLogger, the line it produces.
+//
+//   ICEBERG_LOG_TRACE("entering scan for {}", table);
+//     2026-06-16T10:59:41.186Z trace [12345] [table_scan.cc:88] entering scan for db.t
+//   ICEBERG_LOG_DEBUG("cache miss key={}", key);
+//     2026-06-16T10:59:41.186Z debug [12345] [cache.cc:42] cache miss key=manifest-7
+//   ICEBERG_LOG_INFO("loaded {} manifests in {} ms", n, ms);
+//     2026-06-16T10:59:41.186Z info [12345] [table_scan.cc:91] loaded 5 manifests in 12
+//     ms
+//   ICEBERG_LOG_WARN("retry {} after {}", attempt, err);
+//     2026-06-16T10:59:41.186Z warn [12345] [io.cc:51] retry 2 after timeout
+//   ICEBERG_LOG_ERROR("commit failed: {}", status);
+//     2026-06-16T10:59:41.186Z error [12345] [txn.cc:77] commit failed: conflict
+//   ICEBERG_LOG_CRITICAL("metadata unreadable at {}", path);
+//     2026-06-16T10:59:41.186Z critical [12345] [meta.cc:30] metadata unreadable at
+//     s3://b/m.json
+//   ICEBERG_LOG_FATAL("unrecoverable: {}", reason);   // emits, flushes, then
+//   std::abort()
+//     2026-06-16T10:59:41.186Z fatal [12345] [boot.cc:19] unrecoverable: bad config
+//
+// Less common forms:
+//   ICEBERG_LOG(level, "level chosen at runtime: {}", x);     // runtime severity
+//   ICEBERG_LOG_TO(logger, level, "to an explicit logger {}", y);
+//   ICEBERG_LOG_RUNTIME_FMT(level, fmt_string, args...);       // non-literal format
+//
+// Include short_log_macros.h for bare aliases (LOG_INFO, ...). A format string is
+// mandatory; zero extra args is fine (ICEBERG_LOG_INFO("done")).
+// ---------------------------------------------------------------------------
+
+/// \brief Compile-time severity floor: statements below this level are discarded
+/// via `if constexpr`, so no emit code runs and no format call / source_location
+/// is generated for them (the compiler is free to optimize the dead branch away).
+/// The statement must still be well-formed -- a bad format string or a
+/// non-formattable argument is a compile error even when the branch is discarded.
+/// Defaults to keeping everything. ICEBERG_LOG_FATAL is never gated by this floor
+/// -- its abort is always compiled in.
+#ifndef ICEBERG_LOG_ACTIVE_LEVEL
+#  define ICEBERG_LOG_ACTIVE_LEVEL ::iceberg::LogLevel::kTrace
+#endif
+
+// A message-builder lambda that formats lazily (only invoked past ShouldLog by the
+// EmitIfEnabled helpers), so disabled logs never evaluate their arguments.
+#define ICEBERG_INTERNAL_LOG_MESSAGE(FMT_, ...) \
+  [&]() -> ::std::string { return ::std::format((FMT_)__VA_OPT__(, ) __VA_ARGS__); }
+
+// Fixed-severity emit with a compile-time floor (`if constexpr`) then the shared
+// current-logger path. Formatting happens only on the taken path and never throws.
+#define ICEBERG_INTERNAL_LOG(level_, FMT_, ...)                           \
+  do {                                                                    \
+    if constexpr ((level_) >= ICEBERG_LOG_ACTIVE_LEVEL) {                 \
+      ::iceberg::internal::LogToCurrent(                                  \
+          (level_), ::std::source_location::current(),                    \
+          ICEBERG_INTERNAL_LOG_MESSAGE(FMT_ __VA_OPT__(, ) __VA_ARGS__)); \
+    }                                                                     \
+  } while (0)
+
+#define ICEBERG_LOG_TRACE(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kTrace, __VA_ARGS__)
+#define ICEBERG_LOG_DEBUG(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kDebug, __VA_ARGS__)
+#define ICEBERG_LOG_INFO(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kInfo, __VA_ARGS__)
+#define ICEBERG_LOG_WARN(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kWarn, __VA_ARGS__)
+#define ICEBERG_LOG_ERROR(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kError, __VA_ARGS__)
+#define ICEBERG_LOG_CRITICAL(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kCritical, __VA_ARGS__)
+
+// FATAL: emit if enabled (never compile-stripped), then ALWAYS flush + abort.
+// Acquires the effective (scoped-or-default) logger ONCE so a concurrent
+// SetDefaultLogger cannot flush a different logger than it emitted to.
+#define ICEBERG_LOG_FATAL(FMT_, ...)     \
+  ::iceberg::internal::LogFatal(         \
+      ::std::source_location::current(), \
+      ICEBERG_INTERNAL_LOG_MESSAGE(FMT_ __VA_OPT__(, ) __VA_ARGS__))
+
+// Generic, runtime-level form against the default logger. No compile-time floor
+// (the level is not a constant). Aborts when level == kFatal.
+#define ICEBERG_LOG(level_, FMT_, ...)             \
+  ::iceberg::internal::LogToCurrentRuntime(        \
+      (level_), ::std::source_location::current(), \
+      ICEBERG_INTERNAL_LOG_MESSAGE(FMT_ __VA_OPT__(, ) __VA_ARGS__))
+
+// Generic form targeting an EXPLICIT logger (must be an lvalue Logger&). Honors
+// only that logger's ShouldLog. Aborts when level == kFatal.
+#define ICEBERG_LOG_TO(logger_, level_, FMT_, ...)            \
+  ::iceberg::internal::LogToExplicitRuntime(                  \
+      (logger_), (level_), ::std::source_location::current(), \
+      ICEBERG_INTERNAL_LOG_MESSAGE(FMT_ __VA_OPT__(, ) __VA_ARGS__))
+
+// Runtime (non-literal) format string against the default logger. Aborts when
+// level == kFatal.
+#define ICEBERG_LOG_RUNTIME_FMT(level_, FMT_, ...)                             \
+  ::iceberg::internal::LogToCurrentRuntime(                                    \
+      (level_), ::std::source_location::current(), [&]() -> ::std::string {    \
+        return ::iceberg::internal::VFormat((FMT_)__VA_OPT__(, ) __VA_ARGS__); \
+      })

--- a/src/iceberg/logging/log_macros.h
+++ b/src/iceberg/logging/log_macros.h
@@ -108,15 +108,34 @@ void LogToExplicitRuntime(Logger& logger, LogLevel level,
 }
 
 /// \brief Fatal path: acquire the effective (scoped-or-default) logger ONCE, emit
-/// if enabled, flush that same logger, then abort. Never returns.
+/// if enabled, flush that same logger, run any registered FatalHandler, then
+/// abort. Never returns.
+///
+/// The message is always formatted here (independent of ShouldLog) so the handler
+/// receives it even when the fatal record itself is filtered out. The handler runs
+/// after emit+flush and before abort; if it does not itself terminate the process,
+/// std::abort() still runs.
 template <typename MakeMessage>
 [[noreturn]] void LogFatal(const std::source_location& location,
                            MakeMessage&& make_message) noexcept {
+  std::string message;
+  try {
+    message = std::forward<MakeMessage>(make_message)();
+  } catch (...) {
+    message = "<fmt error>";
+  }
   auto logger = GetCurrentLogger();
   if (logger) {
-    EmitIfEnabled(*logger, LogLevel::kFatal, location,
-                  std::forward<MakeMessage>(make_message));
+    if (logger->ShouldLog(LogLevel::kFatal)) {
+      Emit(*logger, LogLevel::kFatal, location, std::string(message));
+    }
     logger->Flush();
+  }
+  if (auto handler = GetFatalHandler()) {
+    try {
+      handler(location, message);
+    } catch (...) {  // a throwing handler must not prevent the abort
+    }
   }
   std::abort();
 }

--- a/src/iceberg/logging/logger.cc
+++ b/src/iceberg/logging/logger.cc
@@ -106,6 +106,35 @@ void SetDefaultLevel(LogLevel level) {
   slot.logger->SetLevel(level);
 }
 
+namespace {
+
+/// \brief Immortal (leaked, hence teardown-safe) home for the fatal handler and
+/// its mutex. Leaked like Slot() so GetFatalHandler() is valid even during static
+/// teardown / from the fatal path at any time.
+struct FatalHandlerSlot {
+  std::mutex mtx;
+  FatalHandler handler;
+};
+
+FatalHandlerSlot& FatalSlot() {
+  static auto* slot = new FatalHandlerSlot();
+  return *slot;
+}
+
+}  // namespace
+
+void SetFatalHandler(FatalHandler handler) {
+  FatalHandlerSlot& slot = FatalSlot();
+  std::lock_guard<std::mutex> lock(slot.mtx);
+  slot.handler = std::move(handler);
+}
+
+FatalHandler GetFatalHandler() {
+  FatalHandlerSlot& slot = FatalSlot();
+  std::lock_guard<std::mutex> lock(slot.mtx);
+  return slot.handler;  // copy under lock; safe to invoke without holding the lock
+}
+
 namespace internal {
 
 namespace {

--- a/src/iceberg/logging/logger.h
+++ b/src/iceberg/logging/logger.h
@@ -28,6 +28,7 @@
 
 #include <concepts>
 #include <cstdlib>
+#include <exception>
 #include <format>
 #include <memory>
 #include <source_location>
@@ -339,7 +340,7 @@ void FormatAndEmit(Logger& logger, LogLevel level, const std::source_location& l
   if (!logger.ShouldLog(level)) return;
   try {
     Emit(logger, level, loc, std::format(fmt, std::forward<Args>(args)...));
-  } catch (...) {
+  } catch (const std::exception&) {
     EmitFormatError(logger, level, loc);
   }
 }
@@ -371,3 +372,180 @@ void Log(Logger& logger, LogLevel level,
 }
 
 }  // namespace iceberg
+
+// ---------------------------------------------------------------------------
+// Logging macros.
+//
+// Every macro takes a std::format string followed by its arguments. The
+// rendered line depends on the active backend (see cerr_logger.h for the
+// std::cerr layout, or the spdlog pattern); the examples below show the call
+// site and, for the default CerrLogger, the line it produces.
+//
+//   ICEBERG_LOG_TRACE("entering scan for {}", table);
+//     2026-06-16T10:59:41.186Z trace [12345] table_scan.cc:88] entering scan for db.t
+//   ICEBERG_LOG_DEBUG("cache miss key={}", key);
+//     2026-06-16T10:59:41.186Z debug [12345] cache.cc:42] cache miss key=manifest-7
+//   ICEBERG_LOG_INFO("loaded {} manifests in {} ms", n, ms);
+//     2026-06-16T10:59:41.186Z info [12345] table_scan.cc:91] loaded 5 manifests in 12 ms
+//   ICEBERG_LOG_WARN("retry {} after {}", attempt, err);
+//     2026-06-16T10:59:41.186Z warn [12345] io.cc:51] retry 2 after timeout
+//   ICEBERG_LOG_ERROR("commit failed: {}", status);
+//     2026-06-16T10:59:41.186Z error [12345] txn.cc:77] commit failed: conflict
+//   ICEBERG_LOG_CRITICAL("metadata unreadable at {}", path);
+//     2026-06-16T10:59:41.186Z critical [12345] meta.cc:30] metadata unreadable at
+//     s3://b/m.json
+//   ICEBERG_LOG_FATAL("unrecoverable: {}", reason);   // emits, flushes, then
+//   std::abort()
+//     2026-06-16T10:59:41.186Z fatal [12345] boot.cc:19] unrecoverable: bad config
+//
+// Less common forms:
+//   ICEBERG_LOG(level, "level chosen at runtime: {}", x);     // runtime severity
+//   ICEBERG_LOG_TO(logger, level, "to an explicit logger {}", y);
+//   ICEBERG_LOG_RUNTIME_FMT(level, fmt_string, args...);       // non-literal format
+//
+// With ICEBERG_LOG_SHORT_MACROS defined, bare aliases (LOG_INFO, ...) are also
+// available. A format string is mandatory; zero extra args is fine
+// (ICEBERG_LOG_INFO("done")).
+// ---------------------------------------------------------------------------
+
+/// \brief Compile-time severity floor: statements below this level are removed
+/// entirely from the build (their format call sites and source_location literals
+/// are never emitted). Defaults to keeping everything. ICEBERG_LOG_FATAL is never
+/// gated by this floor -- its abort is always compiled in.
+#ifndef ICEBERG_LOG_ACTIVE_LEVEL
+#  define ICEBERG_LOG_ACTIVE_LEVEL ::iceberg::LogLevel::kTrace
+#endif
+
+// Internal: fixed-severity emit with compile-time floor then the authoritative
+// Logger::ShouldLog (the single source of truth for runtime filtering), with
+// formatting only on the taken path, never throwing.
+#define ICEBERG_INTERNAL_LOG(level_, FMT_, ...)                                      \
+  do {                                                                               \
+    if constexpr ((level_) >= ICEBERG_LOG_ACTIVE_LEVEL) {                            \
+      const auto& _ib_logger = ::iceberg::internal::CurrentLogger();                 \
+      if (_ib_logger && _ib_logger->ShouldLog(level_)) {                             \
+        try {                                                                        \
+          ::iceberg::internal::Emit(*_ib_logger, (level_),                           \
+                                    ::std::source_location::current(),               \
+                                    ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__)); \
+        } catch (const std::exception&) {                                            \
+          ::iceberg::internal::EmitFormatError(*_ib_logger, (level_),                \
+                                               ::std::source_location::current());   \
+        }                                                                            \
+      }                                                                              \
+    }                                                                                \
+  } while (0)
+
+#define ICEBERG_LOG_TRACE(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kTrace, __VA_ARGS__)
+#define ICEBERG_LOG_DEBUG(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kDebug, __VA_ARGS__)
+#define ICEBERG_LOG_INFO(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kInfo, __VA_ARGS__)
+#define ICEBERG_LOG_WARN(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kWarn, __VA_ARGS__)
+#define ICEBERG_LOG_ERROR(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kError, __VA_ARGS__)
+#define ICEBERG_LOG_CRITICAL(...) \
+  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kCritical, __VA_ARGS__)
+
+// FATAL: emit if enabled (never compile-stripped), then ALWAYS flush + abort.
+// Acquires the effective (scoped-or-default) logger ONCE -- honoring any active
+// ScopedLogger binding -- and uses that same instance for emit and flush, so a
+// concurrent SetDefaultLogger cannot flush a different logger than it emitted to.
+#define ICEBERG_LOG_FATAL(FMT_, ...)                                                   \
+  do {                                                                                 \
+    auto _ib_logger = ::iceberg::GetCurrentLogger();                                   \
+    if (_ib_logger && _ib_logger->ShouldLog(::iceberg::LogLevel::kFatal)) {            \
+      try {                                                                            \
+        ::iceberg::internal::Emit(*_ib_logger, ::iceberg::LogLevel::kFatal,            \
+                                  ::std::source_location::current(),                   \
+                                  ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__));     \
+      } catch (const std::exception&) {                                                \
+        ::iceberg::internal::EmitFormatError(*_ib_logger, ::iceberg::LogLevel::kFatal, \
+                                             ::std::source_location::current());       \
+      }                                                                                \
+    }                                                                                  \
+    if (_ib_logger) _ib_logger->Flush();                                               \
+    ::std::abort();                                                                    \
+  } while (0)
+
+// Generic, runtime-level form against the default logger. No compile-time floor
+// (the level is not a constant). Acquires the logger once; aborts when level == kFatal
+// (flushing that same logger first).
+#define ICEBERG_LOG(level_, FMT_, ...)                                             \
+  do {                                                                             \
+    const ::iceberg::LogLevel _ib_lvl = (level_);                                  \
+    const auto& _ib_logger = ::iceberg::internal::CurrentLogger();                 \
+    if (_ib_logger && _ib_logger->ShouldLog(_ib_lvl)) {                            \
+      try {                                                                        \
+        ::iceberg::internal::Emit(*_ib_logger, _ib_lvl,                            \
+                                  ::std::source_location::current(),               \
+                                  ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__)); \
+      } catch (const std::exception&) {                                            \
+        ::iceberg::internal::EmitFormatError(*_ib_logger, _ib_lvl,                 \
+                                             ::std::source_location::current());   \
+      }                                                                            \
+    }                                                                              \
+    if (_ib_lvl == ::iceberg::LogLevel::kFatal) {                                  \
+      if (_ib_logger) _ib_logger->Flush();                                         \
+      ::std::abort();                                                              \
+    }                                                                              \
+  } while (0)
+
+// Generic form targeting an EXPLICIT logger (must be an lvalue Logger&). Honors
+// only that logger's ShouldLog. Aborts when level == kFatal.
+#define ICEBERG_LOG_TO(logger_, level_, FMT_, ...)                                 \
+  do {                                                                             \
+    ::iceberg::Logger& _ib_logger = (logger_);                                     \
+    const ::iceberg::LogLevel _ib_lvl = (level_);                                  \
+    if (_ib_logger.ShouldLog(_ib_lvl)) {                                           \
+      try {                                                                        \
+        ::iceberg::internal::Emit(_ib_logger, _ib_lvl,                             \
+                                  ::std::source_location::current(),               \
+                                  ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__)); \
+      } catch (const std::exception&) {                                            \
+        ::iceberg::internal::EmitFormatError(_ib_logger, _ib_lvl,                  \
+                                             ::std::source_location::current());   \
+      }                                                                            \
+    }                                                                              \
+    if (_ib_lvl == ::iceberg::LogLevel::kFatal) {                                  \
+      _ib_logger.Flush();                                                          \
+      ::std::abort();                                                              \
+    }                                                                              \
+  } while (0)
+
+// Runtime (non-literal) format string against the default logger. Acquires the
+// logger once; aborts when level == kFatal (flushing that same logger first).
+#define ICEBERG_LOG_RUNTIME_FMT(level_, FMT_, ...)                               \
+  do {                                                                           \
+    const ::iceberg::LogLevel _ib_lvl = (level_);                                \
+    const auto& _ib_logger = ::iceberg::internal::CurrentLogger();               \
+    if (_ib_logger && _ib_logger->ShouldLog(_ib_lvl)) {                          \
+      try {                                                                      \
+        ::iceberg::internal::Emit(                                               \
+            *_ib_logger, _ib_lvl, ::std::source_location::current(),             \
+            ::iceberg::internal::VFormat((FMT_)__VA_OPT__(, ) __VA_ARGS__));     \
+      } catch (const std::exception&) {                                          \
+        ::iceberg::internal::EmitFormatError(*_ib_logger, _ib_lvl,               \
+                                             ::std::source_location::current()); \
+      }                                                                          \
+    }                                                                            \
+    if (_ib_lvl == ::iceberg::LogLevel::kFatal) {                                \
+      if (_ib_logger) _ib_logger->Flush();                                       \
+      ::std::abort();                                                            \
+    }                                                                            \
+  } while (0)
+
+// Bare, Java-style aliases. Opt-IN only (define ICEBERG_LOG_SHORT_MACROS before
+// including this header) to avoid colliding with glog/abseil/windows.h in
+// consumer translation units. No bare LOG(level) is provided.
+#ifdef ICEBERG_LOG_SHORT_MACROS
+#  define LOG_TRACE(...) ICEBERG_LOG_TRACE(__VA_ARGS__)
+#  define LOG_DEBUG(...) ICEBERG_LOG_DEBUG(__VA_ARGS__)
+#  define LOG_INFO(...) ICEBERG_LOG_INFO(__VA_ARGS__)
+#  define LOG_WARN(...) ICEBERG_LOG_WARN(__VA_ARGS__)
+#  define LOG_ERROR(...) ICEBERG_LOG_ERROR(__VA_ARGS__)
+#  define LOG_CRITICAL(...) ICEBERG_LOG_CRITICAL(__VA_ARGS__)
+#  define LOG_FATAL(...) ICEBERG_LOG_FATAL(__VA_ARGS__)
+#endif  // ICEBERG_LOG_SHORT_MACROS

--- a/src/iceberg/logging/logger.h
+++ b/src/iceberg/logging/logger.h
@@ -56,7 +56,7 @@ struct ICEBERG_EXPORT LogAttribute {
 
 /// \brief A single log record handed to a Logger.
 ///
-/// The formatted message is owned (moved in by the logging macros), so a sink
+/// The formatted message is owned (moved in when emitted), so a sink
 /// may safely retain the record beyond the Log() call. The member set must not
 /// depend on the build's logging backend (the spdlog backend never appears here).
 /// Use LogMessage::Builder for a readable way to assemble one, especially with
@@ -134,11 +134,11 @@ inline constexpr std::string_view kPatternProperty = "pattern";
 
 /// \brief Pluggable logging sink.
 ///
-/// ShouldLog() is the single authority for runtime filtering -- the macros call
-/// it on every (compile-time-enabled) statement, so level changes by any path
-/// take effect immediately. Implementations must be thread-safe and must not
+/// ShouldLog() is the single authority for runtime filtering -- the logging path
+/// calls it on every (compile-time-enabled) statement, so level changes by any
+/// path take effect immediately. Implementations must be thread-safe and must not
 /// throw. They must also obey:
-///   - No reentrancy: Log()/Flush() must not call the logging macros or
+///   - No reentrancy: Log()/Flush() must not call the logging API or
 ///     GetDefaultLogger() (UB -- deadlock with mutex-based sinks).
 ///   - level() is an accessor consistent with ShouldLog (used by SetDefaultLevel
 ///     and introspection); ShouldLog may implement finer logic than a level compare.
@@ -187,7 +187,7 @@ class ICEBERG_EXPORT Logger {
 /// \brief Return the process-global default logger (never null).
 ///
 /// Off the hot path -- acquires the slot lock and returns an owning copy. The
-/// logging macros use the cheaper internal hot-path accessor instead.
+/// logging path uses the cheaper internal hot-path accessor instead.
 ICEBERG_EXPORT std::shared_ptr<Logger> GetDefaultLogger();
 
 /// \brief Return the effective logger for this thread (never null): the active
@@ -214,7 +214,7 @@ ICEBERG_EXPORT void SetDefaultLevel(LogLevel level);
 /// \brief Bind a logger for the current thread until this object leaves scope.
 ///
 /// The default logging path on this thread -- CurrentLogger(), Log(level, ...),
-/// and the LOG_* macros -- routes to \p logger instead of the global default;
+/// and the ICEBERG_LOG_* macros -- routes to \p logger instead of the global default;
 /// explicit Log(logger, ...) is unaffected. Bindings nest and restore on exit, and
 /// nullptr masks any enclosing binding back to the global default. Lets an engine
 /// route Iceberg's own logs into a per catalog/session/query/task context with no
@@ -247,8 +247,8 @@ class ICEBERG_EXPORT ScopedLogger {
 };
 
 // ---------------------------------------------------------------------------
-// Using the API directly (the LOG_* macros that wrap this are added later in
-// the stack). Example: a custom sink, installed as the process default.
+// Using the API directly (the ICEBERG_LOG_* macros that wrap this live in
+// log_macros.h). Example: a custom sink, installed as the process default.
 //
 //   class MySink : public Logger {
 //    public:
@@ -285,8 +285,8 @@ ICEBERG_EXPORT const std::shared_ptr<Logger>& CurrentLogger() noexcept;
 
 /// \brief Build a LogMessage from the already-formatted text and dispatch it.
 ///
-/// Declared ICEBERG_EXPORT because the logging macros expand into this call in
-/// consumer translation units.
+/// Declared ICEBERG_EXPORT because the logging helpers/macros expand into this
+/// call in consumer translation units.
 ICEBERG_EXPORT void Emit(Logger& logger, LogLevel level,
                          const std::source_location& location, std::string&& message);
 
@@ -297,18 +297,6 @@ ICEBERG_EXPORT void Emit(Logger& logger, LogLevel level,
 /// even when a format argument throws.
 ICEBERG_EXPORT void EmitFormatError(Logger& logger, LogLevel level,
                                     const std::source_location& location) noexcept;
-
-/// \brief Runtime (non-literal) format-string helper.
-///
-/// std::format requires a compile-time format string; this routes a runtime
-/// string through std::vformat. Args are bound as named lvalues and the
-/// arg-store is held in a named variable so it outlives the vformat call
-/// (C++23 make_format_args rejects rvalues -- P2905 / LWG3631).
-template <typename... Args>
-std::string VFormat(std::string_view fmt, Args&&... args) {
-  auto store = std::make_format_args(args...);
-  return std::vformat(fmt, store);
-}
 
 /// \brief A checked format string bundled with the caller's source_location.
 ///
@@ -374,186 +362,3 @@ void Log(Logger& logger, LogLevel level,
 }
 
 }  // namespace iceberg
-
-// ---------------------------------------------------------------------------
-// Logging macros.
-//
-// Every macro takes a std::format string followed by its arguments. The
-// rendered line depends on the active backend (see cerr_logger.h for the
-// std::cerr layout, or the spdlog pattern); the examples below show the call
-// site and, for the default CerrLogger, the line it produces.
-//
-//   ICEBERG_LOG_TRACE("entering scan for {}", table);
-//     2026-06-16T10:59:41.186Z trace [12345] [table_scan.cc:88] entering scan for db.t
-//   ICEBERG_LOG_DEBUG("cache miss key={}", key);
-//     2026-06-16T10:59:41.186Z debug [12345] [cache.cc:42] cache miss key=manifest-7
-//   ICEBERG_LOG_INFO("loaded {} manifests in {} ms", n, ms);
-//     2026-06-16T10:59:41.186Z info [12345] [table_scan.cc:91] loaded 5 manifests in 12
-//     ms
-//   ICEBERG_LOG_WARN("retry {} after {}", attempt, err);
-//     2026-06-16T10:59:41.186Z warn [12345] [io.cc:51] retry 2 after timeout
-//   ICEBERG_LOG_ERROR("commit failed: {}", status);
-//     2026-06-16T10:59:41.186Z error [12345] [txn.cc:77] commit failed: conflict
-//   ICEBERG_LOG_CRITICAL("metadata unreadable at {}", path);
-//     2026-06-16T10:59:41.186Z critical [12345] [meta.cc:30] metadata unreadable at
-//     s3://b/m.json
-//   ICEBERG_LOG_FATAL("unrecoverable: {}", reason);   // emits, flushes, then
-//   std::abort()
-//     2026-06-16T10:59:41.186Z fatal [12345] [boot.cc:19] unrecoverable: bad config
-//
-// Less common forms:
-//   ICEBERG_LOG(level, "level chosen at runtime: {}", x);     // runtime severity
-//   ICEBERG_LOG_TO(logger, level, "to an explicit logger {}", y);
-//   ICEBERG_LOG_RUNTIME_FMT(level, fmt_string, args...);       // non-literal format
-//
-// With ICEBERG_LOG_SHORT_MACROS defined, bare aliases (LOG_INFO, ...) are also
-// available. A format string is mandatory; zero extra args is fine
-// (ICEBERG_LOG_INFO("done")).
-// ---------------------------------------------------------------------------
-
-/// \brief Compile-time severity floor: statements below this level are discarded
-/// via `if constexpr`, so no emit code runs and no format call / source_location
-/// is generated for them (the compiler is free to optimize the dead branch away).
-/// The statement must still be well-formed -- a bad format string or a
-/// non-formattable argument is a compile error even when the branch is discarded.
-/// Defaults to keeping everything. ICEBERG_LOG_FATAL is never gated by this floor
-/// -- its abort is always compiled in.
-#ifndef ICEBERG_LOG_ACTIVE_LEVEL
-#  define ICEBERG_LOG_ACTIVE_LEVEL ::iceberg::LogLevel::kTrace
-#endif
-
-// Internal: fixed-severity emit with compile-time floor then the authoritative
-// Logger::ShouldLog (the single source of truth for runtime filtering), with
-// formatting only on the taken path, never throwing. The catch-all upholds the
-// "logging never throws" guarantee even when a user-defined std::formatter throws
-// a non-std::exception type (a std::format_error/bad_alloc route to EmitFormatError).
-#define ICEBERG_INTERNAL_LOG(level_, FMT_, ...)                                      \
-  do {                                                                               \
-    if constexpr ((level_) >= ICEBERG_LOG_ACTIVE_LEVEL) {                            \
-      const auto& _ib_logger = ::iceberg::internal::CurrentLogger();                 \
-      if (_ib_logger && _ib_logger->ShouldLog(level_)) {                             \
-        try {                                                                        \
-          ::iceberg::internal::Emit(*_ib_logger, (level_),                           \
-                                    ::std::source_location::current(),               \
-                                    ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__)); \
-        } catch (...) {                                                              \
-          ::iceberg::internal::EmitFormatError(*_ib_logger, (level_),                \
-                                               ::std::source_location::current());   \
-        }                                                                            \
-      }                                                                              \
-    }                                                                                \
-  } while (0)
-
-#define ICEBERG_LOG_TRACE(...) \
-  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kTrace, __VA_ARGS__)
-#define ICEBERG_LOG_DEBUG(...) \
-  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kDebug, __VA_ARGS__)
-#define ICEBERG_LOG_INFO(...) \
-  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kInfo, __VA_ARGS__)
-#define ICEBERG_LOG_WARN(...) \
-  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kWarn, __VA_ARGS__)
-#define ICEBERG_LOG_ERROR(...) \
-  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kError, __VA_ARGS__)
-#define ICEBERG_LOG_CRITICAL(...) \
-  ICEBERG_INTERNAL_LOG(::iceberg::LogLevel::kCritical, __VA_ARGS__)
-
-// FATAL: emit if enabled (never compile-stripped), then ALWAYS flush + abort.
-// Acquires the effective (scoped-or-default) logger ONCE -- honoring any active
-// ScopedLogger binding -- and uses that same instance for emit and flush, so a
-// concurrent SetDefaultLogger cannot flush a different logger than it emitted to.
-#define ICEBERG_LOG_FATAL(FMT_, ...)                                                   \
-  do {                                                                                 \
-    auto _ib_logger = ::iceberg::GetCurrentLogger();                                   \
-    if (_ib_logger && _ib_logger->ShouldLog(::iceberg::LogLevel::kFatal)) {            \
-      try {                                                                            \
-        ::iceberg::internal::Emit(*_ib_logger, ::iceberg::LogLevel::kFatal,            \
-                                  ::std::source_location::current(),                   \
-                                  ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__));     \
-      } catch (...) {                                                                  \
-        ::iceberg::internal::EmitFormatError(*_ib_logger, ::iceberg::LogLevel::kFatal, \
-                                             ::std::source_location::current());       \
-      }                                                                                \
-    }                                                                                  \
-    if (_ib_logger) _ib_logger->Flush();                                               \
-    ::std::abort();                                                                    \
-  } while (0)
-
-// Generic, runtime-level form against the default logger. No compile-time floor
-// (the level is not a constant). Acquires the logger once; aborts when level == kFatal
-// (flushing that same logger first).
-#define ICEBERG_LOG(level_, FMT_, ...)                                             \
-  do {                                                                             \
-    const ::iceberg::LogLevel _ib_lvl = (level_);                                  \
-    const auto& _ib_logger = ::iceberg::internal::CurrentLogger();                 \
-    if (_ib_logger && _ib_logger->ShouldLog(_ib_lvl)) {                            \
-      try {                                                                        \
-        ::iceberg::internal::Emit(*_ib_logger, _ib_lvl,                            \
-                                  ::std::source_location::current(),               \
-                                  ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__)); \
-      } catch (...) {                                                              \
-        ::iceberg::internal::EmitFormatError(*_ib_logger, _ib_lvl,                 \
-                                             ::std::source_location::current());   \
-      }                                                                            \
-    }                                                                              \
-    if (_ib_lvl == ::iceberg::LogLevel::kFatal) {                                  \
-      if (_ib_logger) _ib_logger->Flush();                                         \
-      ::std::abort();                                                              \
-    }                                                                              \
-  } while (0)
-
-// Generic form targeting an EXPLICIT logger (must be an lvalue Logger&). Honors
-// only that logger's ShouldLog. Aborts when level == kFatal.
-#define ICEBERG_LOG_TO(logger_, level_, FMT_, ...)                                 \
-  do {                                                                             \
-    ::iceberg::Logger& _ib_logger = (logger_);                                     \
-    const ::iceberg::LogLevel _ib_lvl = (level_);                                  \
-    if (_ib_logger.ShouldLog(_ib_lvl)) {                                           \
-      try {                                                                        \
-        ::iceberg::internal::Emit(_ib_logger, _ib_lvl,                             \
-                                  ::std::source_location::current(),               \
-                                  ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__)); \
-      } catch (...) {                                                              \
-        ::iceberg::internal::EmitFormatError(_ib_logger, _ib_lvl,                  \
-                                             ::std::source_location::current());   \
-      }                                                                            \
-    }                                                                              \
-    if (_ib_lvl == ::iceberg::LogLevel::kFatal) {                                  \
-      _ib_logger.Flush();                                                          \
-      ::std::abort();                                                              \
-    }                                                                              \
-  } while (0)
-
-// Runtime (non-literal) format string against the default logger. Acquires the
-// logger once; aborts when level == kFatal (flushing that same logger first).
-#define ICEBERG_LOG_RUNTIME_FMT(level_, FMT_, ...)                               \
-  do {                                                                           \
-    const ::iceberg::LogLevel _ib_lvl = (level_);                                \
-    const auto& _ib_logger = ::iceberg::internal::CurrentLogger();               \
-    if (_ib_logger && _ib_logger->ShouldLog(_ib_lvl)) {                          \
-      try {                                                                      \
-        ::iceberg::internal::Emit(                                               \
-            *_ib_logger, _ib_lvl, ::std::source_location::current(),             \
-            ::iceberg::internal::VFormat((FMT_)__VA_OPT__(, ) __VA_ARGS__));     \
-      } catch (...) {                                                            \
-        ::iceberg::internal::EmitFormatError(*_ib_logger, _ib_lvl,               \
-                                             ::std::source_location::current()); \
-      }                                                                          \
-    }                                                                            \
-    if (_ib_lvl == ::iceberg::LogLevel::kFatal) {                                \
-      if (_ib_logger) _ib_logger->Flush();                                       \
-      ::std::abort();                                                            \
-    }                                                                            \
-  } while (0)
-
-// Bare, Java-style aliases. Opt-IN only (define ICEBERG_LOG_SHORT_MACROS before
-// including this header) to avoid colliding with glog/abseil/windows.h in
-// consumer translation units. No bare LOG(level) is provided.
-#ifdef ICEBERG_LOG_SHORT_MACROS
-#  define LOG_TRACE(...) ICEBERG_LOG_TRACE(__VA_ARGS__)
-#  define LOG_DEBUG(...) ICEBERG_LOG_DEBUG(__VA_ARGS__)
-#  define LOG_INFO(...) ICEBERG_LOG_INFO(__VA_ARGS__)
-#  define LOG_WARN(...) ICEBERG_LOG_WARN(__VA_ARGS__)
-#  define LOG_ERROR(...) ICEBERG_LOG_ERROR(__VA_ARGS__)
-#  define LOG_CRITICAL(...) ICEBERG_LOG_CRITICAL(__VA_ARGS__)
-#  define LOG_FATAL(...) ICEBERG_LOG_FATAL(__VA_ARGS__)
-#endif  // ICEBERG_LOG_SHORT_MACROS

--- a/src/iceberg/logging/logger.h
+++ b/src/iceberg/logging/logger.h
@@ -341,6 +341,9 @@ void FormatAndEmit(Logger& logger, LogLevel level, const std::source_location& l
   try {
     Emit(logger, level, loc, std::format(fmt, std::forward<Args>(args)...));
   } catch (const std::exception&) {
+    // The only throws here are std::format_error / std::bad_alloc -- same recovery
+    // for both (drop, emit a fixed marker). Catch std::exception, not (...), so a
+    // non-std unwind like abi::__forced_unwind (thread cancellation) propagates.
     EmitFormatError(logger, level, loc);
   }
 }
@@ -418,7 +421,9 @@ void Log(Logger& logger, LogLevel level,
 
 // Internal: fixed-severity emit with compile-time floor then the authoritative
 // Logger::ShouldLog (the single source of truth for runtime filtering), with
-// formatting only on the taken path, never throwing.
+// formatting only on the taken path, never throwing. The catch handles
+// std::exception (std::format_error / std::bad_alloc) -- not (...) -- so a non-std
+// unwind such as abi::__forced_unwind (thread cancellation) still propagates.
 #define ICEBERG_INTERNAL_LOG(level_, FMT_, ...)                                      \
   do {                                                                               \
     if constexpr ((level_) >= ICEBERG_LOG_ACTIVE_LEVEL) {                            \

--- a/src/iceberg/logging/logger.h
+++ b/src/iceberg/logging/logger.h
@@ -28,7 +28,6 @@
 
 #include <concepts>
 #include <cstdlib>
-#include <exception>
 #include <format>
 #include <memory>
 #include <source_location>
@@ -340,10 +339,10 @@ void FormatAndEmit(Logger& logger, LogLevel level, const std::source_location& l
   if (!logger.ShouldLog(level)) return;
   try {
     Emit(logger, level, loc, std::format(fmt, std::forward<Args>(args)...));
-  } catch (const std::exception&) {
-    // The only throws here are std::format_error / std::bad_alloc -- same recovery
-    // for both (drop, emit a fixed marker). Catch std::exception, not (...), so a
-    // non-std unwind like abi::__forced_unwind (thread cancellation) propagates.
+  } catch (...) {
+    // Catch-all upholds the noexcept "logging never throws" guarantee: a
+    // user-defined std::formatter may throw a non-std::exception type, and this
+    // function is noexcept, so anything escaping here would call std::terminate.
     EmitFormatError(logger, level, loc);
   }
 }
@@ -385,21 +384,22 @@ void Log(Logger& logger, LogLevel level,
 // site and, for the default CerrLogger, the line it produces.
 //
 //   ICEBERG_LOG_TRACE("entering scan for {}", table);
-//     2026-06-16T10:59:41.186Z trace [12345] table_scan.cc:88] entering scan for db.t
+//     2026-06-16T10:59:41.186Z trace [12345] [table_scan.cc:88] entering scan for db.t
 //   ICEBERG_LOG_DEBUG("cache miss key={}", key);
-//     2026-06-16T10:59:41.186Z debug [12345] cache.cc:42] cache miss key=manifest-7
+//     2026-06-16T10:59:41.186Z debug [12345] [cache.cc:42] cache miss key=manifest-7
 //   ICEBERG_LOG_INFO("loaded {} manifests in {} ms", n, ms);
-//     2026-06-16T10:59:41.186Z info [12345] table_scan.cc:91] loaded 5 manifests in 12 ms
+//     2026-06-16T10:59:41.186Z info [12345] [table_scan.cc:91] loaded 5 manifests in 12
+//     ms
 //   ICEBERG_LOG_WARN("retry {} after {}", attempt, err);
-//     2026-06-16T10:59:41.186Z warn [12345] io.cc:51] retry 2 after timeout
+//     2026-06-16T10:59:41.186Z warn [12345] [io.cc:51] retry 2 after timeout
 //   ICEBERG_LOG_ERROR("commit failed: {}", status);
-//     2026-06-16T10:59:41.186Z error [12345] txn.cc:77] commit failed: conflict
+//     2026-06-16T10:59:41.186Z error [12345] [txn.cc:77] commit failed: conflict
 //   ICEBERG_LOG_CRITICAL("metadata unreadable at {}", path);
-//     2026-06-16T10:59:41.186Z critical [12345] meta.cc:30] metadata unreadable at
+//     2026-06-16T10:59:41.186Z critical [12345] [meta.cc:30] metadata unreadable at
 //     s3://b/m.json
 //   ICEBERG_LOG_FATAL("unrecoverable: {}", reason);   // emits, flushes, then
 //   std::abort()
-//     2026-06-16T10:59:41.186Z fatal [12345] boot.cc:19] unrecoverable: bad config
+//     2026-06-16T10:59:41.186Z fatal [12345] [boot.cc:19] unrecoverable: bad config
 //
 // Less common forms:
 //   ICEBERG_LOG(level, "level chosen at runtime: {}", x);     // runtime severity
@@ -411,19 +411,22 @@ void Log(Logger& logger, LogLevel level,
 // (ICEBERG_LOG_INFO("done")).
 // ---------------------------------------------------------------------------
 
-/// \brief Compile-time severity floor: statements below this level are removed
-/// entirely from the build (their format call sites and source_location literals
-/// are never emitted). Defaults to keeping everything. ICEBERG_LOG_FATAL is never
-/// gated by this floor -- its abort is always compiled in.
+/// \brief Compile-time severity floor: statements below this level are discarded
+/// via `if constexpr`, so no emit code runs and no format call / source_location
+/// is generated for them (the compiler is free to optimize the dead branch away).
+/// The statement must still be well-formed -- a bad format string or a
+/// non-formattable argument is a compile error even when the branch is discarded.
+/// Defaults to keeping everything. ICEBERG_LOG_FATAL is never gated by this floor
+/// -- its abort is always compiled in.
 #ifndef ICEBERG_LOG_ACTIVE_LEVEL
 #  define ICEBERG_LOG_ACTIVE_LEVEL ::iceberg::LogLevel::kTrace
 #endif
 
 // Internal: fixed-severity emit with compile-time floor then the authoritative
 // Logger::ShouldLog (the single source of truth for runtime filtering), with
-// formatting only on the taken path, never throwing. The catch handles
-// std::exception (std::format_error / std::bad_alloc) -- not (...) -- so a non-std
-// unwind such as abi::__forced_unwind (thread cancellation) still propagates.
+// formatting only on the taken path, never throwing. The catch-all upholds the
+// "logging never throws" guarantee even when a user-defined std::formatter throws
+// a non-std::exception type (a std::format_error/bad_alloc route to EmitFormatError).
 #define ICEBERG_INTERNAL_LOG(level_, FMT_, ...)                                      \
   do {                                                                               \
     if constexpr ((level_) >= ICEBERG_LOG_ACTIVE_LEVEL) {                            \
@@ -433,7 +436,7 @@ void Log(Logger& logger, LogLevel level,
           ::iceberg::internal::Emit(*_ib_logger, (level_),                           \
                                     ::std::source_location::current(),               \
                                     ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__)); \
-        } catch (const std::exception&) {                                            \
+        } catch (...) {                                                              \
           ::iceberg::internal::EmitFormatError(*_ib_logger, (level_),                \
                                                ::std::source_location::current());   \
         }                                                                            \
@@ -466,7 +469,7 @@ void Log(Logger& logger, LogLevel level,
         ::iceberg::internal::Emit(*_ib_logger, ::iceberg::LogLevel::kFatal,            \
                                   ::std::source_location::current(),                   \
                                   ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__));     \
-      } catch (const std::exception&) {                                                \
+      } catch (...) {                                                                  \
         ::iceberg::internal::EmitFormatError(*_ib_logger, ::iceberg::LogLevel::kFatal, \
                                              ::std::source_location::current());       \
       }                                                                                \
@@ -487,7 +490,7 @@ void Log(Logger& logger, LogLevel level,
         ::iceberg::internal::Emit(*_ib_logger, _ib_lvl,                            \
                                   ::std::source_location::current(),               \
                                   ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__)); \
-      } catch (const std::exception&) {                                            \
+      } catch (...) {                                                              \
         ::iceberg::internal::EmitFormatError(*_ib_logger, _ib_lvl,                 \
                                              ::std::source_location::current());   \
       }                                                                            \
@@ -509,7 +512,7 @@ void Log(Logger& logger, LogLevel level,
         ::iceberg::internal::Emit(_ib_logger, _ib_lvl,                             \
                                   ::std::source_location::current(),               \
                                   ::std::format(FMT_ __VA_OPT__(, ) __VA_ARGS__)); \
-      } catch (const std::exception&) {                                            \
+      } catch (...) {                                                              \
         ::iceberg::internal::EmitFormatError(_ib_logger, _ib_lvl,                  \
                                              ::std::source_location::current());   \
       }                                                                            \
@@ -531,7 +534,7 @@ void Log(Logger& logger, LogLevel level,
         ::iceberg::internal::Emit(                                               \
             *_ib_logger, _ib_lvl, ::std::source_location::current(),             \
             ::iceberg::internal::VFormat((FMT_)__VA_OPT__(, ) __VA_ARGS__));     \
-      } catch (const std::exception&) {                                          \
+      } catch (...) {                                                            \
         ::iceberg::internal::EmitFormatError(*_ib_logger, _ib_lvl,               \
                                              ::std::source_location::current()); \
       }                                                                          \

--- a/src/iceberg/logging/logger.h
+++ b/src/iceberg/logging/logger.h
@@ -29,6 +29,7 @@
 #include <concepts>
 #include <cstdlib>
 #include <format>
+#include <functional>
 #include <memory>
 #include <source_location>
 #include <string>
@@ -210,6 +211,26 @@ ICEBERG_EXPORT void SetDefaultLogger(std::shared_ptr<Logger> logger);
 /// decided by the logger's own ShouldLog(), so changing a logger's level by any
 /// means (this, SetLevel on a held handle, or Initialize) takes effect immediately.
 ICEBERG_EXPORT void SetDefaultLevel(LogLevel level);
+
+/// \brief A hook invoked on the fatal-log path just before std::abort().
+///
+/// Receives the fatal record's source location and already-formatted message.
+/// Runs after the record has been emitted and the logger flushed, so an embedder
+/// (JNI, a Python host, a crash reporter) can print a stack trace, flush its own
+/// resources, or translate the abort. It must not return normally on the
+/// expectation of cancelling the abort -- ICEBERG_LOG_FATAL always terminates; if
+/// the handler itself does not exit the process, std::abort() still runs after it.
+using FatalHandler =
+    std::function<void(const std::source_location&, std::string_view message)>;
+
+/// \brief Install (or clear, with nullptr) the process-global fatal handler.
+///
+/// Thread-safe. Intended to be set once at startup. Replaces any previous handler.
+ICEBERG_EXPORT void SetFatalHandler(FatalHandler handler);
+
+/// \brief Return the installed fatal handler (empty if none). Used by the fatal
+/// logging path; thread-safe.
+ICEBERG_EXPORT FatalHandler GetFatalHandler();
 
 /// \brief Bind a logger for the current thread until this object leaves scope.
 ///

--- a/src/iceberg/logging/meson.build
+++ b/src/iceberg/logging/meson.build
@@ -16,6 +16,12 @@
 # under the License.
 
 install_headers(
-    ['cerr_logger.h', 'log_level.h', 'logger.h'],
+    [
+        'cerr_logger.h',
+        'log_level.h',
+        'log_macros.h',
+        'logger.h',
+        'short_log_macros.h',
+    ],
     subdir: 'iceberg/logging',
 )

--- a/src/iceberg/logging/short_log_macros.h
+++ b/src/iceberg/logging/short_log_macros.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+/// \file iceberg/logging/short_log_macros.h
+/// \brief Opt-in bare LOG_* aliases for the ICEBERG_LOG_* macros.
+///
+/// Separate opt-in header (not pulled in by logger.h or log_macros.h) so the
+/// short, unprefixed names never leak into consumers by default -- they would
+/// collide with glog/abseil/windows.h. Include this header explicitly to use
+/// them. No bare LOG(level) is provided.
+
+#include "iceberg/logging/log_macros.h"
+
+#define LOG_TRACE(...) ICEBERG_LOG_TRACE(__VA_ARGS__)
+#define LOG_DEBUG(...) ICEBERG_LOG_DEBUG(__VA_ARGS__)
+#define LOG_INFO(...) ICEBERG_LOG_INFO(__VA_ARGS__)
+#define LOG_WARN(...) ICEBERG_LOG_WARN(__VA_ARGS__)
+#define LOG_ERROR(...) ICEBERG_LOG_ERROR(__VA_ARGS__)
+#define LOG_CRITICAL(...) ICEBERG_LOG_CRITICAL(__VA_ARGS__)
+#define LOG_FATAL(...) ICEBERG_LOG_FATAL(__VA_ARGS__)

--- a/src/iceberg/test/CMakeLists.txt
+++ b/src/iceberg/test/CMakeLists.txt
@@ -62,7 +62,9 @@ function(add_iceberg_test test_name)
   endif()
 
   if(MSVC_TOOLCHAIN)
-    target_compile_options(${test_name} PRIVATE /bigobj)
+    # /Zc:preprocessor: conforming preprocessor for the __VA_OPT__ in the logging
+    # macros (MSVC's traditional preprocessor rejects it).
+    target_compile_options(${test_name} PRIVATE /bigobj /Zc:preprocessor)
   endif()
 
   add_test(NAME ${test_name} COMMAND ${test_name})
@@ -103,7 +105,9 @@ add_iceberg_test(logging_test
                  SOURCES
                  cerr_logger_test.cc
                  log_level_test.cc
-                 logger_test.cc)
+                 logger_test.cc
+                 macros_active_level_test.cc
+                 macros_test.cc)
 
 add_iceberg_test(expression_test
                  SOURCES

--- a/src/iceberg/test/macros_active_level_test.cc
+++ b/src/iceberg/test/macros_active_level_test.cc
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Compile-time floor set to kOff for this translation unit: every fixed-severity
+// macro below kFatal must be stripped to nothing, while ICEBERG_LOG_FATAL must
+// still abort (its abort is never gated by the compile-time floor).
+#define ICEBERG_LOG_ACTIVE_LEVEL ::iceberg::LogLevel::kOff
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "iceberg/logging/log_level.h"
+#include "iceberg/logging/logger.h"
+#include "iceberg/test/logging_test_helpers.h"
+
+namespace iceberg {
+
+TEST(MacrosActiveLevelTest, BelowFloorStatementsAreCompiledOut) {
+  auto logger = std::make_shared<CapturingLogger>();
+  logger->SetLevel(LogLevel::kTrace);
+  ScopedDefaultLogger guard(logger);
+
+  int calls = 0;
+  // counted() is only "called" from the compile-time-stripped macros below, so the
+  // analyzer sees its init as a dead store -- which is exactly what this verifies.
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+  auto counted = [&calls]() {
+    ++calls;
+    return 1;
+  };
+  // Stripped at compile time -> arguments never evaluated, nothing emitted,
+  // even though the runtime logger would accept these levels.
+  ICEBERG_LOG_INFO("{}", counted());
+  ICEBERG_LOG_CRITICAL("{}", counted());
+  EXPECT_EQ(calls, 0);
+  EXPECT_EQ(logger->count(), 0u);
+}
+
+TEST(MacrosActiveLevelDeathTest, FatalStillAbortsWhenEverythingElseStripped) {
+  EXPECT_DEATH({ ICEBERG_LOG_FATAL("still fatal"); }, "");
+}
+
+}  // namespace iceberg

--- a/src/iceberg/test/macros_active_level_test.cc
+++ b/src/iceberg/test/macros_active_level_test.cc
@@ -27,6 +27,7 @@
 #include <gtest/gtest.h>
 
 #include "iceberg/logging/log_level.h"
+#include "iceberg/logging/log_macros.h"
 #include "iceberg/logging/logger.h"
 #include "iceberg/test/logging_test_helpers.h"
 

--- a/src/iceberg/test/macros_test.cc
+++ b/src/iceberg/test/macros_test.cc
@@ -147,4 +147,18 @@ TEST(MacrosDeathTest, LogToFatalEmitsThenAborts) {
       "tofatal 2");
 }
 
+// Regression guard: ICEBERG_LOG_FATAL must route through the active ScopedLogger
+// binding (GetCurrentLogger), not the process default (GetDefaultLogger). A scoped
+// CerrLogger emits the record before the abort; the message must reach that sink.
+TEST(MacrosDeathTest, FatalRoutesThroughScopedLogger) {
+  EXPECT_DEATH(
+      {
+        SetDefaultLevel(LogLevel::kOff);  // default gate off -> only the scope emits
+        auto scoped = std::make_shared<CerrLogger>(LogLevel::kTrace);
+        ScopedLogger bind(scoped);
+        ICEBERG_LOG_FATAL("scopedfatal {}", 9);
+      },
+      "scopedfatal 9");
+}
+
 }  // namespace iceberg

--- a/src/iceberg/test/macros_test.cc
+++ b/src/iceberg/test/macros_test.cc
@@ -23,6 +23,7 @@
 
 #include "iceberg/logging/cerr_logger.h"
 #include "iceberg/logging/log_level.h"
+#include "iceberg/logging/log_macros.h"
 #include "iceberg/logging/logger.h"
 #include "iceberg/test/logging_test_helpers.h"
 

--- a/src/iceberg/test/macros_test.cc
+++ b/src/iceberg/test/macros_test.cc
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "iceberg/logging/cerr_logger.h"
+#include "iceberg/logging/log_level.h"
+#include "iceberg/logging/logger.h"
+#include "iceberg/test/logging_test_helpers.h"
+
+namespace iceberg {
+
+namespace {
+
+std::shared_ptr<CapturingLogger> InstallCapturing(LogLevel level = LogLevel::kTrace) {
+  auto logger = std::make_shared<CapturingLogger>();
+  logger->SetLevel(level);
+  return logger;
+}
+
+}  // namespace
+
+TEST(MacrosTest, InfoFormatsAndCapturesLocation) {
+  auto logger = InstallCapturing();
+  ScopedDefaultLogger guard(logger);
+  ICEBERG_LOG_INFO("x={}", 42);
+  auto records = logger->records();
+  ASSERT_EQ(records.size(), 1u);
+  EXPECT_EQ(records[0].level, LogLevel::kInfo);
+  EXPECT_EQ(records[0].message, "x=42");
+  EXPECT_NE(records[0].location.line(), 0u);
+}
+
+TEST(MacrosTest, RuntimeLevelFiltersBelowThreshold) {
+  auto logger = InstallCapturing();
+  ScopedDefaultLogger guard(logger);
+  SetDefaultLevel(LogLevel::kError);
+  ICEBERG_LOG_INFO("dropped");
+  ICEBERG_LOG_ERROR("kept");
+  auto records = logger->records();
+  ASSERT_EQ(records.size(), 1u);
+  EXPECT_EQ(records[0].message, "kept");
+}
+
+TEST(MacrosTest, DisabledLevelDoesNotEvaluateArguments) {
+  auto logger = InstallCapturing();
+  ScopedDefaultLogger guard(logger);
+  SetDefaultLevel(LogLevel::kError);
+  int calls = 0;
+  auto counted = [&calls]() {
+    ++calls;
+    return 1;
+  };
+  ICEBERG_LOG_INFO("{}", counted());
+  EXPECT_EQ(calls, 0);
+}
+
+TEST(MacrosTest, DanglingElseBindsCorrectly) {
+  auto logger = InstallCapturing();
+  ScopedDefaultLogger guard(logger);
+  bool took_else = false;
+  // Intentionally brace-free: this verifies the macro keeps dangling-else binding
+  // correct. Adding braces would defeat the test, so suppress the tidy check.
+  // NOLINTBEGIN(google-readability-braces-around-statements)
+  if (false)
+    ICEBERG_LOG_INFO("if-branch");
+  else
+    took_else = true;
+  // NOLINTEND(google-readability-braces-around-statements)
+  EXPECT_TRUE(took_else);
+  EXPECT_EQ(logger->count(), 0u);
+}
+
+TEST(MacrosTest, GenericRuntimeLevelMacroCompilesAndLogs) {
+  auto logger = InstallCapturing();
+  ScopedDefaultLogger guard(logger);
+  LogLevel level = LogLevel::kWarn;
+  ICEBERG_LOG(level, "n={}", 7);
+  auto records = logger->records();
+  ASSERT_EQ(records.size(), 1u);
+  EXPECT_EQ(records[0].message, "n=7");
+  EXPECT_EQ(records[0].level, LogLevel::kWarn);
+}
+
+TEST(MacrosTest, LogToHonorsOnlyExplicitLoggerNotDefaultGate) {
+  auto sink = InstallCapturing();
+  ScopedDefaultLogger guard(InstallCapturing());
+  SetDefaultLevel(LogLevel::kOff);  // default gate would block everything
+  ICEBERG_LOG_TO(*sink, LogLevel::kInfo, "explicit {}", 1);
+  EXPECT_EQ(sink->count(), 1u);
+}
+
+TEST(MacrosTest, NeverThrowsOnBadRuntimeFormat) {
+  auto logger = InstallCapturing();
+  ScopedDefaultLogger guard(logger);
+  // Invalid runtime format string -> std::vformat throws -> swallowed -> fallback.
+  EXPECT_NO_THROW(ICEBERG_LOG_RUNTIME_FMT(LogLevel::kInfo, "{"));
+  auto records = logger->records();
+  ASSERT_EQ(records.size(), 1u);
+  EXPECT_EQ(records[0].message, "<fmt error>");
+}
+
+TEST(MacrosDeathTest, FatalEmitsThenAborts) {
+  // Default logger writes to std::cerr; the message must appear before abort.
+  EXPECT_DEATH({ ICEBERG_LOG_FATAL("fatalmsg {}", 7); }, "fatalmsg 7");
+}
+
+TEST(MacrosDeathTest, FatalAbortsEvenWhenRuntimeDisabled) {
+  EXPECT_DEATH(
+      {
+        SetDefaultLevel(LogLevel::kOff);
+        ICEBERG_LOG_FATAL("suppressed");
+      },
+      "");
+}
+
+TEST(MacrosDeathTest, GenericRuntimeFatalEmitsThenAborts) {
+  // ICEBERG_LOG with a runtime kFatal level must also emit then abort.
+  EXPECT_DEATH({ ICEBERG_LOG(LogLevel::kFatal, "gfatal {}", 1); }, "gfatal 1");
+}
+
+TEST(MacrosDeathTest, LogToFatalEmitsThenAborts) {
+  // ICEBERG_LOG_TO with kFatal must emit to the explicit logger then abort.
+  EXPECT_DEATH(
+      {
+        CerrLogger sink(LogLevel::kTrace);
+        ICEBERG_LOG_TO(sink, LogLevel::kFatal, "tofatal {}", 2);
+      },
+      "tofatal 2");
+}
+
+}  // namespace iceberg

--- a/src/iceberg/test/macros_test.cc
+++ b/src/iceberg/test/macros_test.cc
@@ -17,7 +17,10 @@
  * under the License.
  */
 
+#include <iostream>
 #include <memory>
+#include <source_location>
+#include <string_view>
 
 #include <gtest/gtest.h>
 
@@ -160,6 +163,45 @@ TEST(MacrosDeathTest, FatalRoutesThroughScopedLogger) {
         ICEBERG_LOG_FATAL("scopedfatal {}", 9);
       },
       "scopedfatal 9");
+}
+
+// A registered FatalHandler runs on the fatal path (after emit+flush) and receives
+// the formatted message; the process still aborts afterwards.
+TEST(MacrosDeathTest, FatalHandlerRunsWithFormattedMessageBeforeAbort) {
+  EXPECT_DEATH(
+      {
+        SetFatalHandler([](const std::source_location&, std::string_view message) {
+          std::cerr << "HANDLER[" << message << "]\n";
+        });
+        ICEBERG_LOG_FATAL("boom {}", 42);
+      },
+      "HANDLER\\[boom 42\\]");
+}
+
+// The handler receives the caller's source location.
+TEST(MacrosDeathTest, FatalHandlerReceivesCallSiteLocation) {
+  EXPECT_DEATH(
+      {
+        SetFatalHandler([](const std::source_location& loc, std::string_view) {
+          std::cerr << "LOC:" << (loc.line() > 0 ? "ok" : "bad") << "\n";
+        });
+        ICEBERG_LOG_FATAL("x");
+      },
+      "LOC:ok");
+}
+
+// The handler is a termination hook independent of log filtering: it still fires
+// (with the formatted message) when the fatal record itself is suppressed.
+TEST(MacrosDeathTest, FatalHandlerRunsEvenWhenRecordSuppressed) {
+  EXPECT_DEATH(
+      {
+        SetDefaultLevel(LogLevel::kOff);
+        SetFatalHandler([](const std::source_location&, std::string_view message) {
+          std::cerr << "H[" << message << "]\n";
+        });
+        ICEBERG_LOG_FATAL("suppressed {}", 7);
+      },
+      "H\\[suppressed 7\\]");
 }
 
 }  // namespace iceberg

--- a/src/iceberg/test/meson.build
+++ b/src/iceberg/test/meson.build
@@ -67,6 +67,8 @@ iceberg_tests = {
             'cerr_logger_test.cc',
             'log_level_test.cc',
             'logger_test.cc',
+            'macros_active_level_test.cc',
+            'macros_test.cc',
         ),
     },
     'expression_test': {


### PR DESCRIPTION
Part 4 of the logging stack (builds on #724). Adds the application-facing macros — the part most callers actually use.

**What's here**
- `ICEBERG_LOG_{TRACE,DEBUG,INFO,WARN,ERROR,CRITICAL,FATAL}`, the generic `ICEBERG_LOG(level, …)`, `ICEBERG_LOG_TO(logger, …)`, and `ICEBERG_LOG_RUNTIME_FMT` for runtime format strings.
- `ICEBERG_LOG_ACTIVE_LEVEL` is a compile-time floor: statements below it are removed entirely. `ICEBERG_LOG_FATAL` always emits, flushes, then aborts.
- Filtering is decided only by `ShouldLog()`; formatting happens only on the taken path and never throws (a bad format falls back safely).
- Generic/runtime-format macros use the same lock-free fast path as the fixed-severity ones (the slot lock is taken only on the fatal/abort path).
- Bare `LOG_*` aliases are opt-in via `ICEBERG_LOG_SHORT_MACROS`.

**Build note** — sets `/Zc:preprocessor` on MSVC, required for the `__VA_OPT__` used by the macros.

**Examples** — every macro takes a `std::format` string + args. The rendered line depends on the active backend; with the default `CerrLogger` it looks like:

```
ICEBERG_LOG_TRACE("entering scan for {}", table);
  2026-06-16T10:59:41.186Z trace [12345] table_scan.cc:88] entering scan for db.t
ICEBERG_LOG_DEBUG("cache miss key={}", key);
  2026-06-16T10:59:41.186Z debug [12345] cache.cc:42] cache miss key=manifest-7
ICEBERG_LOG_INFO("loaded {} manifests in {} ms", n, ms);
  2026-06-16T10:59:41.186Z info [12345] table_scan.cc:91] loaded 5 manifests in 12 ms
ICEBERG_LOG_WARN("retry {} after {}", attempt, err);
  2026-06-16T10:59:41.186Z warn [12345] io.cc:51] retry 2 after timeout
ICEBERG_LOG_ERROR("commit failed: {}", status);
  2026-06-16T10:59:41.186Z error [12345] txn.cc:77] commit failed: conflict
ICEBERG_LOG_CRITICAL("metadata unreadable at {}", path);
  2026-06-16T10:59:41.186Z critical [12345] meta.cc:30] metadata unreadable at s3://b/m.json
ICEBERG_LOG_FATAL("unrecoverable: {}", reason);   // emits, flushes, then std::abort()
  2026-06-16T10:59:41.186Z fatal [12345] boot.cc:19] unrecoverable: bad config
```

Less common forms: `ICEBERG_LOG(level, …)` (runtime severity), `ICEBERG_LOG_TO(logger, level, …)` (explicit logger), `ICEBERG_LOG_RUNTIME_FMT(level, fmt_string, args…)` (non-literal format). The same examples are documented inline in `logger.h`.

**Tests** — `macros_test` / `macros_active_level_test`: formatting, level gating, "argument not evaluated when disabled", compile-time stripping, never-throws, and FATAL-aborts death tests. clang/libc++.

This pull request and its description were written by Isaac.
