### PR TITLE
ci: cancel superseded runs in remaining workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,10 @@ on:
   schedule:
     - cron: '16 4 * * 1'
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -27,6 +27,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   cpp-linter:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -21,6 +21,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,6 +25,10 @@ on:
       - '**'
       - '!dependabot/**'
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,6 +26,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: ["**"]
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## What
Add a concurrency block to the five workflows that don't have one — `cpp-linter`, `pre-commit`, `license_check`, `zizmor`, and `codeql`:

```yaml
concurrency:
  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
  cancel-in-progress: true
```

## Why
The heavier workflows already cancel outdated runs, but these five don't - so pushing again to a PR leaves the old runs going and tying up runners. Grouping on `head_ref || sha` cancels superseded PR runs while leaving `main` and scheduled runs untouched.
