### PR TITLE
build: silence benign MSVC C4251/C4275 dll-interface warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,9 @@ project(
 )
 
 cpp = meson.get_compiler('cpp')
-args = cpp.get_supported_arguments(['/bigobj'])
+# Hide two noisy MSVC warnings (C4251/C4275) about standard-library types used in
+# our public classes. They're harmless because the whole library ships as one DLL.
+args = cpp.get_supported_arguments(['/bigobj', '/wd4251', '/wd4275'])
 add_project_arguments(args, language: 'cpp')
 
 subdir('src')


### PR DESCRIPTION
## What
Add `/wd4251` and `/wd4275` in `meson.build`, applied only where the compiler accepts them.

## Why
The MSVC build prints tens of thousands of lines of C4251/C4275 warnings about exported classes (like `TableProperties` and `ConfigBase`/`Entry`) that hold standard-library members. These are harmless when everything is built as one DLL with one compiler, but they bury the warnings that actually matter in the Windows logs. The flags are ignored on GCC and Clang, which don't have these warnings.

For reference, the average Meson Windows build logs ~22k of these warning lines (971 unique messages), drowning the handful of real warnings in the same run:
https://github.com/apache/iceberg-cpp/actions/runs/27870777076/job/82482181520