### PR TITLE
ci: scope push trigger to main to drop redundant PR runs

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -24,11 +24,11 @@
 name: "ASF Allowlist Check"
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/aws_test.yml
+++ b/.github/workflows/aws_test.yml
@@ -20,8 +20,7 @@ name: AWS Tests
 on:
   push:
     branches:
-      - '**'
-      - '!dependabot/**'
+      - main
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,10 +21,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [ "main" ]
+    branches:
+      - main
   schedule:
     - cron: '16 4 * * 1'
 

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -27,12 +27,12 @@ on:
       - 'cmake_modules/**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
     paths-ignore:
       - '.github/**'
       - 'ci/**'
       - 'cmake_modules/**'
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,12 +18,12 @@
 name: pre-commit
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - '**'
       - '!dependabot/**'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/sanitizer_test.yml
+++ b/.github/workflows/sanitizer_test.yml
@@ -20,8 +20,7 @@ name: ASAN and UBSAN Tests
 on:
   push:
     branches:
-      - '**'
-      - '!dependabot/**'
+      - main
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/sql_catalog_test.yml
+++ b/.github/workflows/sql_catalog_test.yml
@@ -20,8 +20,7 @@ name: SQL Catalog Tests
 on:
   push:
     branches:
-      - '**'
-      - '!dependabot/**'
+      - main
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,7 @@ name: Test
 on:
   push:
     branches:
-      - '**'
-      - '!dependabot/**'
+      - main
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,10 +21,10 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: ["**"]
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}


### PR DESCRIPTION
## Change
Make push triggers more consistent by having the test workflows run branch pushes only on `main`. Pull requests still run the same checks, and tag builds are unchanged.

The duplicate-run case is narrow: it only happens for branches pushed directly to the Apache repo, so it mostly affects committers and bots rather than normal fork-based contributors. Pull request checks cover those branch updates; direct `main` runs still give us post-merge CI and warm caches.

Also cleans up nearby `on:` sections so the triggers are easier to compare, including removing `zizmor`'s redundant all-branches pull request filter.

## Validation
Checked that all workflow YAML files still parse.

## Remaining Trigger Inconsistencies
These are intentional or out of scope, so this PR leaves them alone:

- Test workflows still run on all tag pushes to preserve release behavior.
- `rc` only runs on release-candidate tags.
- `pre-commit` still runs on regular branch pushes because it is cheap.
- `docs`, `cpp-linter`, `license_check`, and `codeql` keep their narrower rules.

Related discussion: apache/iceberg-cpp#799.