### PR TITLE
fix: avoid signed overflow in integer truncation

### DIFF
--- a/src/iceberg/test/truncate_util_test.cc
+++ b/src/iceberg/test/truncate_util_test.cc
@@ -19,6 +19,8 @@
 
 #include "iceberg/util/truncate_util.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "iceberg/expression/literal.h"
@@ -49,6 +51,19 @@ TEST(TruncateUtilTest, TruncateLiteral) {
   EXPECT_EQ(TruncateUtils::TruncateLiteral(
                 Literal::Binary(std::vector<uint8_t>(data.begin(), data.end())), 3),
             Literal::Binary(std::vector<uint8_t>(expected.begin(), expected.end())));
+}
+
+TEST(TruncateUtilTest, TruncateLiteralAvoidsSignedIntegerOverflow) {
+  EXPECT_EQ(TruncateUtils::TruncateLiteral(
+                Literal::Int(std::numeric_limits<int32_t>::max() - 1),
+                std::numeric_limits<int32_t>::max()),
+            Literal::Int(0));
+  EXPECT_EQ(TruncateUtils::TruncateLiteral(
+                Literal::Int(std::numeric_limits<int32_t>::min()), 10),
+            Literal::Int(std::numeric_limits<int32_t>::max() - 1));
+  EXPECT_EQ(TruncateUtils::TruncateLiteral(
+                Literal::Long(std::numeric_limits<int64_t>::min()), 10),
+            Literal::Long(std::numeric_limits<int64_t>::max() - 1));
 }
 
 TEST(TruncateUtilTest, TruncateLiteralRejectsInvalidWidth) {

--- a/src/iceberg/util/truncate_util.h
+++ b/src/iceberg/util/truncate_util.h
@@ -22,11 +22,13 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "iceberg/iceberg_export.h"
 #include "iceberg/result.h"
 #include "iceberg/type_fwd.h"
+#include "iceberg/util/int128.h"
 
 namespace iceberg {
 
@@ -84,7 +86,15 @@ class ICEBERG_EXPORT TruncateUtils {
   template <typename T>
     requires std::is_same_v<T, int32_t> || std::is_same_v<T, int64_t>
   static inline T TruncateInteger(T v, int32_t W) {
-    return v - (((v % W) + W) % W);
+    using WideInt = std::conditional_t<std::is_same_v<T, int32_t>, int64_t, int128_t>;
+    using UnsignedT = std::make_unsigned_t<T>;
+
+    const auto value = static_cast<WideInt>(v);
+    const auto width = static_cast<WideInt>(W);
+    const auto remainder = ((value % width) + width) % width;
+    const auto truncated = value - remainder;
+    // Preserve modulo conversion when the mathematical result is below the signed range.
+    return static_cast<T>(static_cast<UnsignedT>(truncated));
   }
 
   /// \brief Truncate a Decimal to a specified width.


### PR DESCRIPTION
## Summary

- evaluate integer truncation arithmetic in a wider signed type to avoid signed overflow
- preserve modulo conversion when the mathematical result falls below the source type's signed range
- add regression coverage for large positive widths and `int32_t` / `int64_t` minimum values

## Testing

- `cmake -S . -B build-truncate -G Ninja -DICEBERG_BUILD_BUNDLE=OFF -DICEBERG_BUILD_REST=OFF -DICEBERG_BUILD_SHARED=OFF -DICEBERG_ENABLE_UBSAN=ON`
- `UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 ctest --test-dir build-truncate -R util_test --output-on-failure`
