### PR TITLE
ci: cache vcpkg packages on Windows builds

### DIFF
--- a/.github/workflows/sql_catalog_test.yml
+++ b/.github/workflows/sql_catalog_test.yml
@@ -80,8 +80,15 @@ jobs:
         run: |
           echo "CC=${{ matrix.CC }}" >> $GITHUB_ENV
           echo "CXX=${{ matrix.CXX }}" >> $GITHUB_ENV
-      - name: Install dependencies on Windows
+      - name: Cache vcpkg packages
         if: ${{ startsWith(matrix.runs-on, 'windows') }}
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: vcpkg-cache
+        with:
+          path: C:/vcpkg/installed
+          key: vcpkg-x64-windows-sql-catalog-${{ hashFiles('.github/workflows/sql_catalog_test.yml') }}
+      - name: Install dependencies on Windows
+        if: ${{ startsWith(matrix.runs-on, 'windows') && steps.vcpkg-cache.outputs.cache-hit != 'true' }}
         shell: pwsh
         run: |
           vcpkg install zlib:x64-windows nlohmann-json:x64-windows nanoarrow:x64-windows roaring:x64-windows sqlite3:x64-windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,14 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
           arch: x64
+      - name: Cache vcpkg packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: vcpkg-cache
+        with:
+          path: C:/vcpkg/installed
+          key: vcpkg-x64-windows-test-${{ hashFiles('.github/workflows/test.yml') }}
       - name: Install dependencies
+        if: ${{ steps.vcpkg-cache.outputs.cache-hit != 'true' }}
         shell: pwsh
         run: |
           vcpkg install zlib:x64-windows nlohmann-json:x64-windows nanoarrow:x64-windows roaring:x64-windows cpr:x64-windows


### PR DESCRIPTION
## What
Cache the installed vcpkg packages on the Windows builds in `test` and `sql_catalog_test`, and skip the install step when the cache is present.

## Why
Every Windows run reinstalls the same packages (zlib, nlohmann-json, nanoarrow, roaring, plus cpr / sqlite3) from scratch, costing a couple of minutes each time. Caching them removes that on every run after the first. This matches what `aws_test` already does.

## Validation
A warm run reused the cached packages and skipped the install. The cache only rebuilds when the package list changes.
