### PR TITLE
fix: validate truncate widths in utility entrypoints

### DIFF
--- a/src/iceberg/test/truncate_util_test.cc
+++ b/src/iceberg/test/truncate_util_test.cc
@@ -51,6 +51,26 @@ TEST(TruncateUtilTest, TruncateLiteral) {
             Literal::Binary(std::vector<uint8_t>(expected.begin(), expected.end())));
 }
 
+TEST(TruncateUtilTest, TruncateLiteralRejectsInvalidWidth) {
+  std::vector<uint8_t> data{1, 2, 3};
+
+  auto expect_invalid_width = [](const auto& result) {
+    EXPECT_THAT(result, IsError(ErrorKind::kInvalidArgument));
+    EXPECT_THAT(result, HasErrorMessage("Width must be positive"));
+  };
+
+  for (int32_t width : {0, -1}) {
+    SCOPED_TRACE(width);
+    expect_invalid_width(TruncateUtils::TruncateLiteral(Literal::Int(1), width));
+    expect_invalid_width(TruncateUtils::TruncateLiteral(Literal::Long(1), width));
+    expect_invalid_width(
+        TruncateUtils::TruncateLiteral(Literal::Decimal(1065, 4, 2), width));
+    expect_invalid_width(
+        TruncateUtils::TruncateLiteral(Literal::String("iceberg"), width));
+    expect_invalid_width(TruncateUtils::TruncateLiteral(Literal::Binary(data), width));
+  }
+}
+
 TEST(TruncateUtilTest, TruncateBinaryMax) {
   std::vector<uint8_t> test1{1, 1, 2};
   std::vector<uint8_t> test2{1, 1, 0xFF, 2};
@@ -188,6 +208,28 @@ TEST(TruncateUtilTest, TruncateStringMax) {
   ICEBERG_UNWRAP_OR_FAIL(auto result9_2,
                          TruncateUtils::TruncateLiteralMax(Literal::String(test9), 2));
   EXPECT_EQ(result9_2, Literal::String(test9_2_expected));
+}
+
+TEST(TruncateUtilTest, TruncateLiteralMaxRejectsInvalidWidth) {
+  std::vector<uint8_t> data{1, 2, 3};
+
+  auto expect_invalid_width = [](const auto& result) {
+    EXPECT_THAT(result, IsError(ErrorKind::kInvalidArgument));
+    EXPECT_THAT(result, HasErrorMessage("Width must be positive"));
+  };
+
+  for (int32_t width : {0, -1}) {
+    SCOPED_TRACE(width);
+    expect_invalid_width(
+        TruncateUtils::TruncateLiteralMax(Literal::String("iceberg"), width));
+    expect_invalid_width(TruncateUtils::TruncateLiteralMax(Literal::Binary(data), width));
+  }
+}
+
+TEST(TruncateUtilTest, TruncateUTF8MaxRejectsZeroWidth) {
+  auto result = TruncateUtils::TruncateUTF8Max("iceberg", 0);
+  EXPECT_THAT(result, IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(result, HasErrorMessage("Width must be positive"));
 }
 
 }  // namespace iceberg

--- a/src/iceberg/util/truncate_util.cc
+++ b/src/iceberg/util/truncate_util.cc
@@ -26,6 +26,7 @@
 #include "iceberg/expression/literal.h"
 #include "iceberg/type.h"
 #include "iceberg/util/checked_cast.h"
+#include "iceberg/util/macros.h"
 
 namespace iceberg {
 
@@ -33,6 +34,20 @@ namespace {
 constexpr uint32_t kUtf8MaxCodePoint = 0x10FFFF;
 constexpr uint32_t kUtf8MinSurrogate = 0xD800;
 constexpr uint32_t kUtf8MaxSurrogate = 0xDFFF;
+
+Status ValidateTruncateWidth(int32_t width) {
+  if (width <= 0) {
+    return InvalidArgument("Width must be positive, got {}", width);
+  }
+  return {};
+}
+
+Status ValidateTruncateWidth(size_t width) {
+  if (width == 0) {
+    return InvalidArgument("Width must be positive, got 0");
+  }
+  return {};
+}
 
 std::optional<uint32_t> DecodeUtf8CodePoint(std::string_view source) {
   if (source.empty()) {
@@ -205,6 +220,8 @@ Result<std::optional<Literal>> TruncateLiteralMaxImpl<TypeId::kBinary>(
 
 Result<std::optional<std::string>> TruncateUtils::TruncateUTF8Max(
     const std::string& source, size_t L) {
+  ICEBERG_RETURN_UNEXPECTED(ValidateTruncateWidth(L));
+
   std::string truncated = TruncateUTF8(source, L);
   if (truncated == source) {
     return truncated;
@@ -253,6 +270,8 @@ Decimal TruncateUtils::TruncateDecimal(const Decimal& decimal, int32_t width) {
     return TruncateLiteralImpl<TYPE_ID>(literal, width);
 
 Result<Literal> TruncateUtils::TruncateLiteral(const Literal& literal, int32_t width) {
+  ICEBERG_RETURN_UNEXPECTED(ValidateTruncateWidth(width));
+
   if (literal.IsNull()) [[unlikely]] {
     // Return null as is
     return literal;
@@ -280,6 +299,8 @@ Result<Literal> TruncateUtils::TruncateLiteral(const Literal& literal, int32_t w
 
 Result<std::optional<Literal>> TruncateUtils::TruncateLiteralMax(const Literal& literal,
                                                                  int32_t width) {
+  ICEBERG_RETURN_UNEXPECTED(ValidateTruncateWidth(width));
+
   if (literal.IsNull()) [[unlikely]] {
     // Return null as is
     return literal;


### PR DESCRIPTION
## Summary

- Reject non-positive widths in the `TruncateLiteral` and `TruncateLiteralMax` utility entrypoints.
- Reject zero width in `TruncateUTF8Max`, which returns a `Result` and can report invalid input directly.
- Add regression coverage for zero and negative widths across numeric, decimal, string, and binary literal truncation.

## Why

The truncate transform validates its width before creating a transform function, but the utility functions can also be called directly. Without a guard there, invalid widths can reach modulo operations or iterator arithmetic in the type-specific implementations.

## Testing

- `cmake --build build --target util_test`
- `ctest --test-dir build -R util_test --output-on-failure`