### PR TITLE
fix(rest): avoid default catalog reference cycle

### DIFF
--- a/src/iceberg/catalog/rest/rest_catalog.cc
+++ b/src/iceberg/catalog/rest/rest_catalog.cc
@@ -487,11 +487,13 @@ RestCatalog::RestCatalog(RestCatalogProperties config, std::shared_ptr<FileIO> f
 std::string_view RestCatalog::name() const { return name_; }
 
 Result<std::shared_ptr<Catalog>> RestCatalog::AsCatalog() {
-  if (!default_catalog_) {
-    default_catalog_ =
-        std::make_shared<ContextCatalog>(shared_from_this(), default_context_);
+  if (auto catalog = default_catalog_.lock()) {
+    return catalog;
   }
-  return default_catalog_;
+
+  auto catalog = std::make_shared<ContextCatalog>(shared_from_this(), default_context_);
+  default_catalog_ = catalog;
+  return catalog;
 }
 
 Result<std::shared_ptr<Catalog>> RestCatalog::WithContext(SessionContext context) {

--- a/src/iceberg/catalog/rest/rest_catalog.h
+++ b/src/iceberg/catalog/rest/rest_catalog.h
@@ -181,7 +181,7 @@ class ICEBERG_REST_EXPORT RestCatalog final
   std::shared_ptr<auth::AuthSession> catalog_session_;
   SnapshotMode snapshot_mode_;
   SessionContext default_context_;
-  std::shared_ptr<Catalog> default_catalog_;
+  std::weak_ptr<Catalog> default_catalog_;
 };
 
 }  // namespace iceberg::rest

--- a/src/iceberg/test/rest_catalog_integration_test.cc
+++ b/src/iceberg/test/rest_catalog_integration_test.cc
@@ -203,6 +203,31 @@ TEST_F(RestCatalogIntegrationTest, MakeCatalogSuccess) {
   EXPECT_THAT(root->WithContext(SessionContext{}), IsError(ErrorKind::kInvalidArgument));
 }
 
+TEST_F(RestCatalogIntegrationTest, DefaultCatalogCacheDoesNotKeepRootAlive) {
+  std::weak_ptr<RestCatalog> weak_root;
+  std::weak_ptr<Catalog> weak_catalog;
+
+  {
+    auto config = RestCatalogProperties::default_properties();
+    config.Set(RestCatalogProperties::kUri, CatalogUri())
+        .Set(RestCatalogProperties::kName, std::string(kCatalogName))
+        .Set(RestCatalogProperties::kWarehouse, std::string(kWarehouseName));
+    config.mutable_configs()[std::string(RestCatalogProperties::kIOImpl.key())] =
+        std::string(kStdFileIOImpl);
+
+    ICEBERG_UNWRAP_OR_FAIL(auto root, RestCatalog::Make(config));
+    ICEBERG_UNWRAP_OR_FAIL(auto catalog, root->AsCatalog());
+    ICEBERG_UNWRAP_OR_FAIL(auto same_catalog, root->AsCatalog());
+
+    weak_root = root;
+    weak_catalog = catalog;
+    EXPECT_EQ(catalog, same_catalog);
+  }
+
+  EXPECT_TRUE(weak_catalog.expired());
+  EXPECT_TRUE(weak_root.expired());
+}
+
 TEST_F(RestCatalogIntegrationTest, FetchServerConfigDirect) {
   HttpClient client({});
   auto noop_session = auth::AuthSession::MakeDefault({});


### PR DESCRIPTION
Store the cached default catalog view as a weak_ptr so AsCatalog() can reuse a live view without keeping it alive from the RestCatalog root.