### PR TITLE
fix(scan): reject missing column stats fields

### DIFF
--- a/src/iceberg/table_scan.cc
+++ b/src/iceberg/table_scan.cc
@@ -400,9 +400,8 @@ Status TableScanBuilder<ScanType>::ResolveColumnStatsSelection() {
   const auto& schema = schema_ref.get();
   for (const auto& column_name : *requested_column_stats_) {
     ICEBERG_ASSIGN_OR_RAISE(auto field, schema->FindFieldByName(column_name));
-    if (field.has_value()) {
-      context_.columns_to_keep_stats.insert(field.value().get().field_id());
-    }
+    ICEBERG_CHECK(field.has_value(), "Cannot find stats column: {}", column_name);
+    context_.columns_to_keep_stats.insert(field.value().get().field_id());
   }
 
   return {};

--- a/src/iceberg/test/table_scan_test.cc
+++ b/src/iceberg/test/table_scan_test.cc
@@ -285,6 +285,16 @@ TEST_P(TableScanTest, IncludeColumnStatsUsesFinalSnapshotSchema) {
   }
 }
 
+TEST_P(TableScanTest, IncludeColumnStatsRejectsMissingColumn) {
+  ICEBERG_UNWRAP_OR_FAIL(auto builder,
+                         DataTableScanBuilder::Make(table_metadata_, file_io_));
+  builder->IncludeColumnStats({"missing"});
+
+  EXPECT_THAT(builder->Build(),
+              ::testing::AllOf(IsError(ErrorKind::kValidationFailed),
+                               HasErrorMessage("Cannot find stats column: missing")));
+}
+
 TEST_P(TableScanTest, TableScanBuilderValidationErrors) {
   // Test negative min rows
   ICEBERG_UNWRAP_OR_FAIL(auto builder,


### PR DESCRIPTION
## Summary
- fail table scan builds when IncludeColumnStats requests an unknown column
- add regression coverage for missing requested stats columns

## Tests
- cmake --build build --target scan_test -j 8 -- -s
- ctest --test-dir build -R scan_test --output-on-failure