### PR TITLE
fix(rest): align error handlers with Java implementation

### DIFF
--- a/src/iceberg/catalog/rest/auth/oauth2_util.cc
+++ b/src/iceberg/catalog/rest/auth/oauth2_util.cc
@@ -66,7 +66,7 @@ Result<OAuthTokenResponse> FetchToken(HttpClient& client, AuthSession& session,
   ICEBERG_ASSIGN_OR_RAISE(
       auto response,
       client.PostForm(properties.oauth2_server_uri(), form_data,
-                      /*headers=*/{}, *DefaultErrorHandler::Instance(), session));
+                      /*headers=*/{}, *OAuthErrorHandler::Instance(), session));
 
   ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
   ICEBERG_ASSIGN_OR_RAISE(auto token_response, FromJson<OAuthTokenResponse>(json));

--- a/src/iceberg/catalog/rest/error_handlers.cc
+++ b/src/iceberg/catalog/rest/error_handlers.cc
@@ -31,8 +31,26 @@ constexpr std::string_view kIllegalArgumentException = "IllegalArgumentException
 constexpr std::string_view kNoSuchNamespaceException = "NoSuchNamespaceException";
 constexpr std::string_view kNamespaceNotEmptyException = "NamespaceNotEmptyException";
 constexpr std::string_view kNoSuchTableException = "NoSuchTableException";
-constexpr std::string_view kNoSuchPlanIdException = "NoSuchPlanIdException";
-constexpr std::string_view kNoSuchPlanTaskException = "NoSuchPlanTaskException";
+constexpr std::string_view kNotFoundException = "NotFoundException";
+constexpr std::string_view kInvalidClient = "invalid_client";
+constexpr std::string_view kInvalidRequest = "invalid_request";
+constexpr std::string_view kInvalidGrant = "invalid_grant";
+constexpr std::string_view kUnauthorizedClient = "unauthorized_client";
+constexpr std::string_view kUnsupportedGrantType = "unsupported_grant_type";
+constexpr std::string_view kInvalidScope = "invalid_scope";
+constexpr std::string_view kNull = "null";
+
+std::string_view NullIfEmpty(const std::string& value) {
+  if (value.empty()) {
+    return kNull;
+  }
+  return value;
+}
+
+Status CreateRestError(const ErrorResponse& error) {
+  return RestError("Unable to process (code: {}, type: {}): {}", error.code,
+                   NullIfEmpty(error.type), NullIfEmpty(error.message));
+}
 
 }  // namespace
 
@@ -63,7 +81,7 @@ Status DefaultErrorHandler::Accept(const ErrorResponse& error) const {
       return ServiceUnavailable("Service unavailable: {}", error.message);
   }
 
-  return RestError("Code: {}, message: {}", error.code, error.message);
+  return CreateRestError(error);
 }
 
 const std::shared_ptr<NamespaceErrorHandler>& NamespaceErrorHandler::Instance() {
@@ -84,7 +102,7 @@ Status NamespaceErrorHandler::Accept(const ErrorResponse& error) const {
     case 409:
       return AlreadyExists(error.message);
     case 422:
-      return RestError("Unable to process: {}", error.message);
+      return CreateRestError(error);
   }
 
   return DefaultErrorHandler::Accept(error);
@@ -104,6 +122,19 @@ Status DropNamespaceErrorHandler::Accept(const ErrorResponse& error) const {
   return NamespaceErrorHandler::Accept(error);
 }
 
+const std::shared_ptr<ConfigErrorHandler>& ConfigErrorHandler::Instance() {
+  static const std::shared_ptr<ConfigErrorHandler> instance{new ConfigErrorHandler()};
+  return instance;
+}
+
+Status ConfigErrorHandler::Accept(const ErrorResponse& error) const {
+  if (error.code == 404 && !error.type.empty()) {
+    return NoSuchWarehouse(error.message);
+  }
+
+  return DefaultErrorHandler::Accept(error);
+}
+
 const std::shared_ptr<TableErrorHandler>& TableErrorHandler::Instance() {
   static const std::shared_ptr<TableErrorHandler> instance{new TableErrorHandler()};
   return instance;
@@ -115,26 +146,10 @@ Status TableErrorHandler::Accept(const ErrorResponse& error) const {
       if (error.type == kNoSuchNamespaceException) {
         return NoSuchNamespace(error.message);
       }
-      return NoSuchTable(error.message);
-    case 409:
-      return AlreadyExists(error.message);
-  }
-
-  return DefaultErrorHandler::Accept(error);
-}
-
-const std::shared_ptr<ViewErrorHandler>& ViewErrorHandler::Instance() {
-  static const std::shared_ptr<ViewErrorHandler> instance{new ViewErrorHandler()};
-  return instance;
-}
-
-Status ViewErrorHandler::Accept(const ErrorResponse& error) const {
-  switch (error.code) {
-    case 404:
-      if (error.type == kNoSuchNamespaceException) {
-        return NoSuchNamespace(error.message);
+      if (error.type == kNotFoundException) {
+        return NotFound(error.message);
       }
-      return NoSuchView(error.message);
+      return NoSuchTable(error.message);
     case 409:
       return AlreadyExists(error.message);
   }
@@ -164,6 +179,23 @@ Status TableCommitErrorHandler::Accept(const ErrorResponse& error) const {
   return DefaultErrorHandler::Accept(error);
 }
 
+const std::shared_ptr<CreateTableErrorHandler>& CreateTableErrorHandler::Instance() {
+  static const std::shared_ptr<CreateTableErrorHandler> instance{
+      new CreateTableErrorHandler()};
+  return instance;
+}
+
+Status CreateTableErrorHandler::Accept(const ErrorResponse& error) const {
+  switch (error.code) {
+    case 404:
+      return NoSuchNamespace(error.message);
+    case 409:
+      return AlreadyExists(error.message);
+  }
+
+  return TableCommitErrorHandler::Accept(error);
+}
+
 const std::shared_ptr<ViewCommitErrorHandler>& ViewCommitErrorHandler::Instance() {
   static const std::shared_ptr<ViewCommitErrorHandler> instance{
       new ViewCommitErrorHandler()};
@@ -186,6 +218,25 @@ Status ViewCommitErrorHandler::Accept(const ErrorResponse& error) const {
   return DefaultErrorHandler::Accept(error);
 }
 
+const std::shared_ptr<ViewErrorHandler>& ViewErrorHandler::Instance() {
+  static const std::shared_ptr<ViewErrorHandler> instance{new ViewErrorHandler()};
+  return instance;
+}
+
+Status ViewErrorHandler::Accept(const ErrorResponse& error) const {
+  switch (error.code) {
+    case 404:
+      if (error.type == kNoSuchNamespaceException) {
+        return NoSuchNamespace(error.message);
+      }
+      return NoSuchView(error.message);
+    case 409:
+      return AlreadyExists(error.message);
+  }
+
+  return DefaultErrorHandler::Accept(error);
+}
+
 const std::shared_ptr<PlanErrorHandler>& PlanErrorHandler::Instance() {
   static const std::shared_ptr<PlanErrorHandler> instance{new PlanErrorHandler()};
   return instance;
@@ -200,12 +251,7 @@ Status PlanErrorHandler::Accept(const ErrorResponse& error) const {
       if (error.type == kNoSuchTableException) {
         return NoSuchTable(error.message);
       }
-      if (error.type == kNoSuchPlanIdException) {
-        return NoSuchPlanId(error.message);
-      }
-      return NotFound(error.message);
-    case 406:
-      return NotSupported(error.message);
+      return NoSuchPlanId(error.message);
   }
 
   return DefaultErrorHandler::Accept(error);
@@ -225,13 +271,32 @@ Status PlanTaskErrorHandler::Accept(const ErrorResponse& error) const {
       if (error.type == kNoSuchTableException) {
         return NoSuchTable(error.message);
       }
-      if (error.type == kNoSuchPlanTaskException) {
-        return NoSuchPlanTask(error.message);
-      }
-      return NotFound(error.message);
+      return NoSuchPlanTask(error.message);
   }
 
   return DefaultErrorHandler::Accept(error);
+}
+
+const std::shared_ptr<OAuthErrorHandler>& OAuthErrorHandler::Instance() {
+  static const std::shared_ptr<OAuthErrorHandler> instance{new OAuthErrorHandler()};
+  return instance;
+}
+
+Status OAuthErrorHandler::Accept(const ErrorResponse& error) const {
+  if (!error.type.empty()) {
+    if (error.type == kInvalidClient) {
+      return NotAuthorized("Not authorized: {}: {}", error.type,
+                           NullIfEmpty(error.message));
+    }
+    if (error.type == kInvalidRequest || error.type == kInvalidGrant ||
+        error.type == kUnauthorizedClient || error.type == kUnsupportedGrantType ||
+        error.type == kInvalidScope) {
+      return BadRequest("Malformed request: {}: {}", error.type,
+                        NullIfEmpty(error.message));
+    }
+  }
+
+  return CreateRestError(error);
 }
 
 }  // namespace iceberg::rest

--- a/src/iceberg/catalog/rest/error_handlers.cc
+++ b/src/iceberg/catalog/rest/error_handlers.cc
@@ -21,7 +21,11 @@
 
 #include <string_view>
 
+#include "iceberg/catalog/rest/json_serde_internal.h"
 #include "iceberg/catalog/rest/types.h"
+#include "iceberg/json_serde_internal.h"
+#include "iceberg/util/json_util_internal.h"
+#include "iceberg/util/macros.h"
 
 namespace iceberg::rest {
 
@@ -40,6 +44,8 @@ constexpr std::string_view kUnauthorizedClient = "unauthorized_client";
 constexpr std::string_view kUnsupportedGrantType = "unsupported_grant_type";
 constexpr std::string_view kInvalidScope = "invalid_scope";
 constexpr std::string_view kNull = "null";
+constexpr std::string_view kOAuthError = "error";
+constexpr std::string_view kOAuthErrorDescription = "error_description";
 
 std::string_view NullIfEmpty(const std::string& value) {
   if (value.empty()) {
@@ -83,6 +89,16 @@ Status DefaultErrorHandler::Accept(const ErrorResponse& error) const {
   }
 
   return CreateRestError(error);
+}
+
+Result<ErrorResponse> DefaultErrorHandler::ParseResponse(uint32_t /*code*/,
+                                                         const std::string& text) const {
+  if (text.empty()) {
+    return InvalidArgument("Empty response body");
+  }
+  ICEBERG_ASSIGN_OR_RAISE(auto json_result, FromJsonString(text));
+  ICEBERG_ASSIGN_OR_RAISE(auto error_result, ErrorResponseFromJson(json_result));
+  return error_result;
 }
 
 const std::shared_ptr<NamespaceErrorHandler>& NamespaceErrorHandler::Instance() {
@@ -298,6 +314,23 @@ Status OAuthErrorHandler::Accept(const ErrorResponse& error) const {
   }
 
   return CreateRestError(error);
+}
+
+Result<ErrorResponse> OAuthErrorHandler::ParseResponse(uint32_t code,
+                                                       const std::string& text) const {
+  if (text.empty()) {
+    return InvalidArgument("Empty response body");
+  }
+
+  ICEBERG_ASSIGN_OR_RAISE(auto json_result, FromJsonString(text));
+
+  ErrorResponse error;
+  error.code = code;
+  ICEBERG_ASSIGN_OR_RAISE(error.type,
+                          GetJsonValue<std::string>(json_result, kOAuthError));
+  ICEBERG_ASSIGN_OR_RAISE(error.message, GetJsonValueOrDefault<std::string>(
+                                             json_result, kOAuthErrorDescription));
+  return error;
 }
 
 }  // namespace iceberg::rest

--- a/src/iceberg/catalog/rest/error_handlers.cc
+++ b/src/iceberg/catalog/rest/error_handlers.cc
@@ -32,6 +32,7 @@ constexpr std::string_view kNoSuchNamespaceException = "NoSuchNamespaceException
 constexpr std::string_view kNamespaceNotEmptyException = "NamespaceNotEmptyException";
 constexpr std::string_view kNoSuchTableException = "NoSuchTableException";
 constexpr std::string_view kNotFoundException = "NotFoundException";
+constexpr std::string_view kRestException = "RESTException";
 constexpr std::string_view kInvalidClient = "invalid_client";
 constexpr std::string_view kInvalidRequest = "invalid_request";
 constexpr std::string_view kInvalidGrant = "invalid_grant";
@@ -128,7 +129,7 @@ const std::shared_ptr<ConfigErrorHandler>& ConfigErrorHandler::Instance() {
 }
 
 Status ConfigErrorHandler::Accept(const ErrorResponse& error) const {
-  if (error.code == 404 && !error.type.empty()) {
+  if (error.code == 404 && !error.type.empty() && error.type != kRestException) {
     return NoSuchWarehouse(error.message);
   }
 

--- a/src/iceberg/catalog/rest/error_handlers.h
+++ b/src/iceberg/catalog/rest/error_handlers.h
@@ -79,6 +79,18 @@ class ICEBERG_REST_EXPORT DropNamespaceErrorHandler final : public NamespaceErro
   constexpr DropNamespaceErrorHandler() = default;
 };
 
+/// \brief Error handler for the catalog config endpoint.
+class ICEBERG_REST_EXPORT ConfigErrorHandler final : public DefaultErrorHandler {
+ public:
+  /// \brief Returns the singleton instance
+  static const std::shared_ptr<ConfigErrorHandler>& Instance();
+
+  Status Accept(const ErrorResponse& error) const override;
+
+ private:
+  constexpr ConfigErrorHandler() = default;
+};
+
 /// \brief Table-level error handler.
 class ICEBERG_REST_EXPORT TableErrorHandler final : public DefaultErrorHandler {
  public:
@@ -91,6 +103,30 @@ class ICEBERG_REST_EXPORT TableErrorHandler final : public DefaultErrorHandler {
   constexpr TableErrorHandler() = default;
 };
 
+/// \brief Table commit operation error handler.
+class ICEBERG_REST_EXPORT TableCommitErrorHandler : public DefaultErrorHandler {
+ public:
+  /// \brief Returns the singleton instance
+  static const std::shared_ptr<TableCommitErrorHandler>& Instance();
+
+  Status Accept(const ErrorResponse& error) const override;
+
+ protected:
+  constexpr TableCommitErrorHandler() = default;
+};
+
+/// \brief Table create commit operation error handler.
+class ICEBERG_REST_EXPORT CreateTableErrorHandler final : public TableCommitErrorHandler {
+ public:
+  /// \brief Returns the singleton instance
+  static const std::shared_ptr<CreateTableErrorHandler>& Instance();
+
+  Status Accept(const ErrorResponse& error) const override;
+
+ private:
+  constexpr CreateTableErrorHandler() = default;
+};
+
 /// \brief View-level error handler.
 class ICEBERG_REST_EXPORT ViewErrorHandler final : public DefaultErrorHandler {
  public:
@@ -101,18 +137,6 @@ class ICEBERG_REST_EXPORT ViewErrorHandler final : public DefaultErrorHandler {
 
  private:
   constexpr ViewErrorHandler() = default;
-};
-
-/// \brief Table commit operation error handler.
-class ICEBERG_REST_EXPORT TableCommitErrorHandler final : public DefaultErrorHandler {
- public:
-  /// \brief Returns the singleton instance
-  static const std::shared_ptr<TableCommitErrorHandler>& Instance();
-
-  Status Accept(const ErrorResponse& error) const override;
-
- private:
-  constexpr TableCommitErrorHandler() = default;
 };
 
 /// \brief View commit operation error handler.
@@ -147,6 +171,17 @@ class ICEBERG_REST_EXPORT PlanTaskErrorHandler final : public DefaultErrorHandle
 
  private:
   constexpr PlanTaskErrorHandler() = default;
+};
+
+/// \brief OAuth token endpoint error handler.
+class ICEBERG_REST_EXPORT OAuthErrorHandler final : public ErrorHandler {
+ public:
+  static const std::shared_ptr<OAuthErrorHandler>& Instance();
+
+  Status Accept(const ErrorResponse& error) const override;
+
+ private:
+  constexpr OAuthErrorHandler() = default;
 };
 
 }  // namespace iceberg::rest

--- a/src/iceberg/catalog/rest/error_handlers.h
+++ b/src/iceberg/catalog/rest/error_handlers.h
@@ -19,10 +19,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
+#include <string>
 
 #include "iceberg/catalog/rest/iceberg_rest_export.h"
-#include "iceberg/catalog/rest/type_fwd.h"
+#include "iceberg/catalog/rest/types.h"
 #include "iceberg/result.h"
 
 /// \file iceberg/catalog/rest/error_handlers.h
@@ -41,6 +43,14 @@ class ICEBERG_REST_EXPORT ErrorHandler {
   /// \param error The error response parsed from the HTTP response body
   /// \return An Error object with appropriate ErrorKind and message
   virtual Status Accept(const ErrorResponse& error) const = 0;
+
+  /// \brief Parse an HTTP error response body.
+  ///
+  /// \param code The HTTP status code from the failed response
+  /// \param text The HTTP response body
+  /// \return The parsed error response
+  virtual Result<ErrorResponse> ParseResponse(uint32_t code,
+                                              const std::string& text) const = 0;
 };
 
 /// \brief Default error handler for REST API responses.
@@ -50,6 +60,8 @@ class ICEBERG_REST_EXPORT DefaultErrorHandler : public ErrorHandler {
   static const std::shared_ptr<DefaultErrorHandler>& Instance();
 
   Status Accept(const ErrorResponse& error) const override;
+  Result<ErrorResponse> ParseResponse(uint32_t code,
+                                      const std::string& text) const override;
 
  protected:
   constexpr DefaultErrorHandler() = default;
@@ -179,6 +191,8 @@ class ICEBERG_REST_EXPORT OAuthErrorHandler final : public ErrorHandler {
   static const std::shared_ptr<OAuthErrorHandler>& Instance();
 
   Status Accept(const ErrorResponse& error) const override;
+  Result<ErrorResponse> ParseResponse(uint32_t code,
+                                      const std::string& text) const override;
 
  private:
   constexpr OAuthErrorHandler() = default;

--- a/src/iceberg/catalog/rest/http_client.cc
+++ b/src/iceberg/catalog/rest/http_client.cc
@@ -31,6 +31,7 @@
 #include "iceberg/catalog/rest/rest_util.h"
 #include "iceberg/json_serde_internal.h"
 #include "iceberg/result.h"
+#include "iceberg/util/json_util_internal.h"
 #include "iceberg/util/macros.h"
 
 namespace iceberg::rest {
@@ -69,6 +70,8 @@ namespace {
 
 /// \brief Default error type for unparseable REST responses.
 constexpr std::string_view kRestExceptionType = "RESTException";
+constexpr std::string_view kOAuthError = "error";
+constexpr std::string_view kOAuthErrorDescription = "error_description";
 
 /// \brief Merge default headers with per-request headers (per-request wins).
 HttpHeaders MergeHeaders(
@@ -141,7 +144,7 @@ ErrorResponse BuildDefaultErrorResponse(const cpr::Response& response) {
   };
 }
 
-/// \brief Tries to parse the response body as an ErrorResponse.
+/// \brief Tries to parse the response body as a REST ErrorResponse.
 Result<ErrorResponse> TryParseErrorResponse(const std::string& text) {
   if (text.empty()) {
     return InvalidArgument("Empty response body");
@@ -151,13 +154,34 @@ Result<ErrorResponse> TryParseErrorResponse(const std::string& text) {
   return error_result;
 }
 
+/// \brief Tries to parse the response body as an OAuth error response.
+Result<ErrorResponse> TryParseOAuthErrorResponse(uint32_t code, const std::string& text) {
+  if (text.empty()) {
+    return InvalidArgument("Empty response body");
+  }
+
+  ICEBERG_ASSIGN_OR_RAISE(auto json_result, FromJsonString(text));
+
+  ErrorResponse error;
+  error.code = code;
+  ICEBERG_ASSIGN_OR_RAISE(error.type,
+                          GetJsonValue<std::string>(json_result, kOAuthError));
+  ICEBERG_ASSIGN_OR_RAISE(error.message, GetJsonValueOrDefault<std::string>(
+                                             json_result, kOAuthErrorDescription));
+  return error;
+}
+
 /// \brief Handles failure responses by invoking the provided error handler.
 Status HandleFailureResponse(const cpr::Response& response,
                              const ErrorHandler& error_handler) {
   if (IsSuccessful(response.status_code)) {
     return {};
   }
-  auto parse_result = TryParseErrorResponse(response.text);
+  auto parse_result =
+      dynamic_cast<const OAuthErrorHandler*>(&error_handler) != nullptr
+          ? TryParseOAuthErrorResponse(static_cast<uint32_t>(response.status_code),
+                                       response.text)
+          : TryParseErrorResponse(response.text);
   const ErrorResponse final_error =
       parse_result.value_or(BuildDefaultErrorResponse(response));
   return error_handler.Accept(final_error);

--- a/src/iceberg/catalog/rest/http_client.cc
+++ b/src/iceberg/catalog/rest/http_client.cc
@@ -22,16 +22,12 @@
 #include <map>
 
 #include <cpr/cpr.h>
-#include <nlohmann/json.hpp>
 
 #include "iceberg/catalog/rest/auth/auth_session.h"
 #include "iceberg/catalog/rest/constant.h"
 #include "iceberg/catalog/rest/error_handlers.h"
-#include "iceberg/catalog/rest/json_serde_internal.h"
 #include "iceberg/catalog/rest/rest_util.h"
-#include "iceberg/json_serde_internal.h"
 #include "iceberg/result.h"
-#include "iceberg/util/json_util_internal.h"
 #include "iceberg/util/macros.h"
 
 namespace iceberg::rest {
@@ -70,8 +66,6 @@ namespace {
 
 /// \brief Default error type for unparseable REST responses.
 constexpr std::string_view kRestExceptionType = "RESTException";
-constexpr std::string_view kOAuthError = "error";
-constexpr std::string_view kOAuthErrorDescription = "error_description";
 
 /// \brief Merge default headers with per-request headers (per-request wins).
 HttpHeaders MergeHeaders(
@@ -144,44 +138,14 @@ ErrorResponse BuildDefaultErrorResponse(const cpr::Response& response) {
   };
 }
 
-/// \brief Tries to parse the response body as a REST ErrorResponse.
-Result<ErrorResponse> TryParseErrorResponse(const std::string& text) {
-  if (text.empty()) {
-    return InvalidArgument("Empty response body");
-  }
-  ICEBERG_ASSIGN_OR_RAISE(auto json_result, FromJsonString(text));
-  ICEBERG_ASSIGN_OR_RAISE(auto error_result, ErrorResponseFromJson(json_result));
-  return error_result;
-}
-
-/// \brief Tries to parse the response body as an OAuth error response.
-Result<ErrorResponse> TryParseOAuthErrorResponse(uint32_t code, const std::string& text) {
-  if (text.empty()) {
-    return InvalidArgument("Empty response body");
-  }
-
-  ICEBERG_ASSIGN_OR_RAISE(auto json_result, FromJsonString(text));
-
-  ErrorResponse error;
-  error.code = code;
-  ICEBERG_ASSIGN_OR_RAISE(error.type,
-                          GetJsonValue<std::string>(json_result, kOAuthError));
-  ICEBERG_ASSIGN_OR_RAISE(error.message, GetJsonValueOrDefault<std::string>(
-                                             json_result, kOAuthErrorDescription));
-  return error;
-}
-
 /// \brief Handles failure responses by invoking the provided error handler.
 Status HandleFailureResponse(const cpr::Response& response,
                              const ErrorHandler& error_handler) {
   if (IsSuccessful(response.status_code)) {
     return {};
   }
-  auto parse_result =
-      dynamic_cast<const OAuthErrorHandler*>(&error_handler) != nullptr
-          ? TryParseOAuthErrorResponse(static_cast<uint32_t>(response.status_code),
-                                       response.text)
-          : TryParseErrorResponse(response.text);
+  auto parse_result = error_handler.ParseResponse(
+      static_cast<uint32_t>(response.status_code), response.text);
   const ErrorResponse final_error =
       parse_result.value_or(BuildDefaultErrorResponse(response));
   return error_handler.Accept(final_error);

--- a/src/iceberg/catalog/rest/rest_catalog.cc
+++ b/src/iceberg/catalog/rest/rest_catalog.cc
@@ -48,6 +48,7 @@
 #include "iceberg/sort_order.h"
 #include "iceberg/table.h"
 #include "iceberg/table_requirement.h"
+#include "iceberg/table_requirements.h"
 #include "iceberg/table_update.h"
 #include "iceberg/transaction.h"
 #include "iceberg/util/macros.h"
@@ -89,7 +90,7 @@ Result<CatalogConfig> FetchServerConfig(const ResourcePaths& paths,
 
   ICEBERG_ASSIGN_OR_RAISE(const auto response,
                           client.Get(config_path, params, /*headers=*/{},
-                                     *DefaultErrorHandler::Instance(), session));
+                                     *ConfigErrorHandler::Instance(), session));
   ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
   return CatalogConfigFromJson(json);
 }
@@ -710,9 +711,14 @@ Result<CommitTableResponse> RestCatalog::UpdateTableInternal(
   }
 
   ICEBERG_ASSIGN_OR_RAISE(auto json_request, ToJsonString(ToJson(request)));
-  ICEBERG_ASSIGN_OR_RAISE(const auto response,
-                          client_->Post(path, json_request, /*headers=*/{},
-                                        *TableErrorHandler::Instance(), session));
+  ICEBERG_ASSIGN_OR_RAISE(auto is_create, TableRequirements::IsCreate(requirements));
+  const ErrorHandler* error_handler = TableCommitErrorHandler::Instance().get();
+  if (is_create) {
+    error_handler = CreateTableErrorHandler::Instance().get();
+  }
+  ICEBERG_ASSIGN_OR_RAISE(
+      const auto response,
+      client_->Post(path, json_request, /*headers=*/{}, *error_handler, session));
 
   ICEBERG_ASSIGN_OR_RAISE(auto json, FromJsonString(response.body()));
   ICEBERG_ASSIGN_OR_RAISE(auto commit_response, CommitTableResponseFromJson(json));

--- a/src/iceberg/result.h
+++ b/src/iceberg/result.h
@@ -53,6 +53,7 @@ enum class ErrorKind {
   kNoSuchPlanId,
   kNoSuchPlanTask,
   kNoSuchTable,
+  kNoSuchWarehouse,
   kNoSuchView,
   kNotAllowed,
   kNotAuthorized,
@@ -118,6 +119,7 @@ DEFINE_ERROR_FUNCTION(NoSuchNamespace)
 DEFINE_ERROR_FUNCTION(NoSuchPlanId)
 DEFINE_ERROR_FUNCTION(NoSuchPlanTask)
 DEFINE_ERROR_FUNCTION(NoSuchTable)
+DEFINE_ERROR_FUNCTION(NoSuchWarehouse)
 DEFINE_ERROR_FUNCTION(NoSuchView)
 DEFINE_ERROR_FUNCTION(NotAllowed)
 DEFINE_ERROR_FUNCTION(NotAuthorized)

--- a/src/iceberg/test/CMakeLists.txt
+++ b/src/iceberg/test/CMakeLists.txt
@@ -291,6 +291,7 @@ if(ICEBERG_BUILD_REST)
   add_rest_iceberg_test(rest_catalog_test
                         SOURCES
                         auth_manager_test.cc
+                        error_handlers_test.cc
                         endpoint_test.cc
                         rest_file_io_test.cc
                         rest_json_serde_test.cc

--- a/src/iceberg/test/error_handlers_test.cc
+++ b/src/iceberg/test/error_handlers_test.cc
@@ -206,6 +206,19 @@ TEST(ErrorHandlersTest, OAuthErrorHandlerMapsInvalidClientToNotAuthorized) {
       HasErrorMessage("Not authorized: invalid_client: Credentials given were invalid"));
 }
 
+TEST(ErrorHandlersTest, OAuthErrorHandlerParsesOAuthErrorResponse) {
+  auto parse_result = OAuthErrorHandler::Instance()->ParseResponse(
+      400,
+      R"({"error":"invalid_client","error_description":"Credentials given were invalid"})");
+  ASSERT_TRUE(parse_result.has_value());
+
+  EXPECT_EQ(parse_result->code, 400);
+  EXPECT_EQ(parse_result->type, "invalid_client");
+  EXPECT_EQ(parse_result->message, "Credentials given were invalid");
+  EXPECT_THAT(OAuthErrorHandler::Instance()->Accept(*parse_result),
+              IsError(ErrorKind::kNotAuthorized));
+}
+
 TEST(ErrorHandlersTest, OAuthErrorHandlerMapsClientErrorsToBadRequest) {
   ErrorResponse error{
       .code = 400,

--- a/src/iceberg/test/error_handlers_test.cc
+++ b/src/iceberg/test/error_handlers_test.cc
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/catalog/rest/error_handlers.h"
+
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+#include "iceberg/catalog/rest/types.h"
+#include "iceberg/test/matchers.h"
+
+namespace iceberg::rest {
+
+namespace {
+
+void ExpectErrorWithMessage(const Status& status, ErrorKind kind,
+                            std::string_view message) {
+  ASSERT_FALSE(status.has_value());
+  EXPECT_EQ(status.error().kind, kind);
+  EXPECT_EQ(status.error().message, message);
+}
+
+}  // namespace
+
+TEST(ErrorHandlersTest, DefaultErrorHandlerIncludesCodeAndType) {
+  ErrorResponse error{
+      .code = 422,
+      .type = "ValidationException",
+      .message = "Invalid input",
+  };
+
+  ExpectErrorWithMessage(
+      DefaultErrorHandler::Instance()->Accept(error), ErrorKind::kRestError,
+      "Unable to process (code: 422, type: ValidationException): Invalid input");
+}
+
+TEST(ErrorHandlersTest, DefaultErrorHandlerWithCodeOnly) {
+  ErrorResponse error{
+      .code = 422,
+      .type = "",
+      .message = "",
+  };
+
+  ExpectErrorWithMessage(DefaultErrorHandler::Instance()->Accept(error),
+                         ErrorKind::kRestError,
+                         "Unable to process (code: 422, type: null): null");
+}
+
+TEST(ErrorHandlersTest, DefaultErrorHandlerWithCodeAndMessageOnly) {
+  ErrorResponse error{
+      .code = 422,
+      .type = "",
+      .message = "Invalid input",
+  };
+
+  ExpectErrorWithMessage(DefaultErrorHandler::Instance()->Accept(error),
+                         ErrorKind::kRestError,
+                         "Unable to process (code: 422, type: null): Invalid input");
+}
+
+TEST(ErrorHandlersTest, DefaultErrorHandlerWithCodeAndTypeOnly) {
+  ErrorResponse error{
+      .code = 422,
+      .type = "ValidationException",
+      .message = "",
+  };
+
+  ExpectErrorWithMessage(
+      DefaultErrorHandler::Instance()->Accept(error), ErrorKind::kRestError,
+      "Unable to process (code: 422, type: ValidationException): null");
+}
+
+TEST(ErrorHandlersTest, NamespaceErrorHandlerFormats422AsRestError) {
+  ErrorResponse error{
+      .code = 422,
+      .type = "ValidationException",
+      .message = "Invalid namespace",
+  };
+
+  ExpectErrorWithMessage(
+      NamespaceErrorHandler::Instance()->Accept(error), ErrorKind::kRestError,
+      "Unable to process (code: 422, type: ValidationException): Invalid namespace");
+}
+
+TEST(ErrorHandlersTest, TableErrorHandlerMaps404NotFoundToNotFound) {
+  ErrorResponse error{
+      .code = 404,
+      .type = "NotFoundException",
+      .message = "Failed to open input stream for file: metadata.json",
+  };
+
+  EXPECT_THAT(TableErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kNotFound));
+  EXPECT_THAT(TableErrorHandler::Instance()->Accept(error),
+              HasErrorMessage("metadata.json"));
+}
+
+TEST(ErrorHandlersTest, TableErrorHandlerMaps404ToNoSuchTableByDefault) {
+  ErrorResponse error{
+      .code = 404,
+      .type = "NoSuchTableException",
+      .message = "Table does not exist",
+  };
+
+  EXPECT_THAT(TableErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kNoSuchTable));
+}
+
+TEST(ErrorHandlersTest, CreateTableErrorHandlerMaps404ToNoSuchNamespace) {
+  ErrorResponse error{
+      .code = 404,
+      .type = "NoSuchNamespaceException",
+      .message = "Namespace does not exist",
+  };
+
+  EXPECT_THAT(CreateTableErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kNoSuchNamespace));
+}
+
+TEST(ErrorHandlersTest, CreateTableErrorHandlerMaps409ToAlreadyExists) {
+  ErrorResponse error{
+      .code = 409,
+      .type = "AlreadyExistsException",
+      .message = "Table already exists",
+  };
+
+  EXPECT_THAT(CreateTableErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kAlreadyExists));
+}
+
+TEST(ErrorHandlersTest, CreateTableErrorHandlerMapsServiceFailureToCommitStateUnknown) {
+  ErrorResponse error{
+      .code = 503,
+      .type = "ServiceFailureException",
+      .message = "Service unavailable",
+  };
+
+  EXPECT_THAT(CreateTableErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kCommitStateUnknown));
+  EXPECT_THAT(CreateTableErrorHandler::Instance()->Accept(error),
+              HasErrorMessage("Service failed: 503: Service unavailable"));
+}
+
+TEST(ErrorHandlersTest, PlanErrorHandlerMapsUnknown404ToNoSuchPlanId) {
+  ErrorResponse error{
+      .code = 404,
+      .type = "UnknownException",
+      .message = "Plan does not exist",
+  };
+
+  EXPECT_THAT(PlanErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kNoSuchPlanId));
+}
+
+TEST(ErrorHandlersTest, PlanErrorHandlerDelegates406ToDefaultHandler) {
+  ErrorResponse error{
+      .code = 406,
+      .type = "NotAcceptableException",
+      .message = "Not acceptable",
+  };
+
+  ExpectErrorWithMessage(
+      PlanErrorHandler::Instance()->Accept(error), ErrorKind::kRestError,
+      "Unable to process (code: 406, type: NotAcceptableException): Not acceptable");
+}
+
+TEST(ErrorHandlersTest, PlanTaskErrorHandlerMapsUnknown404ToNoSuchPlanTask) {
+  ErrorResponse error{
+      .code = 404,
+      .type = "UnknownException",
+      .message = "Plan task does not exist",
+  };
+
+  EXPECT_THAT(PlanTaskErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kNoSuchPlanTask));
+}
+
+TEST(ErrorHandlersTest, OAuthErrorHandlerMapsInvalidClientToNotAuthorized) {
+  ErrorResponse error{
+      .code = 400,
+      .type = "invalid_client",
+      .message = "Credentials given were invalid",
+  };
+
+  EXPECT_THAT(OAuthErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kNotAuthorized));
+  EXPECT_THAT(
+      OAuthErrorHandler::Instance()->Accept(error),
+      HasErrorMessage("Not authorized: invalid_client: Credentials given were invalid"));
+}
+
+TEST(ErrorHandlersTest, OAuthErrorHandlerMapsClientErrorsToBadRequest) {
+  ErrorResponse error{
+      .code = 400,
+      .type = "invalid_grant",
+      .message = "Grant is invalid",
+  };
+
+  EXPECT_THAT(OAuthErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kBadRequest));
+  EXPECT_THAT(OAuthErrorHandler::Instance()->Accept(error),
+              HasErrorMessage("Malformed request: invalid_grant: Grant is invalid"));
+}
+
+TEST(ErrorHandlersTest, ConfigErrorHandlerMapsTyped404ToNoSuchWarehouse) {
+  ErrorResponse error{
+      .code = 404,
+      .type = "NoSuchWarehouseException",
+      .message = "Warehouse does not exist",
+  };
+
+  EXPECT_THAT(ConfigErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kNoSuchWarehouse));
+}
+
+TEST(ErrorHandlersTest, ConfigErrorHandlerDelegatesUntyped404ToDefaultHandler) {
+  ErrorResponse error{
+      .code = 404,
+      .type = "",
+      .message = "Not Found",
+  };
+
+  EXPECT_THAT(ConfigErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kRestError));
+  EXPECT_THAT(ConfigErrorHandler::Instance()->Accept(error),
+              HasErrorMessage("Not Found"));
+}
+
+TEST(ErrorHandlersTest, ConfigErrorHandlerDelegatesNon404ToDefaultHandler) {
+  ErrorResponse error{
+      .code = 500,
+      .type = "",
+      .message = "Internal server error",
+  };
+
+  EXPECT_THAT(ConfigErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kInternalServerError));
+  EXPECT_THAT(ConfigErrorHandler::Instance()->Accept(error),
+              HasErrorMessage("Internal server error"));
+}
+
+}  // namespace iceberg::rest

--- a/src/iceberg/test/error_handlers_test.cc
+++ b/src/iceberg/test/error_handlers_test.cc
@@ -222,8 +222,8 @@ TEST(ErrorHandlersTest, OAuthErrorHandlerMapsClientErrorsToBadRequest) {
 TEST(ErrorHandlersTest, ConfigErrorHandlerMapsTyped404ToNoSuchWarehouse) {
   ErrorResponse error{
       .code = 404,
-      .type = "NoSuchWarehouseException",
-      .message = "Warehouse does not exist",
+      .type = "NotFoundException",
+      .message = "Warehouse not found",
   };
 
   EXPECT_THAT(ConfigErrorHandler::Instance()->Accept(error),
@@ -234,6 +234,19 @@ TEST(ErrorHandlersTest, ConfigErrorHandlerDelegatesUntyped404ToDefaultHandler) {
   ErrorResponse error{
       .code = 404,
       .type = "",
+      .message = "Not Found",
+  };
+
+  EXPECT_THAT(ConfigErrorHandler::Instance()->Accept(error),
+              IsError(ErrorKind::kRestError));
+  EXPECT_THAT(ConfigErrorHandler::Instance()->Accept(error),
+              HasErrorMessage("Not Found"));
+}
+
+TEST(ErrorHandlersTest, ConfigErrorHandlerDelegatesFallback404ToDefaultHandler) {
+  ErrorResponse error{
+      .code = 404,
+      .type = "RESTException",
       .message = "Not Found",
   };
 

--- a/src/iceberg/test/meson.build
+++ b/src/iceberg/test/meson.build
@@ -131,6 +131,7 @@ if get_option('rest').enabled()
             'sources': files(
                 'auth_manager_test.cc',
                 'endpoint_test.cc',
+                'error_handlers_test.cc',
                 'rest_file_io_test.cc',
                 'rest_json_serde_test.cc',
                 'rest_util_test.cc',


### PR DESCRIPTION
While reviewing #614, I noticed that `PlanErrorHandler::Accept` does not match the behavior of the Java implementation.

A detailed comparison with Java's `ErrorHandlers` revealed several gaps between iceberg-cpp and Iceberg Java. Some of these are oversights in the original implementation, while others correspond to improvements that were made later in Iceberg Java, including:

* https://github.com/apache/iceberg/pull/13143
* https://github.com/apache/iceberg/pull/14927
* https://github.com/apache/iceberg/pull/15051
* https://github.com/apache/iceberg/pull/16059

This PR closes those gaps and brings the error handling behavior in iceberg-cpp closer to the Java implementation.