### PR TITLE
fix(scan): reject missing column stats fields

### DIFF
--- a/src/iceberg/table_scan.cc
+++ b/src/iceberg/table_scan.cc
@@ -400,9 +400,8 @@ Status TableScanBuilder<ScanType>::ResolveColumnStatsSelection() {
   const auto& schema = schema_ref.get();
   for (const auto& column_name : *requested_column_stats_) {
     ICEBERG_ASSIGN_OR_RAISE(auto field, schema->FindFieldByName(column_name));
-    if (field.has_value()) {
-      context_.columns_to_keep_stats.insert(field.value().get().field_id());
-    }
+    ICEBERG_CHECK(field.has_value(), "Cannot find stats column: {}", column_name);
+    context_.columns_to_keep_stats.insert(field.value().get().field_id());
   }
 
   return {};

--- a/src/iceberg/test/table_scan_test.cc
+++ b/src/iceberg/test/table_scan_test.cc
@@ -285,6 +285,16 @@ TEST_P(TableScanTest, IncludeColumnStatsUsesFinalSnapshotSchema) {
   }
 }
 
+TEST_P(TableScanTest, IncludeColumnStatsRejectsMissingColumn) {
+  ICEBERG_UNWRAP_OR_FAIL(auto builder,
+                         DataTableScanBuilder::Make(table_metadata_, file_io_));
+  builder->IncludeColumnStats({"missing"});
+
+  EXPECT_THAT(builder->Build(),
+              ::testing::AllOf(IsError(ErrorKind::kValidationFailed),
+                               HasErrorMessage("Cannot find stats column: missing")));
+}
+
 TEST_P(TableScanTest, TableScanBuilderValidationErrors) {
   // Test negative min rows
   ICEBERG_UNWRAP_OR_FAIL(auto builder,


### PR DESCRIPTION
## Summary
- validate `IncludeColumnStats()` column names against the resolved snapshot schema during scan build
- return a validation error when requested stats columns are missing instead of silently dropping them
- leave `Schema::Select()` and regular scan projection semantics unchanged

## Tests
- `pre-commit run --all-files`
- `cmake --build build --target scan_test`
- `ctest --test-dir build -R '^scan_test$' --output-on-failure`