### PR TITLE
feat(rest): add session-aware REST catalog

### DIFF
--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -21,6 +21,7 @@ set(ICEBERG_SOURCES
     arrow_c_data_util.cc
     arrow_c_data_guard_internal.cc
     catalog/memory/in_memory_catalog.cc
+    catalog/session_context.cc
     delete_file_index.cc
     expression/aggregate.cc
     expression/binder.cc

--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -21,6 +21,7 @@ set(ICEBERG_SOURCES
     arrow_c_data_util.cc
     arrow_c_data_guard_internal.cc
     catalog/memory/in_memory_catalog.cc
+    catalog/session_catalog.cc
     catalog/session_context.cc
     delete_file_index.cc
     expression/aggregate.cc

--- a/src/iceberg/catalog/meson.build
+++ b/src/iceberg/catalog/meson.build
@@ -17,6 +17,11 @@
 
 subdir('memory')
 
+install_headers(
+    ['session_catalog.h', 'session_context.h'],
+    subdir: 'iceberg/catalog',
+)
+
 if get_option('rest').enabled()
     subdir('rest')
 endif

--- a/src/iceberg/catalog/rest/auth/auth_manager.cc
+++ b/src/iceberg/catalog/rest/auth/auth_manager.cc
@@ -38,8 +38,7 @@ Result<std::shared_ptr<AuthSession>> AuthManager::InitSession(
 }
 
 Result<std::shared_ptr<AuthSession>> AuthManager::ContextualSession(
-    [[maybe_unused]] const std::unordered_map<std::string, std::string>& context,
-    std::shared_ptr<AuthSession> parent) {
+    [[maybe_unused]] const SessionContext& context, std::shared_ptr<AuthSession> parent) {
   // By default, return the parent session as-is
   return parent;
 }

--- a/src/iceberg/catalog/rest/auth/auth_manager.h
+++ b/src/iceberg/catalog/rest/auth/auth_manager.h
@@ -70,13 +70,13 @@ class ICEBERG_REST_EXPORT AuthManager {
   /// This method is used by SessionCatalog to create sessions for different contexts
   /// (e.g., different users or tenants).
   ///
-  /// \param context Context properties (e.g., user credentials, tenant info).
+  /// \param context Session context (e.g., session ID, identity, credentials,
+  /// properties).
   /// \param parent Catalog session to inherit from or return as-is.
   /// \return A context-specific session, or the parent session if no context-specific
   /// session is needed, or an error if session creation fails.
   virtual Result<std::shared_ptr<AuthSession>> ContextualSession(
-      const std::unordered_map<std::string, std::string>& context,
-      std::shared_ptr<AuthSession> parent);
+      const SessionContext& context, std::shared_ptr<AuthSession> parent);
 
   /// \brief Create or reuse a session scoped to a single table/view.
   ///

--- a/src/iceberg/catalog/rest/auth/oauth2_util.cc
+++ b/src/iceberg/catalog/rest/auth/oauth2_util.cc
@@ -21,6 +21,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "iceberg/catalog/rest/auth/auth_properties.h"
 #include "iceberg/catalog/rest/auth/auth_session.h"
 #include "iceberg/catalog/rest/error_handlers.h"
 #include "iceberg/catalog/rest/http_client.h"

--- a/src/iceberg/catalog/rest/auth/sigv4_auth_manager_internal.h
+++ b/src/iceberg/catalog/rest/auth/sigv4_auth_manager_internal.h
@@ -126,8 +126,7 @@ class ICEBERG_REST_EXPORT SigV4AuthManager : public AuthManager {
       const std::unordered_map<std::string, std::string>& properties) override;
 
   Result<std::shared_ptr<AuthSession>> ContextualSession(
-      const std::unordered_map<std::string, std::string>& context,
-      std::shared_ptr<AuthSession> parent) override;
+      const SessionContext& context, std::shared_ptr<AuthSession> parent) override;
 
   Result<std::shared_ptr<AuthSession>> TableSession(
       const TableIdentifier& table,

--- a/src/iceberg/catalog/rest/auth/sigv4_manager.cc
+++ b/src/iceberg/catalog/rest/auth/sigv4_manager.cc
@@ -19,6 +19,7 @@
 
 #include "iceberg/catalog/rest/auth/auth_manager_internal.h"
 #include "iceberg/catalog/rest/auth/sigv4_auth_manager_internal.h"
+#include "iceberg/catalog/session_context.h"
 #include "iceberg/result.h"
 
 #if ICEBERG_SIGV4_ENABLED
@@ -142,6 +143,19 @@ std::unordered_map<std::string, std::string> MergeProperties(
   auto merged = base;
   for (const auto& [key, value] : overrides) {
     merged.insert_or_assign(key, value);
+  }
+  return merged;
+}
+
+Result<std::unordered_map<std::string, std::string>> ContextProperties(
+    const SessionContext& context) {
+  auto merged = context.properties;
+  for (const auto& [key, value] : context.credentials) {
+    auto [it, inserted] = merged.emplace(key, value);
+    if (!inserted && it->second != value) {
+      return InvalidArgument("Session context has conflicting values for property '{}'",
+                             key);
+    }
   }
   return merged;
 }
@@ -386,8 +400,7 @@ Result<std::shared_ptr<AuthSession>> SigV4AuthManager::CatalogSession(
 }
 
 Result<std::shared_ptr<AuthSession>> SigV4AuthManager::ContextualSession(
-    const std::unordered_map<std::string, std::string>& context,
-    std::shared_ptr<AuthSession> parent) {
+    const SessionContext& context, std::shared_ptr<AuthSession> parent) {
   auto sigv4_parent = std::dynamic_pointer_cast<SigV4AuthSession>(std::move(parent));
   ICEBERG_PRECHECK(sigv4_parent != nullptr,
                    "SigV4AuthManager parent must be a SigV4AuthSession");
@@ -395,10 +408,11 @@ Result<std::shared_ptr<AuthSession>> SigV4AuthManager::ContextualSession(
   ICEBERG_ASSIGN_OR_RAISE(auto delegate_session, delegate_->ContextualSession(
                                                      context, sigv4_parent->delegate()));
 
-  auto merged = MergeProperties(catalog_properties_, context);
+  ICEBERG_ASSIGN_OR_RAISE(auto context_properties, ContextProperties(context));
+  auto merged = MergeProperties(catalog_properties_, context_properties);
   ICEBERG_ASSIGN_OR_RAISE(
-      auto credentials,
-      ResolveCredentialsProvider(context, sigv4_parent->credentials_provider()));
+      auto credentials, ResolveCredentialsProvider(context_properties,
+                                                   sigv4_parent->credentials_provider()));
   return WrapSession(std::move(delegate_session), merged, std::move(credentials));
 }
 

--- a/src/iceberg/catalog/rest/rest_catalog.cc
+++ b/src/iceberg/catalog/rest/rest_catalog.cc
@@ -20,6 +20,8 @@
 #include "iceberg/catalog/rest/rest_catalog.h"
 
 #include <memory>
+#include <string_view>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -27,6 +29,7 @@
 #include <nlohmann/json.hpp>
 
 #include "iceberg/catalog/rest/auth/auth_managers.h"
+#include "iceberg/catalog/rest/auth/auth_properties.h"
 #include "iceberg/catalog/rest/auth/auth_session.h"
 #include "iceberg/catalog/rest/catalog_properties.h"
 #include "iceberg/catalog/rest/constant.h"
@@ -118,11 +121,287 @@ Result<bool> CaptureNoSuchNamespace(const auto& status) {
   return CaptureNoSuchObject(status, ErrorKind::kNoSuchNamespace);
 }
 
+Status ValidateNoFileIOConfig(
+    const std::unordered_map<std::string, std::string>& table_config) {
+  static const std::unordered_set<std::string_view> kTableConfigHandledByAuthKeys = {
+      auth::AuthProperties::kAuthType,
+      auth::AuthProperties::kBasicUsername,
+      auth::AuthProperties::kBasicPassword,
+      auth::AuthProperties::kSigV4Enabled,
+      auth::AuthProperties::kSigV4DelegateAuthType,
+      auth::AuthProperties::kSigV4SigningRegion,
+      auth::AuthProperties::kSigV4SigningName,
+      auth::AuthProperties::kSigV4AccessKeyId,
+      auth::AuthProperties::kSigV4SecretAccessKey,
+      auth::AuthProperties::kSigV4SessionToken,
+      auth::AuthProperties::kToken.key(),
+      auth::AuthProperties::kCredential.key(),
+      auth::AuthProperties::kScope.key(),
+      auth::AuthProperties::kOAuth2ServerUri.key(),
+      auth::AuthProperties::kKeepRefreshed.key(),
+      auth::AuthProperties::kExchangeEnabled.key(),
+      auth::AuthProperties::kAudience.key(),
+      auth::AuthProperties::kResource.key(),
+  };
+
+  for (const auto& [key, _] : table_config) {
+    if (!kTableConfigHandledByAuthKeys.contains(key)) {
+      // Fail closed because unknown table config may be FileIO/storage config.
+      // TODO(gangwu): Build table-specific FileIO when REST storage
+      // credentials and table-level storage config are supported.
+      return NotImplemented(
+          "Table-specific FileIO is not implemented for table config key '{}'", key);
+    }
+  }
+  return {};
+}
+
+Status CheckBoundTable(const TableIdentifier& requested, const TableIdentifier& bound) {
+  if (requested == bound) {
+    return {};
+  }
+  return InvalidArgument("Table-scoped catalog is bound to '{}', got '{}'",
+                         ToString(bound), ToString(requested));
+}
+
 }  // namespace
+
+class RestCatalog::ContextCatalog final
+    : public Catalog,
+      public std::enable_shared_from_this<RestCatalog::ContextCatalog> {
+ public:
+  ContextCatalog(std::shared_ptr<RestCatalog> root, SessionContext context)
+      : root_(std::move(root)), context_(std::move(context)) {}
+
+  std::string_view name() const override { return root_->name(); }
+
+  Result<std::vector<Namespace>> ListNamespaces(const Namespace& ns) const override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->ListNamespaces(ns, *session);
+  }
+
+  Status CreateNamespace(
+      const Namespace& ns,
+      const std::unordered_map<std::string, std::string>& properties) override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->CreateNamespace(ns, properties, *session);
+  }
+
+  Result<std::unordered_map<std::string, std::string>> GetNamespaceProperties(
+      const Namespace& ns) const override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->GetNamespaceProperties(ns, *session);
+  }
+
+  Status DropNamespace(const Namespace& ns) override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->DropNamespace(ns, *session);
+  }
+
+  Result<bool> NamespaceExists(const Namespace& ns) const override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->NamespaceExists(ns, *session);
+  }
+
+  Status UpdateNamespaceProperties(
+      const Namespace& ns, const std::unordered_map<std::string, std::string>& updates,
+      const std::unordered_set<std::string>& removals) override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->UpdateNamespaceProperties(ns, updates, removals, *session);
+  }
+
+  Result<std::vector<TableIdentifier>> ListTables(const Namespace& ns) const override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->ListTables(ns, *session);
+  }
+
+  Result<std::shared_ptr<Table>> CreateTable(
+      const TableIdentifier& identifier, const std::shared_ptr<Schema>& schema,
+      const std::shared_ptr<PartitionSpec>& spec, const std::shared_ptr<SortOrder>& order,
+      const std::string& location,
+      const std::unordered_map<std::string, std::string>& properties) override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->CreateTable(identifier, schema, spec, order, location, properties,
+                              context_, std::move(session));
+  }
+
+  Result<std::shared_ptr<Table>> UpdateTable(
+      const TableIdentifier& identifier,
+      const std::vector<std::unique_ptr<TableRequirement>>& requirements,
+      const std::vector<std::unique_ptr<TableUpdate>>& updates) override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->UpdateTable(identifier, requirements, updates, context_,
+                              std::move(session));
+  }
+
+  Result<std::shared_ptr<Transaction>> StageCreateTable(
+      const TableIdentifier& identifier, const std::shared_ptr<Schema>& schema,
+      const std::shared_ptr<PartitionSpec>& spec, const std::shared_ptr<SortOrder>& order,
+      const std::string& location,
+      const std::unordered_map<std::string, std::string>& properties) override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->StageCreateTable(identifier, schema, spec, order, location, properties,
+                                   context_, std::move(session));
+  }
+
+  Result<bool> TableExists(const TableIdentifier& identifier) const override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->TableExists(identifier, *session);
+  }
+
+  Status RenameTable(const TableIdentifier& from, const TableIdentifier& to) override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->RenameTable(from, to, *session);
+  }
+
+  Status DropTable(const TableIdentifier& identifier, bool purge) override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->DropTable(identifier, purge, *session);
+  }
+
+  Result<std::shared_ptr<Table>> LoadTable(const TableIdentifier& identifier) override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->LoadTable(identifier, context_, session, session);
+  }
+
+  Result<std::shared_ptr<Table>> RegisterTable(
+      const TableIdentifier& identifier,
+      const std::string& metadata_file_location) override {
+    ICEBERG_ASSIGN_OR_RAISE(auto session, root_->ContextualAuthSession(context_));
+    return root_->RegisterTable(identifier, metadata_file_location, context_,
+                                std::move(session));
+  }
+
+ private:
+  std::shared_ptr<RestCatalog> root_;
+  SessionContext context_;
+};
+
+class RestCatalog::TableScopedCatalog final
+    : public Catalog,
+      public std::enable_shared_from_this<RestCatalog::TableScopedCatalog> {
+ public:
+  TableScopedCatalog(std::shared_ptr<RestCatalog> root, SessionContext context,
+                     TableIdentifier identifier,
+                     std::unordered_map<std::string, std::string> table_config,
+                     std::shared_ptr<auth::AuthSession> table_session)
+      : root_(std::move(root)),
+        context_(std::move(context)),
+        identifier_(std::move(identifier)),
+        table_config_(std::move(table_config)),
+        table_session_(std::move(table_session)) {}
+
+  std::string_view name() const override { return root_->name(); }
+
+  Result<std::vector<Namespace>> ListNamespaces(const Namespace& /*ns*/) const override {
+    return NotSupported("Table-scoped catalog does not support ListNamespaces");
+  }
+
+  Status CreateNamespace(
+      const Namespace& /*ns*/,
+      const std::unordered_map<std::string, std::string>& /*properties*/) override {
+    return NotSupported("Table-scoped catalog does not support CreateNamespace");
+  }
+
+  Result<std::unordered_map<std::string, std::string>> GetNamespaceProperties(
+      const Namespace& /*ns*/) const override {
+    return NotSupported("Table-scoped catalog does not support GetNamespaceProperties");
+  }
+
+  Status DropNamespace(const Namespace& /*ns*/) override {
+    return NotSupported("Table-scoped catalog does not support DropNamespace");
+  }
+
+  Result<bool> NamespaceExists(const Namespace& /*ns*/) const override {
+    return NotSupported("Table-scoped catalog does not support NamespaceExists");
+  }
+
+  Status UpdateNamespaceProperties(
+      const Namespace& /*ns*/,
+      const std::unordered_map<std::string, std::string>& /*updates*/,
+      const std::unordered_set<std::string>& /*removals*/) override {
+    return NotSupported(
+        "Table-scoped catalog does not support UpdateNamespaceProperties");
+  }
+
+  Result<std::vector<TableIdentifier>> ListTables(
+      const Namespace& /*ns*/) const override {
+    return NotSupported("Table-scoped catalog does not support ListTables");
+  }
+
+  Result<std::shared_ptr<Table>> CreateTable(
+      const TableIdentifier& identifier, const std::shared_ptr<Schema>& /*schema*/,
+      const std::shared_ptr<PartitionSpec>& /*spec*/,
+      const std::shared_ptr<SortOrder>& /*order*/, const std::string& /*location*/,
+      const std::unordered_map<std::string, std::string>& /*properties*/) override {
+    ICEBERG_RETURN_UNEXPECTED(CheckBoundTable(identifier, identifier_));
+    return NotSupported("Table-scoped catalog does not support CreateTable");
+  }
+
+  Result<std::shared_ptr<Table>> UpdateTable(
+      const TableIdentifier& identifier,
+      const std::vector<std::unique_ptr<TableRequirement>>& requirements,
+      const std::vector<std::unique_ptr<TableUpdate>>& updates) override {
+    ICEBERG_RETURN_UNEXPECTED(CheckBoundTable(identifier, identifier_));
+    ICEBERG_ASSIGN_OR_RAISE(
+        auto response,
+        root_->UpdateTableInternal(identifier, requirements, updates, *table_session_));
+    return root_->MakeTableFromCommitResponse(identifier, std::move(response), context_,
+                                              table_config_, table_session_);
+  }
+
+  Result<std::shared_ptr<Transaction>> StageCreateTable(
+      const TableIdentifier& identifier, const std::shared_ptr<Schema>& /*schema*/,
+      const std::shared_ptr<PartitionSpec>& /*spec*/,
+      const std::shared_ptr<SortOrder>& /*order*/, const std::string& /*location*/,
+      const std::unordered_map<std::string, std::string>& /*properties*/) override {
+    ICEBERG_RETURN_UNEXPECTED(CheckBoundTable(identifier, identifier_));
+    return NotSupported("Table-scoped catalog does not support StageCreateTable");
+  }
+
+  Result<bool> TableExists(const TableIdentifier& identifier) const override {
+    ICEBERG_RETURN_UNEXPECTED(CheckBoundTable(identifier, identifier_));
+    return root_->TableExists(identifier, *table_session_);
+  }
+
+  Status RenameTable(const TableIdentifier& from,
+                     const TableIdentifier& /*to*/) override {
+    ICEBERG_RETURN_UNEXPECTED(CheckBoundTable(from, identifier_));
+    return NotSupported("Table-scoped catalog does not support RenameTable");
+  }
+
+  Status DropTable(const TableIdentifier& identifier, bool /*purge*/) override {
+    ICEBERG_RETURN_UNEXPECTED(CheckBoundTable(identifier, identifier_));
+    return NotSupported("Table-scoped catalog does not support DropTable");
+  }
+
+  Result<std::shared_ptr<Table>> LoadTable(const TableIdentifier& identifier) override {
+    ICEBERG_RETURN_UNEXPECTED(CheckBoundTable(identifier, identifier_));
+    ICEBERG_ASSIGN_OR_RAISE(auto contextual, root_->ContextualAuthSession(context_));
+    return root_->LoadTable(identifier, context_, table_session_, std::move(contextual));
+  }
+
+  Result<std::shared_ptr<Table>> RegisterTable(
+      const TableIdentifier& identifier,
+      const std::string& /*metadata_file_location*/) override {
+    ICEBERG_RETURN_UNEXPECTED(CheckBoundTable(identifier, identifier_));
+    return NotSupported("Table-scoped catalog does not support RegisterTable");
+  }
+
+ private:
+  std::shared_ptr<RestCatalog> root_;
+  SessionContext context_;
+  TableIdentifier identifier_;
+  std::unordered_map<std::string, std::string> table_config_;
+  std::shared_ptr<auth::AuthSession> table_session_;
+};
 
 RestCatalog::~RestCatalog() {
   if (catalog_session_) {
     std::ignore = catalog_session_->Close();
+  }
+  if (auth_manager_) {
+    std::ignore = auth_manager_->Close();
   }
 }
 
@@ -178,10 +457,11 @@ Result<std::shared_ptr<RestCatalog>> RestCatalog::Make(
   // Create FileIO with the final configuration
   ICEBERG_ASSIGN_OR_RAISE(auto file_io, MakeCatalogFileIO(final_config));
 
-  return std::shared_ptr<RestCatalog>(
-      new RestCatalog(std::move(final_config), std::move(file_io), std::move(client),
-                      std::move(paths), std::move(endpoints), std::move(auth_manager),
-                      std::move(catalog_session), snapshot_mode));
+  auto default_context = SessionContext::Empty();
+  return std::shared_ptr<RestCatalog>(new RestCatalog(
+      std::move(final_config), std::move(file_io), std::move(client), std::move(paths),
+      std::move(endpoints), std::move(auth_manager), std::move(catalog_session),
+      snapshot_mode, std::move(default_context)));
 }
 
 RestCatalog::RestCatalog(RestCatalogProperties config, std::shared_ptr<FileIO> file_io,
@@ -190,7 +470,7 @@ RestCatalog::RestCatalog(RestCatalogProperties config, std::shared_ptr<FileIO> f
                          std::unordered_set<Endpoint> endpoints,
                          std::unique_ptr<auth::AuthManager> auth_manager,
                          std::shared_ptr<auth::AuthSession> catalog_session,
-                         SnapshotMode snapshot_mode)
+                         SnapshotMode snapshot_mode, SessionContext default_context)
     : config_(std::move(config)),
       file_io_(std::move(file_io)),
       client_(std::move(client)),
@@ -199,13 +479,50 @@ RestCatalog::RestCatalog(RestCatalogProperties config, std::shared_ptr<FileIO> f
       supported_endpoints_(std::move(endpoints)),
       auth_manager_(std::move(auth_manager)),
       catalog_session_(std::move(catalog_session)),
-      snapshot_mode_(snapshot_mode) {
+      snapshot_mode_(snapshot_mode),
+      default_context_(std::move(default_context)) {
   ICEBERG_DCHECK(catalog_session_ != nullptr, "catalog_session must not be null");
 }
 
 std::string_view RestCatalog::name() const { return name_; }
 
-Result<std::vector<Namespace>> RestCatalog::ListNamespaces(const Namespace& ns) const {
+Result<std::shared_ptr<Catalog>> RestCatalog::AsCatalog() {
+  if (!default_catalog_) {
+    default_catalog_ =
+        std::make_shared<ContextCatalog>(shared_from_this(), default_context_);
+  }
+  return default_catalog_;
+}
+
+Result<std::shared_ptr<Catalog>> RestCatalog::WithContext(SessionContext context) {
+  if (context.session_id.empty()) {
+    return InvalidArgument("Session context session_id must not be empty");
+  }
+  return std::make_shared<ContextCatalog>(shared_from_this(), std::move(context));
+}
+
+Result<std::shared_ptr<auth::AuthSession>> RestCatalog::ContextualAuthSession(
+    const SessionContext& context) {
+  return auth_manager_->ContextualSession(context, catalog_session_);
+}
+
+Result<std::shared_ptr<auth::AuthSession>> RestCatalog::TableAuthSession(
+    const TableIdentifier& identifier,
+    const std::unordered_map<std::string, std::string>& table_config,
+    std::shared_ptr<auth::AuthSession> contextual_session) {
+  return auth_manager_->TableSession(identifier, table_config,
+                                     std::move(contextual_session));
+}
+
+Result<std::shared_ptr<FileIO>> RestCatalog::TableFileIO(
+    const SessionContext& /*context*/,
+    const std::unordered_map<std::string, std::string>& table_config) const {
+  ICEBERG_RETURN_UNEXPECTED(ValidateNoFileIOConfig(table_config));
+  return file_io_;
+}
+
+Result<std::vector<Namespace>> RestCatalog::ListNamespaces(
+    const Namespace& ns, auth::AuthSession& session) const {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::ListNamespaces());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Namespaces());
   std::vector<Namespace> result;
@@ -220,10 +537,9 @@ Result<std::vector<Namespace>> RestCatalog::ListNamespaces(const Namespace& ns) 
     if (!next_token.empty()) {
       params[kQueryParamPageToken] = next_token;
     }
-    ICEBERG_ASSIGN_OR_RAISE(
-        const auto response,
-        client_->Get(path, params, /*headers=*/{}, *NamespaceErrorHandler::Instance(),
-                     *catalog_session_));
+    ICEBERG_ASSIGN_OR_RAISE(const auto response,
+                            client_->Get(path, params, /*headers=*/{},
+                                         *NamespaceErrorHandler::Instance(), session));
     ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
     ICEBERG_ASSIGN_OR_RAISE(auto list_response, ListNamespacesResponseFromJson(json));
     result.insert(result.end(), list_response.namespaces.begin(),
@@ -237,74 +553,74 @@ Result<std::vector<Namespace>> RestCatalog::ListNamespaces(const Namespace& ns) 
 }
 
 Status RestCatalog::CreateNamespace(
-    const Namespace& ns, const std::unordered_map<std::string, std::string>& properties) {
+    const Namespace& ns, const std::unordered_map<std::string, std::string>& properties,
+    auth::AuthSession& session) {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::CreateNamespace());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Namespaces());
   CreateNamespaceRequest request{.namespace_ = ns, .properties = properties};
   ICEBERG_ASSIGN_OR_RAISE(auto json_request, ToJsonString(ToJson(request)));
-  ICEBERG_ASSIGN_OR_RAISE(
-      const auto response,
-      client_->Post(path, json_request, /*headers=*/{},
-                    *NamespaceErrorHandler::Instance(), *catalog_session_));
+  ICEBERG_ASSIGN_OR_RAISE(const auto response,
+                          client_->Post(path, json_request, /*headers=*/{},
+                                        *NamespaceErrorHandler::Instance(), session));
   ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
   ICEBERG_ASSIGN_OR_RAISE(auto create_response, CreateNamespaceResponseFromJson(json));
   return {};
 }
 
 Result<std::unordered_map<std::string, std::string>> RestCatalog::GetNamespaceProperties(
-    const Namespace& ns) const {
+    const Namespace& ns, auth::AuthSession& session) const {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::GetNamespaceProperties());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Namespace_(ns));
-  ICEBERG_ASSIGN_OR_RAISE(
-      const auto response,
-      client_->Get(path, /*params=*/{}, /*headers=*/{},
-                   *NamespaceErrorHandler::Instance(), *catalog_session_));
+  ICEBERG_ASSIGN_OR_RAISE(const auto response,
+                          client_->Get(path, /*params=*/{}, /*headers=*/{},
+                                       *NamespaceErrorHandler::Instance(), session));
   ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
   ICEBERG_ASSIGN_OR_RAISE(auto get_response, GetNamespaceResponseFromJson(json));
   return get_response.properties;
 }
 
-Status RestCatalog::DropNamespace(const Namespace& ns) {
+Status RestCatalog::DropNamespace(const Namespace& ns, auth::AuthSession& session) {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::DropNamespace());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Namespace_(ns));
   ICEBERG_ASSIGN_OR_RAISE(
       const auto response,
       client_->Delete(path, /*params=*/{}, /*headers=*/{},
-                      *DropNamespaceErrorHandler::Instance(), *catalog_session_));
+                      *DropNamespaceErrorHandler::Instance(), session));
   return {};
 }
 
-Result<bool> RestCatalog::NamespaceExists(const Namespace& ns) const {
+Result<bool> RestCatalog::NamespaceExists(const Namespace& ns,
+                                          auth::AuthSession& session) const {
   if (!supported_endpoints_.contains(Endpoint::NamespaceExists())) {
     // Fall back to GetNamespaceProperties
-    return CaptureNoSuchNamespace(GetNamespaceProperties(ns));
+    return CaptureNoSuchNamespace(GetNamespaceProperties(ns, session));
   }
 
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Namespace_(ns));
-  return CaptureNoSuchNamespace(client_->Head(
-      path, /*headers=*/{}, *NamespaceErrorHandler::Instance(), *catalog_session_));
+  return CaptureNoSuchNamespace(
+      client_->Head(path, /*headers=*/{}, *NamespaceErrorHandler::Instance(), session));
 }
 
 Status RestCatalog::UpdateNamespaceProperties(
     const Namespace& ns, const std::unordered_map<std::string, std::string>& updates,
-    const std::unordered_set<std::string>& removals) {
+    const std::unordered_set<std::string>& removals, auth::AuthSession& session) {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::UpdateNamespace());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->NamespaceProperties(ns));
   UpdateNamespacePropertiesRequest request{
       .removals = std::vector<std::string>(removals.begin(), removals.end()),
       .updates = updates};
   ICEBERG_ASSIGN_OR_RAISE(auto json_request, ToJsonString(ToJson(request)));
-  ICEBERG_ASSIGN_OR_RAISE(
-      const auto response,
-      client_->Post(path, json_request, /*headers=*/{},
-                    *NamespaceErrorHandler::Instance(), *catalog_session_));
+  ICEBERG_ASSIGN_OR_RAISE(const auto response,
+                          client_->Post(path, json_request, /*headers=*/{},
+                                        *NamespaceErrorHandler::Instance(), session));
   ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
   ICEBERG_ASSIGN_OR_RAISE(auto update_response,
                           UpdateNamespacePropertiesResponseFromJson(json));
   return {};
 }
 
-Result<std::vector<TableIdentifier>> RestCatalog::ListTables(const Namespace& ns) const {
+Result<std::vector<TableIdentifier>> RestCatalog::ListTables(
+    const Namespace& ns, auth::AuthSession& session) const {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::ListTables());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Tables(ns));
   std::vector<TableIdentifier> result;
@@ -314,10 +630,9 @@ Result<std::vector<TableIdentifier>> RestCatalog::ListTables(const Namespace& ns
     if (!next_token.empty()) {
       params[kQueryParamPageToken] = next_token;
     }
-    ICEBERG_ASSIGN_OR_RAISE(
-        const auto response,
-        client_->Get(path, params, /*headers=*/{}, *TableErrorHandler::Instance(),
-                     *catalog_session_));
+    ICEBERG_ASSIGN_OR_RAISE(const auto response,
+                            client_->Get(path, params, /*headers=*/{},
+                                         *TableErrorHandler::Instance(), session));
     ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
     ICEBERG_ASSIGN_OR_RAISE(auto list_response, ListTablesResponseFromJson(json));
     result.insert(result.end(), list_response.identifiers.begin(),
@@ -334,7 +649,8 @@ Result<LoadTableResult> RestCatalog::CreateTableInternal(
     const TableIdentifier& identifier, const std::shared_ptr<Schema>& schema,
     const std::shared_ptr<PartitionSpec>& spec, const std::shared_ptr<SortOrder>& order,
     const std::string& location,
-    const std::unordered_map<std::string, std::string>& properties, bool stage_create) {
+    const std::unordered_map<std::string, std::string>& properties, bool stage_create,
+    auth::AuthSession& session) {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::CreateTable());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Tables(identifier.ns));
 
@@ -349,16 +665,12 @@ Result<LoadTableResult> RestCatalog::CreateTableInternal(
   };
 
   ICEBERG_ASSIGN_OR_RAISE(auto json_request, ToJsonString(ToJson(request)));
-  ICEBERG_ASSIGN_OR_RAISE(
-      const auto response,
-      client_->Post(path, json_request, /*headers=*/{}, *TableErrorHandler::Instance(),
-                    *catalog_session_));
+  ICEBERG_ASSIGN_OR_RAISE(const auto response,
+                          client_->Post(path, json_request, /*headers=*/{},
+                                        *TableErrorHandler::Instance(), session));
 
   ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
   ICEBERG_ASSIGN_OR_RAISE(auto load_result, LoadTableResultFromJson(json));
-  // TODO: Wire table-specific auth config from LoadTableResponse once C++ has
-  // table-scoped REST operations or a table-scoped catalog wrapper. The current
-  // Table implementation routes refresh and commit back through Catalog.
   return load_result;
 }
 
@@ -366,18 +678,22 @@ Result<std::shared_ptr<Table>> RestCatalog::CreateTable(
     const TableIdentifier& identifier, const std::shared_ptr<Schema>& schema,
     const std::shared_ptr<PartitionSpec>& spec, const std::shared_ptr<SortOrder>& order,
     const std::string& location,
-    const std::unordered_map<std::string, std::string>& properties) {
-  ICEBERG_ASSIGN_OR_RAISE(auto result,
-                          CreateTableInternal(identifier, schema, spec, order, location,
-                                              properties, /*stage_create=*/false));
-  return Table::Make(identifier, std::move(result.metadata),
-                     std::move(result.metadata_location), file_io_, shared_from_this());
+    const std::unordered_map<std::string, std::string>& properties,
+    const SessionContext& context,
+    std::shared_ptr<auth::AuthSession> contextual_session) {
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto result,
+      CreateTableInternal(identifier, schema, spec, order, location, properties,
+                          /*stage_create=*/false, *contextual_session));
+  return MakeTableFromLoadResult(identifier, std::move(result), context,
+                                 std::move(contextual_session));
 }
 
-Result<std::shared_ptr<Table>> RestCatalog::UpdateTable(
+Result<CommitTableResponse> RestCatalog::UpdateTableInternal(
     const TableIdentifier& identifier,
     const std::vector<std::unique_ptr<TableRequirement>>& requirements,
-    const std::vector<std::unique_ptr<TableUpdate>>& updates) {
+    const std::vector<std::unique_ptr<TableUpdate>>& updates,
+    auth::AuthSession& session) {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::UpdateTable());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Table(identifier));
 
@@ -392,35 +708,60 @@ Result<std::shared_ptr<Table>> RestCatalog::UpdateTable(
   }
 
   ICEBERG_ASSIGN_OR_RAISE(auto json_request, ToJsonString(ToJson(request)));
-  ICEBERG_ASSIGN_OR_RAISE(
-      const auto response,
-      client_->Post(path, json_request, /*headers=*/{}, *TableErrorHandler::Instance(),
-                    *catalog_session_));
+  ICEBERG_ASSIGN_OR_RAISE(const auto response,
+                          client_->Post(path, json_request, /*headers=*/{},
+                                        *TableErrorHandler::Instance(), session));
 
   ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
   ICEBERG_ASSIGN_OR_RAISE(auto commit_response, CommitTableResponseFromJson(json));
+  return commit_response;
+}
 
-  return Table::Make(identifier, std::move(commit_response.metadata),
-                     std::move(commit_response.metadata_location), file_io_,
-                     shared_from_this());
+Result<std::shared_ptr<Table>> RestCatalog::UpdateTable(
+    const TableIdentifier& identifier,
+    const std::vector<std::unique_ptr<TableRequirement>>& requirements,
+    const std::vector<std::unique_ptr<TableUpdate>>& updates,
+    const SessionContext& context,
+    std::shared_ptr<auth::AuthSession> contextual_session) {
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto response,
+      UpdateTableInternal(identifier, requirements, updates, *contextual_session));
+  std::unordered_map<std::string, std::string> table_config;
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto table_session,
+      TableAuthSession(identifier, table_config, std::move(contextual_session)));
+  return MakeTableFromCommitResponse(identifier, std::move(response), context,
+                                     table_config, std::move(table_session));
 }
 
 Result<std::shared_ptr<Transaction>> RestCatalog::StageCreateTable(
     const TableIdentifier& identifier, const std::shared_ptr<Schema>& schema,
     const std::shared_ptr<PartitionSpec>& spec, const std::shared_ptr<SortOrder>& order,
     const std::string& location,
-    const std::unordered_map<std::string, std::string>& properties) {
-  ICEBERG_ASSIGN_OR_RAISE(auto result,
-                          CreateTableInternal(identifier, schema, spec, order, location,
-                                              properties, /*stage_create=*/true));
-  ICEBERG_ASSIGN_OR_RAISE(auto staged_table,
-                          StagedTable::Make(identifier, std::move(result.metadata),
-                                            std::move(result.metadata_location), file_io_,
-                                            shared_from_this()));
+    const std::unordered_map<std::string, std::string>& properties,
+    const SessionContext& context,
+    std::shared_ptr<auth::AuthSession> contextual_session) {
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto result,
+      CreateTableInternal(identifier, schema, spec, order, location, properties,
+                          /*stage_create=*/true, *contextual_session));
+  auto table_config = std::move(result.config);
+  ICEBERG_ASSIGN_OR_RAISE(auto table_io, TableFileIO(context, table_config));
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto table_session,
+      TableAuthSession(identifier, table_config, std::move(contextual_session)));
+  auto table_catalog = std::make_shared<TableScopedCatalog>(
+      shared_from_this(), context, identifier, table_config, std::move(table_session));
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto staged_table,
+      StagedTable::Make(identifier, std::move(result.metadata),
+                        std::move(result.metadata_location), std::move(table_io),
+                        std::move(table_catalog)));
   return Transaction::Make(std::move(staged_table), TransactionKind::kCreate);
 }
 
-Status RestCatalog::DropTable(const TableIdentifier& identifier, bool purge) {
+Status RestCatalog::DropTable(const TableIdentifier& identifier, bool purge,
+                              auth::AuthSession& session) {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::DeleteTable());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Table(identifier));
 
@@ -428,40 +769,40 @@ Status RestCatalog::DropTable(const TableIdentifier& identifier, bool purge) {
   if (purge) {
     params["purgeRequested"] = "true";
   }
-  ICEBERG_ASSIGN_OR_RAISE(
-      const auto response,
-      client_->Delete(path, params, /*headers=*/{}, *TableErrorHandler::Instance(),
-                      *catalog_session_));
+  ICEBERG_ASSIGN_OR_RAISE(const auto response,
+                          client_->Delete(path, params, /*headers=*/{},
+                                          *TableErrorHandler::Instance(), session));
   return {};
 }
 
-Result<bool> RestCatalog::TableExists(const TableIdentifier& identifier) const {
+Result<bool> RestCatalog::TableExists(const TableIdentifier& identifier,
+                                      auth::AuthSession& session) const {
   if (!supported_endpoints_.contains(Endpoint::TableExists())) {
     // Fall back to call LoadTable
-    return CaptureNoSuchTable(LoadTableInternal(identifier));
+    return CaptureNoSuchTable(LoadTableInternal(identifier, session));
   }
 
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Table(identifier));
-  return CaptureNoSuchTable(client_->Head(
-      path, /*headers=*/{}, *TableErrorHandler::Instance(), *catalog_session_));
+  return CaptureNoSuchTable(
+      client_->Head(path, /*headers=*/{}, *TableErrorHandler::Instance(), session));
 }
 
-Status RestCatalog::RenameTable(const TableIdentifier& from, const TableIdentifier& to) {
+Status RestCatalog::RenameTable(const TableIdentifier& from, const TableIdentifier& to,
+                                auth::AuthSession& session) {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::RenameTable());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Rename());
 
   RenameTableRequest request{.source = from, .destination = to};
   ICEBERG_ASSIGN_OR_RAISE(auto json_request, ToJsonString(ToJson(request)));
-  ICEBERG_ASSIGN_OR_RAISE(
-      const auto response,
-      client_->Post(path, json_request, /*headers=*/{}, *TableErrorHandler::Instance(),
-                    *catalog_session_));
+  ICEBERG_ASSIGN_OR_RAISE(const auto response,
+                          client_->Post(path, json_request, /*headers=*/{},
+                                        *TableErrorHandler::Instance(), session));
 
   return {};
 }
 
-Result<std::string> RestCatalog::LoadTableInternal(
-    const TableIdentifier& identifier) const {
+Result<LoadTableResult> RestCatalog::LoadTableInternal(const TableIdentifier& identifier,
+                                                       auth::AuthSession& session) const {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::LoadTable());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Table(identifier));
 
@@ -472,26 +813,27 @@ Result<std::string> RestCatalog::LoadTableInternal(
     params["snapshots"] = "all";
   }
 
-  ICEBERG_ASSIGN_OR_RAISE(
-      const auto response,
-      client_->Get(path, params, /*headers=*/{}, *TableErrorHandler::Instance(),
-                   *catalog_session_));
-  return response.body();
+  ICEBERG_ASSIGN_OR_RAISE(const auto response,
+                          client_->Get(path, params, /*headers=*/{},
+                                       *TableErrorHandler::Instance(), session));
+  ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
+  return LoadTableResultFromJson(json);
 }
 
-Result<std::shared_ptr<Table>> RestCatalog::LoadTable(const TableIdentifier& identifier) {
-  ICEBERG_ASSIGN_OR_RAISE(const auto body, LoadTableInternal(identifier));
-  ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(body));
-  ICEBERG_ASSIGN_OR_RAISE(auto load_result, LoadTableResultFromJson(json));
-  // TODO: Support table-specific auth config and per-table FileIO from the REST
-  // load response when table-scoped REST operations are introduced.
-  return Table::Make(identifier, std::move(load_result.metadata),
-                     std::move(load_result.metadata_location), file_io_,
-                     shared_from_this());
+Result<std::shared_ptr<Table>> RestCatalog::LoadTable(
+    const TableIdentifier& identifier, const SessionContext& context,
+    std::shared_ptr<auth::AuthSession> request_session,
+    std::shared_ptr<auth::AuthSession> contextual_session) {
+  ICEBERG_ASSIGN_OR_RAISE(auto load_result,
+                          LoadTableInternal(identifier, *request_session));
+  return MakeTableFromLoadResult(identifier, std::move(load_result), context,
+                                 std::move(contextual_session));
 }
 
 Result<std::shared_ptr<Table>> RestCatalog::RegisterTable(
-    const TableIdentifier& identifier, const std::string& metadata_file_location) {
+    const TableIdentifier& identifier, const std::string& metadata_file_location,
+    const SessionContext& context,
+    std::shared_ptr<auth::AuthSession> contextual_session) {
   ICEBERG_ENDPOINT_CHECK(supported_endpoints_, Endpoint::RegisterTable());
   ICEBERG_ASSIGN_OR_RAISE(auto path, paths_->Register(identifier.ns));
 
@@ -504,15 +846,44 @@ Result<std::shared_ptr<Table>> RestCatalog::RegisterTable(
   ICEBERG_ASSIGN_OR_RAISE(
       const auto response,
       client_->Post(path, json_request, /*headers=*/{}, *TableErrorHandler::Instance(),
-                    *catalog_session_));
+                    *contextual_session));
 
   ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
   ICEBERG_ASSIGN_OR_RAISE(auto load_result, LoadTableResultFromJson(json));
-  // TODO: Support table-specific auth config and per-table FileIO from the REST
-  // register response when table-scoped REST operations are introduced.
-  return Table::Make(identifier, std::move(load_result.metadata),
-                     std::move(load_result.metadata_location), file_io_,
-                     shared_from_this());
+  return MakeTableFromLoadResult(identifier, std::move(load_result), context,
+                                 std::move(contextual_session));
+}
+
+Result<std::shared_ptr<Table>> RestCatalog::MakeTableFromLoadResult(
+    const TableIdentifier& identifier, LoadTableResult result,
+    const SessionContext& context,
+    std::shared_ptr<auth::AuthSession> contextual_session) {
+  auto table_config = std::move(result.config);
+  ICEBERG_ASSIGN_OR_RAISE(auto table_io, TableFileIO(context, table_config));
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto table_session,
+      TableAuthSession(identifier, table_config, std::move(contextual_session)));
+  auto table_catalog = std::make_shared<TableScopedCatalog>(
+      shared_from_this(), context, identifier, table_config, table_session);
+  return Table::Make(identifier, std::move(result.metadata),
+                     std::move(result.metadata_location), std::move(table_io),
+                     std::move(table_catalog));
+}
+
+Result<std::shared_ptr<Table>> RestCatalog::MakeTableFromCommitResponse(
+    const TableIdentifier& identifier, CommitTableResponse response,
+    const SessionContext& context,
+    const std::unordered_map<std::string, std::string>& table_config,
+    std::shared_ptr<auth::AuthSession> table_session) {
+  // TODO(gangwu): If the REST commit response grows table config or
+  // storage credentials, derive a replacement table session/FileIO from that
+  // response. The current table commit response does not define config.
+  ICEBERG_ASSIGN_OR_RAISE(auto table_io, TableFileIO(context, table_config));
+  auto table_catalog = std::make_shared<TableScopedCatalog>(
+      shared_from_this(), context, identifier, table_config, table_session);
+  return Table::Make(identifier, std::move(response.metadata),
+                     std::move(response.metadata_location), std::move(table_io),
+                     std::move(table_catalog));
 }
 
 }  // namespace iceberg::rest

--- a/src/iceberg/catalog/rest/rest_catalog.h
+++ b/src/iceberg/catalog/rest/rest_catalog.h
@@ -28,6 +28,8 @@
 #include "iceberg/catalog/rest/endpoint.h"
 #include "iceberg/catalog/rest/iceberg_rest_export.h"
 #include "iceberg/catalog/rest/type_fwd.h"
+#include "iceberg/catalog/session_catalog.h"
+#include "iceberg/catalog/session_context.h"
 #include "iceberg/result.h"
 
 /// \file iceberg/catalog/rest/rest_catalog.h
@@ -35,9 +37,10 @@
 
 namespace iceberg::rest {
 
-/// \brief Rest catalog implementation.
-class ICEBERG_REST_EXPORT RestCatalog : public Catalog,
-                                        public std::enable_shared_from_this<RestCatalog> {
+/// \brief Session-aware REST catalog root.
+class ICEBERG_REST_EXPORT RestCatalog final
+    : public SessionCatalog,
+      public std::enable_shared_from_this<RestCatalog> {
  public:
   ~RestCatalog() override;
 
@@ -51,69 +54,122 @@ class ICEBERG_REST_EXPORT RestCatalog : public Catalog,
 
   std::string_view name() const override;
 
-  Result<std::vector<Namespace>> ListNamespaces(const Namespace& ns) const override;
+  Result<std::shared_ptr<Catalog>> AsCatalog() override;
 
-  Status CreateNamespace(
-      const Namespace& ns,
-      const std::unordered_map<std::string, std::string>& properties) override;
-
-  Result<std::unordered_map<std::string, std::string>> GetNamespaceProperties(
-      const Namespace& ns) const override;
-
-  Status DropNamespace(const Namespace& ns) override;
-
-  Result<bool> NamespaceExists(const Namespace& ns) const override;
-
-  Status UpdateNamespaceProperties(
-      const Namespace& ns, const std::unordered_map<std::string, std::string>& updates,
-      const std::unordered_set<std::string>& removals) override;
-
-  Result<std::vector<TableIdentifier>> ListTables(const Namespace& ns) const override;
-
-  Result<std::shared_ptr<Table>> CreateTable(
-      const TableIdentifier& identifier, const std::shared_ptr<Schema>& schema,
-      const std::shared_ptr<PartitionSpec>& spec, const std::shared_ptr<SortOrder>& order,
-      const std::string& location,
-      const std::unordered_map<std::string, std::string>& properties) override;
-
-  Result<std::shared_ptr<Table>> UpdateTable(
-      const TableIdentifier& identifier,
-      const std::vector<std::unique_ptr<TableRequirement>>& requirements,
-      const std::vector<std::unique_ptr<TableUpdate>>& updates) override;
-
-  Result<std::shared_ptr<Transaction>> StageCreateTable(
-      const TableIdentifier& identifier, const std::shared_ptr<Schema>& schema,
-      const std::shared_ptr<PartitionSpec>& spec, const std::shared_ptr<SortOrder>& order,
-      const std::string& location,
-      const std::unordered_map<std::string, std::string>& properties) override;
-
-  Result<bool> TableExists(const TableIdentifier& identifier) const override;
-
-  Status RenameTable(const TableIdentifier& from, const TableIdentifier& to) override;
-
-  Status DropTable(const TableIdentifier& identifier, bool purge) override;
-
-  Result<std::shared_ptr<Table>> LoadTable(const TableIdentifier& identifier) override;
-
-  Result<std::shared_ptr<Table>> RegisterTable(
-      const TableIdentifier& identifier,
-      const std::string& metadata_file_location) override;
+  Result<std::shared_ptr<Catalog>> WithContext(SessionContext context) override;
 
  private:
+  class ContextCatalog;
+  class TableScopedCatalog;
+
   RestCatalog(RestCatalogProperties config, std::shared_ptr<FileIO> file_io,
               std::unique_ptr<HttpClient> client, std::unique_ptr<ResourcePaths> paths,
               std::unordered_set<Endpoint> endpoints,
               std::unique_ptr<auth::AuthManager> auth_manager,
               std::shared_ptr<auth::AuthSession> catalog_session,
-              SnapshotMode snapshot_mode);
+              SnapshotMode snapshot_mode, SessionContext default_context);
 
-  Result<std::string> LoadTableInternal(const TableIdentifier& identifier) const;
+  Result<std::shared_ptr<auth::AuthSession>> ContextualAuthSession(
+      const SessionContext& context);
+
+  Result<std::shared_ptr<auth::AuthSession>> TableAuthSession(
+      const TableIdentifier& identifier,
+      const std::unordered_map<std::string, std::string>& table_config,
+      std::shared_ptr<auth::AuthSession> contextual_session);
+
+  Result<std::shared_ptr<FileIO>> TableFileIO(
+      const SessionContext& context,
+      const std::unordered_map<std::string, std::string>& table_config) const;
+
+  Result<std::vector<Namespace>> ListNamespaces(const Namespace& ns,
+                                                auth::AuthSession& session) const;
+
+  Status CreateNamespace(const Namespace& ns,
+                         const std::unordered_map<std::string, std::string>& properties,
+                         auth::AuthSession& session);
+
+  Result<std::unordered_map<std::string, std::string>> GetNamespaceProperties(
+      const Namespace& ns, auth::AuthSession& session) const;
+
+  Status DropNamespace(const Namespace& ns, auth::AuthSession& session);
+
+  Result<bool> NamespaceExists(const Namespace& ns, auth::AuthSession& session) const;
+
+  Status UpdateNamespaceProperties(
+      const Namespace& ns, const std::unordered_map<std::string, std::string>& updates,
+      const std::unordered_set<std::string>& removals, auth::AuthSession& session);
+
+  Result<std::vector<TableIdentifier>> ListTables(const Namespace& ns,
+                                                  auth::AuthSession& session) const;
+
+  Result<std::shared_ptr<Table>> CreateTable(
+      const TableIdentifier& identifier, const std::shared_ptr<Schema>& schema,
+      const std::shared_ptr<PartitionSpec>& spec, const std::shared_ptr<SortOrder>& order,
+      const std::string& location,
+      const std::unordered_map<std::string, std::string>& properties,
+      const SessionContext& context,
+      std::shared_ptr<auth::AuthSession> contextual_session);
+
+  Result<std::shared_ptr<Table>> UpdateTable(
+      const TableIdentifier& identifier,
+      const std::vector<std::unique_ptr<TableRequirement>>& requirements,
+      const std::vector<std::unique_ptr<TableUpdate>>& updates,
+      const SessionContext& context,
+      std::shared_ptr<auth::AuthSession> contextual_session);
+
+  Result<std::shared_ptr<Transaction>> StageCreateTable(
+      const TableIdentifier& identifier, const std::shared_ptr<Schema>& schema,
+      const std::shared_ptr<PartitionSpec>& spec, const std::shared_ptr<SortOrder>& order,
+      const std::string& location,
+      const std::unordered_map<std::string, std::string>& properties,
+      const SessionContext& context,
+      std::shared_ptr<auth::AuthSession> contextual_session);
+
+  Result<bool> TableExists(const TableIdentifier& identifier,
+                           auth::AuthSession& session) const;
+
+  Status RenameTable(const TableIdentifier& from, const TableIdentifier& to,
+                     auth::AuthSession& session);
+
+  Status DropTable(const TableIdentifier& identifier, bool purge,
+                   auth::AuthSession& session);
+
+  Result<std::shared_ptr<Table>> LoadTable(
+      const TableIdentifier& identifier, const SessionContext& context,
+      std::shared_ptr<auth::AuthSession> request_session,
+      std::shared_ptr<auth::AuthSession> contextual_session);
+
+  Result<std::shared_ptr<Table>> RegisterTable(
+      const TableIdentifier& identifier, const std::string& metadata_file_location,
+      const SessionContext& context,
+      std::shared_ptr<auth::AuthSession> contextual_session);
+
+  Result<LoadTableResult> LoadTableInternal(const TableIdentifier& identifier,
+                                            auth::AuthSession& session) const;
 
   Result<LoadTableResult> CreateTableInternal(
       const TableIdentifier& identifier, const std::shared_ptr<Schema>& schema,
       const std::shared_ptr<PartitionSpec>& spec, const std::shared_ptr<SortOrder>& order,
       const std::string& location,
-      const std::unordered_map<std::string, std::string>& properties, bool stage_create);
+      const std::unordered_map<std::string, std::string>& properties, bool stage_create,
+      auth::AuthSession& session);
+
+  Result<CommitTableResponse> UpdateTableInternal(
+      const TableIdentifier& identifier,
+      const std::vector<std::unique_ptr<TableRequirement>>& requirements,
+      const std::vector<std::unique_ptr<TableUpdate>>& updates,
+      auth::AuthSession& session);
+
+  Result<std::shared_ptr<Table>> MakeTableFromLoadResult(
+      const TableIdentifier& identifier, LoadTableResult result,
+      const SessionContext& context,
+      std::shared_ptr<auth::AuthSession> contextual_session);
+
+  Result<std::shared_ptr<Table>> MakeTableFromCommitResponse(
+      const TableIdentifier& identifier, CommitTableResponse response,
+      const SessionContext& context,
+      const std::unordered_map<std::string, std::string>& table_config,
+      std::shared_ptr<auth::AuthSession> table_session);
 
   RestCatalogProperties config_;
   std::shared_ptr<FileIO> file_io_;
@@ -124,6 +180,8 @@ class ICEBERG_REST_EXPORT RestCatalog : public Catalog,
   std::unique_ptr<auth::AuthManager> auth_manager_;
   std::shared_ptr<auth::AuthSession> catalog_session_;
   SnapshotMode snapshot_mode_;
+  SessionContext default_context_;
+  std::shared_ptr<Catalog> default_catalog_;
 };
 
 }  // namespace iceberg::rest

--- a/src/iceberg/catalog/session_catalog.cc
+++ b/src/iceberg/catalog/session_catalog.cc
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/catalog/session_catalog.h"
+
+namespace iceberg {
+
+SessionCatalog::SessionCatalog() = default;
+
+SessionCatalog::~SessionCatalog() = default;
+
+}  // namespace iceberg

--- a/src/iceberg/catalog/session_catalog.h
+++ b/src/iceberg/catalog/session_catalog.h
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string_view>
+
+#include "iceberg/iceberg_export.h"
+#include "iceberg/result.h"
+#include "iceberg/type_fwd.h"
+
+namespace iceberg {
+
+class Catalog;
+
+/// \brief Factory interface for creating context-bound catalog views.
+///
+/// `SessionCatalog` is not a replacement for `Catalog` and does not duplicate
+/// table or namespace operations. It is a small root interface for catalogs that
+/// can bind the standard `Catalog` API to a `SessionContext`.
+///
+/// Call `AsCatalog()` for the catalog's default session, or `WithContext()` when
+/// the caller has an explicit session identity, properties, or credentials.
+class ICEBERG_EXPORT SessionCatalog {
+ public:
+  virtual ~SessionCatalog() = default;
+
+  /// \brief Catalog name.
+  virtual std::string_view name() const = 0;
+
+  /// \brief Return a `Catalog` view bound to the catalog's default session.
+  ///
+  /// Implementations may cache and return the same default catalog view on
+  /// repeated calls.
+  virtual Result<std::shared_ptr<Catalog>> AsCatalog() = 0;
+
+  /// \brief Return a `Catalog` view bound to the supplied session context.
+  ///
+  /// Implementations should reject invalid contexts, such as an empty
+  /// `SessionContext::session_id`. Returned catalog views use the normal
+  /// `Catalog` interface for all table and namespace operations.
+  virtual Result<std::shared_ptr<Catalog>> WithContext(SessionContext context) = 0;
+};
+
+}  // namespace iceberg

--- a/src/iceberg/catalog/session_catalog.h
+++ b/src/iceberg/catalog/session_catalog.h
@@ -40,7 +40,7 @@ class Catalog;
 /// the caller has an explicit session identity, properties, or credentials.
 class ICEBERG_EXPORT SessionCatalog {
  public:
-  virtual ~SessionCatalog() = default;
+  virtual ~SessionCatalog();
 
   /// \brief Catalog name.
   virtual std::string_view name() const = 0;
@@ -57,6 +57,9 @@ class ICEBERG_EXPORT SessionCatalog {
   /// `SessionContext::session_id`. Returned catalog views use the normal
   /// `Catalog` interface for all table and namespace operations.
   virtual Result<std::shared_ptr<Catalog>> WithContext(SessionContext context) = 0;
+
+ protected:
+  SessionCatalog();
 };
 
 }  // namespace iceberg

--- a/src/iceberg/catalog/session_context.cc
+++ b/src/iceberg/catalog/session_context.cc
@@ -17,31 +17,14 @@
  * under the License.
  */
 
-#pragma once
+#include "iceberg/catalog/session_context.h"
 
-/// \file iceberg/catalog/rest/type_fwd.h
-/// Forward declarations and enum definitions for Iceberg REST API types.
+#include "iceberg/util/uuid.h"
 
-namespace iceberg::rest {
+namespace iceberg {
 
-struct ErrorResponse;
-struct CommitTableResponse;
-struct LoadTableResult;
-struct OAuthTokenResponse;
+SessionContext SessionContext::Empty() {
+  return SessionContext{.session_id = Uuid::GenerateV4().ToString()};
+}
 
-class Endpoint;
-class ErrorHandler;
-class HttpClient;
-class ResourcePaths;
-class RestCatalog;
-class RestCatalogProperties;
-
-}  // namespace iceberg::rest
-
-namespace iceberg::rest::auth {
-
-class AuthManager;
-class AuthProperties;
-class AuthSession;
-
-}  // namespace iceberg::rest::auth
+}  // namespace iceberg

--- a/src/iceberg/catalog/session_context.h
+++ b/src/iceberg/catalog/session_context.h
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "iceberg/iceberg_export.h"
+
+namespace iceberg {
+
+/// \brief Session state used to bind catalog operations to a caller context.
+///
+/// Session context is the isolation boundary for session-aware catalogs. REST
+/// catalogs use `session_id` to derive contextual authentication sessions while
+/// keeping user-visible catalog operations on the normal `Catalog` interface.
+///
+/// The type is intentionally an aggregate so callers can construct it with
+/// designated initializers. `properties` and `credentials` are kept separate so
+/// authentication implementations can detect conflicting keys instead of
+/// silently overriding credentials.
+struct ICEBERG_EXPORT SessionContext {
+  /// Unique session identifier. Explicit contexts must provide a non-empty ID.
+  std::string session_id;
+
+  /// Caller identity. Empty means no identity was supplied. This value is
+  /// descriptive and is not implicitly inserted into authentication properties.
+  std::string identity;
+
+  /// Sensitive context-specific credentials, such as delegated auth material.
+  std::unordered_map<std::string, std::string> credentials;
+
+  /// Non-secret context-specific properties, such as tenant or auth options.
+  std::unordered_map<std::string, std::string> properties;
+
+  /// \brief Create an empty caller context with a generated non-empty session ID.
+  ///
+  /// Each call returns a distinct session ID.
+  static SessionContext Empty();
+};
+
+}  // namespace iceberg

--- a/src/iceberg/meson.build
+++ b/src/iceberg/meson.build
@@ -44,6 +44,7 @@ iceberg_sources = files(
     'arrow_c_data_guard_internal.cc',
     'arrow_c_data_util.cc',
     'catalog/memory/in_memory_catalog.cc',
+    'catalog/session_catalog.cc',
     'catalog/session_context.cc',
     'delete_file_index.cc',
     'expression/aggregate.cc',

--- a/src/iceberg/meson.build
+++ b/src/iceberg/meson.build
@@ -44,6 +44,7 @@ iceberg_sources = files(
     'arrow_c_data_guard_internal.cc',
     'arrow_c_data_util.cc',
     'catalog/memory/in_memory_catalog.cc',
+    'catalog/session_context.cc',
     'delete_file_index.cc',
     'expression/aggregate.cc',
     'expression/binder.cc',

--- a/src/iceberg/test/auth_manager_test.cc
+++ b/src/iceberg/test/auth_manager_test.cc
@@ -40,6 +40,7 @@
 #include "iceberg/catalog/rest/error_handlers.h"
 #include "iceberg/catalog/rest/http_client.h"
 #include "iceberg/catalog/rest/json_serde_internal.h"
+#include "iceberg/catalog/session_context.h"
 #include "iceberg/json_serde_internal.h"
 #include "iceberg/test/matchers.h"
 #include "iceberg/util/base64.h"
@@ -88,6 +89,21 @@ TEST_F(AuthManagerTest, LoadNoopAuthManagerExplicit) {
 TEST_F(AuthManagerTest, LoadNoopAuthManagerInferred) {
   auto manager_result = AuthManagers::Load("test-catalog", {});
   ASSERT_THAT(manager_result, IsOk());
+}
+
+TEST_F(AuthManagerTest, NoopContextualSessionReturnsParentSession) {
+  ICEBERG_UNWRAP_OR_FAIL(auto manager, AuthManagers::Load("test-catalog", {}));
+  ICEBERG_UNWRAP_OR_FAIL(auto parent, manager->CatalogSession(client_, {}));
+
+  SessionContext context{
+      .session_id = "tenant-a",
+      .identity = "user-a",
+      .credentials = {{"credential-key", "credential-value"}},
+      .properties = {{"property-key", "property-value"}},
+  };
+  ICEBERG_UNWRAP_OR_FAIL(auto contextual, manager->ContextualSession(context, parent));
+
+  EXPECT_EQ(contextual, parent);
 }
 
 TEST_F(AuthManagerTest, HttpHeadersAreCaseInsensitiveSingleValueMap) {

--- a/src/iceberg/test/rest_catalog_integration_test.cc
+++ b/src/iceberg/test/rest_catalog_integration_test.cc
@@ -39,6 +39,7 @@
 #include "iceberg/catalog/rest/http_client.h"
 #include "iceberg/catalog/rest/json_serde_internal.h"
 #include "iceberg/catalog/rest/rest_catalog.h"
+#include "iceberg/catalog/session_context.h"
 #include "iceberg/file_io_registry.h"
 #include "iceberg/partition_spec.h"
 #include "iceberg/result.h"
@@ -123,12 +124,12 @@ class RestCatalogIntegrationTest : public ::testing::Test {
   static void TearDownTestSuite() { docker_compose_.reset(); }
 
   /// Create a catalog with default configuration.
-  Result<std::shared_ptr<RestCatalog>> CreateCatalog() {
+  Result<std::shared_ptr<Catalog>> CreateCatalog() {
     return CreateCatalogWithProperties({});
   }
 
   /// Create a catalog with additional properties merged on top of defaults.
-  Result<std::shared_ptr<RestCatalog>> CreateCatalogWithProperties(
+  Result<std::shared_ptr<Catalog>> CreateCatalogWithProperties(
       const std::unordered_map<std::string, std::string>& extra) {
     auto config = RestCatalogProperties::default_properties();
     config.Set(RestCatalogProperties::kUri, CatalogUri())
@@ -139,18 +140,19 @@ class RestCatalogIntegrationTest : public ::testing::Test {
     for (const auto& [k, v] : extra) {
       config.mutable_configs()[k] = v;
     }
-    return RestCatalog::Make(config);
+    ICEBERG_ASSIGN_OR_RAISE(auto root, RestCatalog::Make(config));
+    return root->AsCatalog();
   }
 
   /// Create a catalog configured with a specific snapshot loading mode.
-  Result<std::shared_ptr<RestCatalog>> CreateCatalogWithSnapshotMode(
+  Result<std::shared_ptr<Catalog>> CreateCatalogWithSnapshotMode(
       const std::string& mode) {
     return CreateCatalogWithProperties(
         {{RestCatalogProperties::kSnapshotLoadingMode.key(), mode}});
   }
 
   /// Convenience: create a namespace and return the catalog.
-  Result<std::shared_ptr<RestCatalog>> CreateCatalogAndNamespace(const Namespace& ns) {
+  Result<std::shared_ptr<Catalog>> CreateCatalogAndNamespace(const Namespace& ns) {
     ICEBERG_ASSIGN_OR_RAISE(auto catalog, CreateCatalog());
     auto status = catalog->CreateNamespace(ns, {});
     if (!status.has_value()) {
@@ -169,7 +171,7 @@ class RestCatalogIntegrationTest : public ::testing::Test {
 
   /// Create a table with default schema and no partitioning.
   Result<std::shared_ptr<Table>> CreateDefaultTable(
-      const std::shared_ptr<RestCatalog>& catalog, const TableIdentifier& table_id,
+      const std::shared_ptr<Catalog>& catalog, const TableIdentifier& table_id,
       const std::unordered_map<std::string, std::string>& props = {}) {
     return catalog->CreateTable(table_id, DefaultSchema(), PartitionSpec::Unpartitioned(),
                                 SortOrder::Unsorted(), "", props);
@@ -179,8 +181,26 @@ class RestCatalogIntegrationTest : public ::testing::Test {
 };
 
 TEST_F(RestCatalogIntegrationTest, MakeCatalogSuccess) {
-  ICEBERG_UNWRAP_OR_FAIL(auto catalog, CreateCatalog());
-  EXPECT_EQ(catalog->name(), kCatalogName);
+  auto config = RestCatalogProperties::default_properties();
+  config.Set(RestCatalogProperties::kUri, CatalogUri())
+      .Set(RestCatalogProperties::kName, std::string(kCatalogName))
+      .Set(RestCatalogProperties::kWarehouse, std::string(kWarehouseName));
+  config.mutable_configs()[std::string(RestCatalogProperties::kIOImpl.key())] =
+      std::string(kStdFileIOImpl);
+
+  ICEBERG_UNWRAP_OR_FAIL(auto root, RestCatalog::Make(config));
+  EXPECT_EQ(root->name(), kCatalogName);
+
+  ICEBERG_UNWRAP_OR_FAIL(auto first_default, root->AsCatalog());
+  ICEBERG_UNWRAP_OR_FAIL(auto second_default, root->AsCatalog());
+  EXPECT_EQ(first_default, second_default);
+
+  SessionContext context{.session_id = "tenant-a"};
+  ICEBERG_UNWRAP_OR_FAIL(auto first_context, root->WithContext(context));
+  ICEBERG_UNWRAP_OR_FAIL(auto second_context, root->WithContext(context));
+  EXPECT_NE(first_context, second_context);
+
+  EXPECT_THAT(root->WithContext(SessionContext{}), IsError(ErrorKind::kInvalidArgument));
 }
 
 TEST_F(RestCatalogIntegrationTest, FetchServerConfigDirect) {
@@ -418,6 +438,49 @@ TEST_F(RestCatalogIntegrationTest, UpdateTable) {
   EXPECT_EQ(updated->metadata()->properties.configs().at("key1"), "value1");
 }
 
+TEST_F(RestCatalogIntegrationTest, LoadedTableUsesTableScopedCatalog) {
+  // TODO(gangwu): Add a focused mock REST server/auth manager test that
+  // asserts exact ContextualSession and TableSession inputs, including table
+  // response config. The Docker REST fixture currently returns empty config.
+  Namespace ns{.levels = {"test_table_scoped_catalog"}};
+  ICEBERG_UNWRAP_OR_FAIL(auto catalog, CreateCatalogAndNamespace(ns));
+
+  TableIdentifier table_id{.ns = ns, .name = "t1"};
+  ASSERT_THAT(CreateDefaultTable(catalog, table_id), IsOk());
+
+  ICEBERG_UNWRAP_OR_FAIL(auto loaded, catalog->LoadTable(table_id));
+  ASSERT_THAT(loaded->Refresh(), IsOk());
+
+  TableIdentifier other_id{.ns = ns, .name = "other"};
+  EXPECT_THAT(loaded->catalog()->LoadTable(other_id),
+              IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(loaded->catalog()->CreateTable(other_id, DefaultSchema(),
+                                             PartitionSpec::Unpartitioned(),
+                                             SortOrder::Unsorted(), "", {}),
+              IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(loaded->catalog()->StageCreateTable(other_id, DefaultSchema(),
+                                                  PartitionSpec::Unpartitioned(),
+                                                  SortOrder::Unsorted(), "", {}),
+              IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(loaded->catalog()->RegisterTable(other_id, "file:/tmp/metadata.json"),
+              IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(loaded->catalog()->DropTable(other_id, /*purge=*/false),
+              IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(loaded->catalog()->DropTable(table_id, /*purge=*/false),
+              IsError(ErrorKind::kNotSupported));
+
+  std::vector<std::unique_ptr<TableRequirement>> requirements;
+  requirements.push_back(std::make_unique<table::AssertUUID>(loaded->uuid()));
+
+  std::vector<std::unique_ptr<TableUpdate>> updates;
+  updates.push_back(std::make_unique<table::SetProperties>(
+      std::unordered_map<std::string, std::string>{{"scoped", "true"}}));
+
+  ICEBERG_UNWRAP_OR_FAIL(auto updated,
+                         loaded->catalog()->UpdateTable(table_id, requirements, updates));
+  EXPECT_EQ(updated->metadata()->properties.configs().at("scoped"), "true");
+}
+
 TEST_F(RestCatalogIntegrationTest, RegisterTable) {
   Namespace ns{.levels = {"test_register_table"}};
   ICEBERG_UNWRAP_OR_FAIL(auto catalog, CreateCatalogAndNamespace(ns));
@@ -446,6 +509,12 @@ TEST_F(RestCatalogIntegrationTest, StageCreateTable) {
                                 SortOrder::Unsorted(), "", {{"key1", "value1"}}));
 
   EXPECT_EQ(txn->table()->name(), table_id);
+
+  TableIdentifier other_id{.ns = ns, .name = "other"};
+  EXPECT_THAT(txn->table()->catalog()->LoadTable(other_id),
+              IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(txn->table()->catalog()->DropTable(table_id, /*purge=*/false),
+              IsError(ErrorKind::kNotSupported));
 
   // Not yet visible in catalog
   ICEBERG_UNWRAP_OR_FAIL(auto before, catalog->TableExists(table_id));

--- a/src/iceberg/test/sigv4_auth_test.cc
+++ b/src/iceberg/test/sigv4_auth_test.cc
@@ -38,6 +38,7 @@
 #  include "iceberg/catalog/rest/auth/auth_session.h"
 #  include "iceberg/catalog/rest/auth/sigv4_auth_manager_internal.h"
 #  include "iceberg/catalog/rest/http_client.h"
+#  include "iceberg/catalog/session_context.h"
 #  include "iceberg/table_identifier.h"
 #  include "iceberg/test/matchers.h"
 
@@ -403,7 +404,10 @@ TEST_F(SigV4AuthTest, DerivedCredentialOverridesMustBeComplete) {
                          manager->CatalogSession(client_, properties));
 
   auto context_result = manager->ContextualSession(
-      {{AuthProperties::kSigV4SecretAccessKey, "context-secret"}}, catalog_session);
+      SessionContext{
+          .session_id = "ctx-incomplete",
+          .properties = {{AuthProperties::kSigV4SecretAccessKey, "context-secret"}}},
+      catalog_session);
   EXPECT_THAT(context_result, IsError(ErrorKind::kInvalidArgument));
   EXPECT_THAT(context_result, HasErrorMessage("must be set together"));
 
@@ -447,10 +451,13 @@ TEST_F(SigV4AuthTest, ContextualSessionOverridesProperties) {
 
   ICEBERG_UNWRAP_OR_FAIL(
       auto ctx_session,
-      manager->ContextualSession({{AuthProperties::kSigV4AccessKeyId, "id2"},
-                                  {AuthProperties::kSigV4SecretAccessKey, "secret2"},
-                                  {AuthProperties::kSigV4SigningRegion, "eu-west-1"}},
-                                 catalog_session));
+      manager->ContextualSession(
+          SessionContext{
+              .session_id = "ctx-overrides",
+              .credentials = {{AuthProperties::kSigV4AccessKeyId, "id2"},
+                              {AuthProperties::kSigV4SecretAccessKey, "secret2"}},
+              .properties = {{AuthProperties::kSigV4SigningRegion, "eu-west-1"}}},
+          catalog_session));
 
   ICEBERG_UNWRAP_OR_FAIL(
       auto signed_request,
@@ -492,8 +499,11 @@ TEST_F(SigV4AuthTest, TableSessionIgnoresContextualOverrides) {
                          manager->CatalogSession(client_, properties));
   ICEBERG_UNWRAP_OR_FAIL(
       auto ctx_session,
-      manager->ContextualSession({{AuthProperties::kSigV4SigningRegion, "eu-west-1"}},
-                                 catalog_session));
+      manager->ContextualSession(
+          SessionContext{
+              .session_id = "ctx-region",
+              .properties = {{AuthProperties::kSigV4SigningRegion, "eu-west-1"}}},
+          catalog_session));
 
   iceberg::TableIdentifier table_id{.ns = iceberg::Namespace{{"db1"}}, .name = "table1"};
   ICEBERG_UNWRAP_OR_FAIL(auto table_session,
@@ -505,6 +515,23 @@ TEST_F(SigV4AuthTest, TableSessionIgnoresContextualOverrides) {
                                    .url = "https://example.com/v1/db1/tables/table1"}));
   EXPECT_THAT(HeaderValue(signed_request.headers, "authorization"),
               HasSubstr("us-west-2"));
+}
+
+TEST_F(SigV4AuthTest, ContextualSessionRejectsConflictingKeys) {
+  auto properties = MakeSigV4Properties();
+  ICEBERG_UNWRAP_OR_FAIL(auto manager, AuthManagers::Load("test-catalog", properties));
+  ICEBERG_UNWRAP_OR_FAIL(auto catalog_session,
+                         manager->CatalogSession(client_, properties));
+
+  auto result = manager->ContextualSession(
+      SessionContext{
+          .session_id = "ctx-conflict",
+          .credentials = {{AuthProperties::kSigV4AccessKeyId, "credential-id"}},
+          .properties = {{AuthProperties::kSigV4AccessKeyId, "property-id"}}},
+      catalog_session);
+
+  EXPECT_THAT(result, IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(result, HasErrorMessage("conflicting values"));
 }
 
 }  // namespace iceberg::rest::auth

--- a/src/iceberg/type_fwd.h
+++ b/src/iceberg/type_fwd.h
@@ -207,6 +207,8 @@ using UncheckedStructLikeSet = StructLikeSet<false>;
 /// \brief Catalog
 class Catalog;
 class LocationProvider;
+class SessionCatalog;
+struct SessionContext;
 
 /// \brief Table.
 class Table;


### PR DESCRIPTION
Add SessionContext and SessionCatalog APIs, make RestCatalog a session-aware root, and bind REST catalog operations through default, contextual, and table-scoped catalog views.

Route contextual and table auth through AuthManager, preserve table response config for scoped catalogs, and fail closed on unsupported table FileIO config.