### PR TITLE
fix(rest): reject empty namespace separators

### DIFF
--- a/src/iceberg/catalog/rest/resource_paths.cc
+++ b/src/iceberg/catalog/rest/resource_paths.cc
@@ -34,6 +34,8 @@ Result<std::unique_ptr<ResourcePaths>> ResourcePaths::Make(
   if (base_uri.empty()) {
     return InvalidArgument("Base URI is empty");
   }
+  ICEBERG_PRECHECK(!namespace_separator.empty(),
+                   "REST namespace separator cannot be empty");
   return std::unique_ptr<ResourcePaths>(
       new ResourcePaths(std::move(base_uri), prefix, namespace_separator));
 }

--- a/src/iceberg/catalog/rest/rest_util.cc
+++ b/src/iceberg/catalog/rest/rest_util.cc
@@ -30,6 +30,15 @@
 
 namespace iceberg::rest {
 
+namespace {
+
+Status ValidateNamespaceSeparator(std::string_view separator) {
+  ICEBERG_PRECHECK(!separator.empty(), "REST namespace separator cannot be empty");
+  return {};
+}
+
+}  // namespace
+
 std::string_view TrimTrailingSlash(std::string_view str) {
   while (!str.empty() && str.back() == '/') {
     str.remove_suffix(1);
@@ -67,6 +76,8 @@ Result<std::string> DecodeString(std::string_view str_to_decode) {
 
 Result<std::string> EncodeNamespace(const Namespace& ns_to_encode,
                                     std::string_view separator) {
+  ICEBERG_RETURN_UNEXPECTED(ValidateNamespaceSeparator(separator));
+
   if (ns_to_encode.levels.empty()) {
     return "";
   }
@@ -85,6 +96,8 @@ Result<std::string> EncodeNamespace(const Namespace& ns_to_encode,
 
 Result<Namespace> DecodeNamespace(std::string_view str_to_decode,
                                   std::string_view separator) {
+  ICEBERG_RETURN_UNEXPECTED(ValidateNamespaceSeparator(separator));
+
   if (str_to_decode.empty()) {
     return Namespace{.levels = {}};
   }

--- a/src/iceberg/test/rest_util_test.cc
+++ b/src/iceberg/test/rest_util_test.cc
@@ -25,6 +25,7 @@
 
 #include "iceberg/catalog/rest/catalog_properties.h"
 #include "iceberg/catalog/rest/endpoint.h"
+#include "iceberg/catalog/rest/resource_paths.h"
 #include "iceberg/table_identifier.h"
 #include "iceberg/test/matchers.h"
 
@@ -81,6 +82,25 @@ TEST(RestUtilTest, RoundTripNamespaceWithCustomSeparator) {
               HasValue(::testing::Eq("dogs.and.cats%2Enamed%2Ehank.or.james-westfall")));
   EXPECT_THAT(DecodeNamespace("dogs.and.cats%2Enamed%2Ehank.or.james-westfall", "%2E"),
               HasValue(::testing::Eq(ns)));
+}
+
+TEST(RestUtilTest, NamespaceRejectsEmptySeparator) {
+  auto expect_empty_separator_error = [](const auto& result) {
+    EXPECT_THAT(result, IsError(ErrorKind::kInvalidArgument));
+    EXPECT_THAT(result, HasErrorMessage("REST namespace separator cannot be empty"));
+  };
+
+  expect_empty_separator_error(EncodeNamespace(Namespace{.levels = {"dogs"}}, ""));
+  expect_empty_separator_error(EncodeNamespace(Namespace{.levels = {}}, ""));
+  expect_empty_separator_error(DecodeNamespace("dogs", ""));
+  expect_empty_separator_error(DecodeNamespace("", ""));
+}
+
+TEST(RestUtilTest, ResourcePathsRejectsEmptyNamespaceSeparator) {
+  auto result = ResourcePaths::Make("https://catalog.example.com", "", "");
+
+  EXPECT_THAT(result, IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(result, HasErrorMessage("REST namespace separator cannot be empty"));
 }
 
 TEST(RestUtilTest, EncodeString) {


### PR DESCRIPTION
## Summary

- Reject empty REST namespace separators in namespace encode/decode helpers.
- Reject empty namespace separators when constructing `ResourcePaths`.
- Add regression coverage for direct helper calls and the resource path config boundary.

## Why

`DecodeNamespace` advances by `separator.size()` after each match. An empty separator never advances the cursor, so a misconfigured separator can hang namespace parsing.

## Testing

- `cmake -S . -B build-rest -G Ninja -DICEBERG_BUILD_BUNDLE=OFF -DICEBERG_BUILD_REST=ON -DICEBERG_BUILD_HIVE=OFF -DICEBERG_BUILD_SQL_CATALOG=OFF`
- `cmake --build build-rest --target rest_catalog_test`
- `ctest --test-dir build-rest -R rest_catalog_test --output-on-failure`