### PR TITLE
fix: fix URL encoding for non-ASCII bytes

### DIFF
--- a/src/iceberg/test/url_encoder_test.cc
+++ b/src/iceberg/test/url_encoder_test.cc
@@ -40,6 +40,7 @@ TEST(UrlEncoderTest, Encode) {
               ::testing::Eq("key%3Dvalue%26foo%3Dbar"));
   EXPECT_THAT(UrlEncoder::Encode("100%"), ::testing::Eq("100%25"));
   EXPECT_THAT(UrlEncoder::Encode("hello\x1fworld"), ::testing::Eq("hello%1Fworld"));
+  EXPECT_THAT(UrlEncoder::Encode("caf\xC3\xA9"), ::testing::Eq("caf%C3%A9"));
   EXPECT_THAT(UrlEncoder::Encode(""), ::testing::Eq(""));
 }
 
@@ -69,6 +70,7 @@ TEST(UrlEncoderTest, EncodeDecodeRoundTrip) {
                                          "key=value&foo=bar",
                                          "100%",
                                          "hello\x1Fworld",
+                                         "caf\xC3\xA9",
                                          "special!@#$%^&*()chars",
                                          "mixed-123_test.file~ok",
                                          ""};

--- a/src/iceberg/util/url_encoder.cc
+++ b/src/iceberg/util/url_encoder.cc
@@ -46,12 +46,13 @@ std::string UrlEncoder::Encode(std::string_view str_to_encode) {
   result.reserve(str_to_encode.size() * 3 / 2 /* Heuristic reservation */);
 
   for (char c : str_to_encode) {
-    if (IsUnreserved(c)) {
+    auto b = static_cast<unsigned char>(c);
+    if (IsUnreserved(b)) {
       result += c;
     } else {
       result += '%';
-      result += kHexChars[c >> 4];
-      result += kHexChars[c & 0xF];
+      result += kHexChars[b >> 4];
+      result += kHexChars[b & 0xF];
     }
   }
 


### PR DESCRIPTION
## Summary

- Treat URL encoder input bytes as unsigned before splitting them into hex nibbles.
- Add UTF-8 regression coverage for `café` encoding to `caf%C3%A9`.

## Why

On platforms where `char` is signed, bytes >= 0x80 can become negative before the hex lookup. That can lead to undefined behavior or incorrect percent encoding for non-ASCII strings.

## Testing

- `cmake -S . -B build -G Ninja -DICEBERG_BUILD_BUNDLE=OFF -DICEBERG_BUILD_REST=OFF -DICEBERG_BUILD_HIVE=OFF -DICEBERG_BUILD_SQL_CATALOG=OFF`
- `cmake --build build --target util_test`
- `ctest --test-dir build -R util_test --output-on-failure`