### PR TITLE
feat(expression): cast numeric literals to decimal type

### DIFF
--- a/src/iceberg/expression/literal.cc
+++ b/src/iceberg/expression/literal.cc
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <concepts>
 #include <cstdint>
+#include <format>
 #include <string>
 #include <vector>
 
@@ -89,6 +90,10 @@ class LiteralCaster {
   /// Cast an integer value (from Int or Long) to a decimal target type.
   static Result<Literal> CastIntegerToDecimal(
       int64_t value, const std::shared_ptr<PrimitiveType>& target_type);
+
+  /// Cast a floating-point value (from Float or Double) to a decimal target type.
+  static Result<Literal> CastRealToDecimal(
+      double value, const std::shared_ptr<PrimitiveType>& target_type);
 };
 
 Literal LiteralCaster::BelowMinLiteral(std::shared_ptr<PrimitiveType> type) {
@@ -118,6 +123,50 @@ Result<Literal> LiteralCaster::CastIntegerToDecimal(
   }
   return Literal::Decimal(decimal.value(), decimal_type.precision(),
                           decimal_type.scale());
+}
+
+Result<Literal> LiteralCaster::CastRealToDecimal(
+    double value, const std::shared_ptr<PrimitiveType>& target_type) {
+  const auto& decimal_type = internal::checked_cast<const DecimalType&>(*target_type);
+  const int32_t target_scale = decimal_type.scale();
+  if (target_scale < 0 || target_scale > Decimal::kMaxScale) {
+    return InvalidArgument("Cannot cast {} as a {} value", value,
+                           target_type->ToString());
+  }
+  if (!std::isfinite(value)) {
+    return InvalidArgument("Cannot cast {} as a {} value", value,
+                           target_type->ToString());
+  }
+
+  // Parse the shortest round-tripping decimal representation of the value (matching
+  // Java's BigDecimal.valueOf(double), which goes through Double.toString) into a
+  // full-precision decimal, then round to the target scale below.
+  int32_t parsed_scale = 0;
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto parsed, Decimal::FromString(std::format("{}", value), nullptr, &parsed_scale));
+
+  Decimal unscaled = parsed;
+  if (parsed_scale > target_scale) {
+    // Drop excess fractional digits with HALF_UP rounding (round half away from zero, as
+    // Java does), since Rescale itself only truncates and rejects any dropped remainder.
+    const int32_t drop = parsed_scale - target_scale;
+    ICEBERG_ASSIGN_OR_RAISE(auto divisor, Decimal(1).Rescale(0, drop));
+    ICEBERG_ASSIGN_OR_RAISE(auto divmod, parsed.Divide(divisor));
+    Decimal quotient = divmod.first;
+    Decimal remainder = Decimal::Abs(divmod.second);
+    if (remainder * Decimal(2) >= divisor) {
+      quotient += (value < 0) ? Decimal(-1) : Decimal(1);
+    }
+    unscaled = quotient;
+  } else if (parsed_scale < target_scale) {
+    ICEBERG_ASSIGN_OR_RAISE(unscaled, parsed.Rescale(parsed_scale, target_scale));
+  }
+
+  if (!unscaled.FitsInPrecision(decimal_type.precision())) {
+    return InvalidArgument("Cannot cast {} as a {} value", value,
+                           target_type->ToString());
+  }
+  return Literal::Decimal(unscaled.value(), decimal_type.precision(), target_scale);
 }
 
 Result<Literal> LiteralCaster::CastFromInt(
@@ -195,6 +244,8 @@ Result<Literal> LiteralCaster::CastFromFloat(
   switch (target_type->type_id()) {
     case TypeId::kDouble:
       return Literal::Double(static_cast<double>(float_val));
+    case TypeId::kDecimal:
+      return CastRealToDecimal(static_cast<double>(float_val), target_type);
     default:
       return NotSupported("Cast from Float to {} is not supported",
                           target_type->ToString());
@@ -215,6 +266,8 @@ Result<Literal> LiteralCaster::CastFromDouble(
       }
       return Literal::Float(static_cast<float>(double_val));
     }
+    case TypeId::kDecimal:
+      return CastRealToDecimal(double_val, target_type);
     default:
       return NotSupported("Cast from Double to {} is not supported",
                           target_type->ToString());

--- a/src/iceberg/expression/literal.cc
+++ b/src/iceberg/expression/literal.cc
@@ -102,9 +102,16 @@ Literal LiteralCaster::AboveMaxLiteral(std::shared_ptr<PrimitiveType> type) {
 Result<Literal> LiteralCaster::CastIntegerToDecimal(
     int64_t value, const std::shared_ptr<PrimitiveType>& target_type) {
   const auto& decimal_type = internal::checked_cast<const DecimalType&>(*target_type);
+  const int32_t scale = decimal_type.scale();
+  // DecimalType does not bound its scale, but Rescale indexes a powers-of-ten table sized
+  // for [0, kMaxScale]; reject an out-of-range scale here rather than reading past it.
+  if (scale < 0 || scale > Decimal::kMaxScale) {
+    return InvalidArgument("Cannot cast {} as a {} value", value,
+                           target_type->ToString());
+  }
   // An integer has scale 0, so scaling it to the target scale multiplies the unscaled
   // value by 10^scale; Rescale rejects a target scale that would overflow the value.
-  ICEBERG_ASSIGN_OR_RAISE(auto decimal, Decimal(value).Rescale(0, decimal_type.scale()));
+  ICEBERG_ASSIGN_OR_RAISE(auto decimal, Decimal(value).Rescale(0, scale));
   if (!decimal.FitsInPrecision(decimal_type.precision())) {
     return InvalidArgument("Cannot cast {} as a {} value", value,
                            target_type->ToString());

--- a/src/iceberg/expression/literal.cc
+++ b/src/iceberg/expression/literal.cc
@@ -19,11 +19,14 @@
 
 #include "iceberg/expression/literal.h"
 
+#include <charconv>
 #include <cmath>
 #include <concepts>
 #include <cstdint>
 #include <format>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include <vector>
 
 #include "iceberg/result.h"
@@ -107,6 +110,14 @@ Literal LiteralCaster::AboveMaxLiteral(std::shared_ptr<PrimitiveType> type) {
 
 namespace {
 
+Status ValidateDecimalScale(int32_t scale) {
+  if (scale < -Decimal::kMaxScale || scale > Decimal::kMaxScale) {
+    return InvalidArgument("decimal scale must be in range [-{}, {}], was {}",
+                           Decimal::kMaxScale, Decimal::kMaxScale, scale);
+  }
+  return {};
+}
+
 // Rescale `unscaled` (interpreted at `from_scale`) to `to_scale` using HALF_UP rounding
 // (round half away from zero), matching Java's BigDecimal.setScale(scale, HALF_UP).
 // Unlike Decimal::Rescale, which only truncates and rejects any dropped remainder, this
@@ -136,7 +147,10 @@ Result<Decimal> RescaleHalfUp(const Decimal& unscaled, int32_t from_scale,
   ICEBERG_ASSIGN_OR_RAISE(auto divmod, unscaled.Divide(divisor));
   Decimal quotient = divmod.first;
   Decimal remainder = Decimal::Abs(divmod.second);
-  if (remainder * Decimal(2) >= divisor) {
+  // Compare against divisor/2 rather than remainder*2: for drop near kMaxScale,
+  // remainder*2 can overflow int128 and flip the HALF_UP decision. Powers of ten
+  // with drop >= 1 are always even, so the two comparisons are equivalent.
+  if (remainder >= divisor / Decimal(2)) {
     quotient += negative ? Decimal(-1) : Decimal(1);
   }
   return quotient;
@@ -147,6 +161,7 @@ Result<Decimal> RescaleHalfUp(const Decimal& unscaled, int32_t from_scale,
 Result<Literal> LiteralCaster::CastIntegerToDecimal(
     int64_t value, const std::shared_ptr<PrimitiveType>& target_type) {
   const auto& decimal_type = internal::checked_cast<const DecimalType&>(*target_type);
+  ICEBERG_RETURN_UNEXPECTED(ValidateDecimalScale(decimal_type.scale()));
   // An integer has scale 0; rescale it to the target scale, rounding HALF_UP when the
   // target scale is negative (matching Java's numeric-to-decimal default handling).
   ICEBERG_ASSIGN_OR_RAISE(auto unscaled, RescaleHalfUp(Decimal(value), /*from_scale=*/0,
@@ -162,17 +177,24 @@ Result<Literal> LiteralCaster::CastIntegerToDecimal(
 Result<Literal> LiteralCaster::CastRealToDecimal(
     double value, const std::shared_ptr<PrimitiveType>& target_type) {
   const auto& decimal_type = internal::checked_cast<const DecimalType&>(*target_type);
+  ICEBERG_RETURN_UNEXPECTED(ValidateDecimalScale(decimal_type.scale()));
   if (!std::isfinite(value)) {
     return InvalidArgument("Cannot cast {} as a {} value", value,
                            target_type->ToString());
   }
 
-  // Parse the shortest round-tripping decimal representation of the value (matching
-  // Java's BigDecimal.valueOf(double), which goes through Double.toString) into a
-  // full-precision decimal, then round to the target scale.
+  // Convert via the shortest round-tripping decimal string (std::to_chars without a
+  // format specifier), then round to the target scale. Float callers widen to double
+  // first, so both float and double sources share this path.
+  char buf[64];
+  auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), value);
+  if (ec != std::errc{}) {
+    return InvalidArgument("Cannot cast {} as a {} value", value,
+                           target_type->ToString());
+  }
   int32_t parsed_scale = 0;
-  ICEBERG_ASSIGN_OR_RAISE(
-      auto parsed, Decimal::FromString(std::format("{}", value), nullptr, &parsed_scale));
+  ICEBERG_ASSIGN_OR_RAISE(auto parsed, Decimal::FromString(std::string_view(buf, ptr),
+                                                           nullptr, &parsed_scale));
 
   ICEBERG_ASSIGN_OR_RAISE(auto unscaled, RescaleHalfUp(parsed, parsed_scale,
                                                        decimal_type.scale(), value < 0));

--- a/src/iceberg/expression/literal.cc
+++ b/src/iceberg/expression/literal.cc
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "iceberg/result.h"
 #include "iceberg/type.h"
 #include "iceberg/util/checked_cast.h"
 #include "iceberg/util/conversions.h"

--- a/src/iceberg/expression/literal.cc
+++ b/src/iceberg/expression/literal.cc
@@ -19,6 +19,7 @@
 
 #include "iceberg/expression/literal.h"
 
+#include <array>
 #include <charconv>
 #include <cmath>
 #include <concepts>
@@ -186,15 +187,16 @@ Result<Literal> LiteralCaster::CastRealToDecimal(
   // Convert via the shortest round-tripping decimal string (std::to_chars without a
   // format specifier), then round to the target scale. Float callers widen to double
   // first, so both float and double sources share this path.
-  char buf[64];
-  auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), value);
+  std::array<char, 64> buf{};
+  auto [ptr, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), value);
   if (ec != std::errc{}) {
     return InvalidArgument("Cannot cast {} as a {} value", value,
                            target_type->ToString());
   }
   int32_t parsed_scale = 0;
-  ICEBERG_ASSIGN_OR_RAISE(auto parsed, Decimal::FromString(std::string_view(buf, ptr),
-                                                           nullptr, &parsed_scale));
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto parsed,
+      Decimal::FromString(std::string_view(buf.data(), ptr), nullptr, &parsed_scale));
 
   ICEBERG_ASSIGN_OR_RAISE(auto unscaled, RescaleHalfUp(parsed, parsed_scale,
                                                        decimal_type.scale(), value < 0));

--- a/src/iceberg/expression/literal.cc
+++ b/src/iceberg/expression/literal.cc
@@ -104,35 +104,63 @@ Literal LiteralCaster::AboveMaxLiteral(std::shared_ptr<PrimitiveType> type) {
   return Literal(Literal::AboveMax{}, std::move(type));
 }
 
+namespace {
+
+// Rescale `unscaled` (interpreted at `from_scale`) to `to_scale` using HALF_UP rounding
+// (round half away from zero), matching Java's BigDecimal.setScale(scale, HALF_UP).
+// Unlike Decimal::Rescale, which only truncates and rejects any dropped remainder, this
+// rounds, and it supports the full negative..positive scale range Iceberg decimals allow.
+Result<Decimal> RescaleHalfUp(const Decimal& unscaled, int32_t from_scale,
+                              int32_t to_scale, bool negative) {
+  const int32_t delta = to_scale - from_scale;
+  if (delta == 0) {
+    return unscaled;
+  }
+  if (delta > 0) {
+    // Growing the scale multiplies by 10^delta and is exact; Rescale rejects overflow.
+    if (delta > Decimal::kMaxScale) {
+      return InvalidArgument("scale change {} exceeds the maximum {}", delta,
+                             Decimal::kMaxScale);
+    }
+    return unscaled.Rescale(from_scale, to_scale);
+  }
+  // Shrinking the scale drops `drop` digits with HALF_UP rounding. A drop larger than the
+  // digits any decimal can hold rounds everything away, so the result is zero (e.g.
+  // 1e-100 to decimal(9, 2)); this also keeps the divisor within the powers-of-ten table.
+  const int32_t drop = -delta;
+  if (drop > Decimal::kMaxScale) {
+    return Decimal(0);
+  }
+  ICEBERG_ASSIGN_OR_RAISE(auto divisor, Decimal(1).Rescale(0, drop));
+  ICEBERG_ASSIGN_OR_RAISE(auto divmod, unscaled.Divide(divisor));
+  Decimal quotient = divmod.first;
+  Decimal remainder = Decimal::Abs(divmod.second);
+  if (remainder * Decimal(2) >= divisor) {
+    quotient += negative ? Decimal(-1) : Decimal(1);
+  }
+  return quotient;
+}
+
+}  // namespace
+
 Result<Literal> LiteralCaster::CastIntegerToDecimal(
     int64_t value, const std::shared_ptr<PrimitiveType>& target_type) {
   const auto& decimal_type = internal::checked_cast<const DecimalType&>(*target_type);
-  const int32_t scale = decimal_type.scale();
-  // DecimalType does not bound its scale, but Rescale indexes a powers-of-ten table sized
-  // for [0, kMaxScale]; reject an out-of-range scale here rather than reading past it.
-  if (scale < 0 || scale > Decimal::kMaxScale) {
+  // An integer has scale 0; rescale it to the target scale, rounding HALF_UP when the
+  // target scale is negative (matching Java's numeric-to-decimal default handling).
+  ICEBERG_ASSIGN_OR_RAISE(auto unscaled, RescaleHalfUp(Decimal(value), /*from_scale=*/0,
+                                                       decimal_type.scale(), value < 0));
+  if (!unscaled.FitsInPrecision(decimal_type.precision())) {
     return InvalidArgument("Cannot cast {} as a {} value", value,
                            target_type->ToString());
   }
-  // An integer has scale 0, so scaling it to the target scale multiplies the unscaled
-  // value by 10^scale; Rescale rejects a target scale that would overflow the value.
-  ICEBERG_ASSIGN_OR_RAISE(auto decimal, Decimal(value).Rescale(0, scale));
-  if (!decimal.FitsInPrecision(decimal_type.precision())) {
-    return InvalidArgument("Cannot cast {} as a {} value", value,
-                           target_type->ToString());
-  }
-  return Literal::Decimal(decimal.value(), decimal_type.precision(),
+  return Literal::Decimal(unscaled.value(), decimal_type.precision(),
                           decimal_type.scale());
 }
 
 Result<Literal> LiteralCaster::CastRealToDecimal(
     double value, const std::shared_ptr<PrimitiveType>& target_type) {
   const auto& decimal_type = internal::checked_cast<const DecimalType&>(*target_type);
-  const int32_t target_scale = decimal_type.scale();
-  if (target_scale < 0 || target_scale > Decimal::kMaxScale) {
-    return InvalidArgument("Cannot cast {} as a {} value", value,
-                           target_type->ToString());
-  }
   if (!std::isfinite(value)) {
     return InvalidArgument("Cannot cast {} as a {} value", value,
                            target_type->ToString());
@@ -140,33 +168,19 @@ Result<Literal> LiteralCaster::CastRealToDecimal(
 
   // Parse the shortest round-tripping decimal representation of the value (matching
   // Java's BigDecimal.valueOf(double), which goes through Double.toString) into a
-  // full-precision decimal, then round to the target scale below.
+  // full-precision decimal, then round to the target scale.
   int32_t parsed_scale = 0;
   ICEBERG_ASSIGN_OR_RAISE(
       auto parsed, Decimal::FromString(std::format("{}", value), nullptr, &parsed_scale));
 
-  Decimal unscaled = parsed;
-  if (parsed_scale > target_scale) {
-    // Drop excess fractional digits with HALF_UP rounding (round half away from zero, as
-    // Java does), since Rescale itself only truncates and rejects any dropped remainder.
-    const int32_t drop = parsed_scale - target_scale;
-    ICEBERG_ASSIGN_OR_RAISE(auto divisor, Decimal(1).Rescale(0, drop));
-    ICEBERG_ASSIGN_OR_RAISE(auto divmod, parsed.Divide(divisor));
-    Decimal quotient = divmod.first;
-    Decimal remainder = Decimal::Abs(divmod.second);
-    if (remainder * Decimal(2) >= divisor) {
-      quotient += (value < 0) ? Decimal(-1) : Decimal(1);
-    }
-    unscaled = quotient;
-  } else if (parsed_scale < target_scale) {
-    ICEBERG_ASSIGN_OR_RAISE(unscaled, parsed.Rescale(parsed_scale, target_scale));
-  }
-
+  ICEBERG_ASSIGN_OR_RAISE(auto unscaled, RescaleHalfUp(parsed, parsed_scale,
+                                                       decimal_type.scale(), value < 0));
   if (!unscaled.FitsInPrecision(decimal_type.precision())) {
     return InvalidArgument("Cannot cast {} as a {} value", value,
                            target_type->ToString());
   }
-  return Literal::Decimal(unscaled.value(), decimal_type.precision(), target_scale);
+  return Literal::Decimal(unscaled.value(), decimal_type.precision(),
+                          decimal_type.scale());
 }
 
 Result<Literal> LiteralCaster::CastFromInt(

--- a/src/iceberg/expression/literal.cc
+++ b/src/iceberg/expression/literal.cc
@@ -85,6 +85,10 @@ class LiteralCaster {
   /// Cast from Fixed type to target type.
   static Result<Literal> CastFromFixed(const Literal& literal,
                                        const std::shared_ptr<PrimitiveType>& target_type);
+
+  /// Cast an integer value (from Int or Long) to a decimal target type.
+  static Result<Literal> CastIntegerToDecimal(
+      int64_t value, const std::shared_ptr<PrimitiveType>& target_type);
 };
 
 Literal LiteralCaster::BelowMinLiteral(std::shared_ptr<PrimitiveType> type) {
@@ -93,6 +97,20 @@ Literal LiteralCaster::BelowMinLiteral(std::shared_ptr<PrimitiveType> type) {
 
 Literal LiteralCaster::AboveMaxLiteral(std::shared_ptr<PrimitiveType> type) {
   return Literal(Literal::AboveMax{}, std::move(type));
+}
+
+Result<Literal> LiteralCaster::CastIntegerToDecimal(
+    int64_t value, const std::shared_ptr<PrimitiveType>& target_type) {
+  const auto& decimal_type = internal::checked_cast<const DecimalType&>(*target_type);
+  // An integer has scale 0, so scaling it to the target scale multiplies the unscaled
+  // value by 10^scale; Rescale rejects a target scale that would overflow the value.
+  ICEBERG_ASSIGN_OR_RAISE(auto decimal, Decimal(value).Rescale(0, decimal_type.scale()));
+  if (!decimal.FitsInPrecision(decimal_type.precision())) {
+    return InvalidArgument("Cannot cast {} as a {} value", value,
+                           target_type->ToString());
+  }
+  return Literal::Decimal(decimal.value(), decimal_type.precision(),
+                          decimal_type.scale());
 }
 
 Result<Literal> LiteralCaster::CastFromInt(
@@ -109,6 +127,8 @@ Result<Literal> LiteralCaster::CastFromInt(
       return Literal::Double(static_cast<double>(int_val));
     case TypeId::kDate:
       return Literal::Date(int_val);
+    case TypeId::kDecimal:
+      return CastIntegerToDecimal(static_cast<int64_t>(int_val), target_type);
     default:
       return NotSupported("Cast from Int to {} is not implemented",
                           target_type->ToString());
@@ -153,6 +173,8 @@ Result<Literal> LiteralCaster::CastFromLong(
       return Literal::TimestampNs(long_val);
     case TypeId::kTimestampTzNs:
       return Literal::TimestampTzNs(long_val);
+    case TypeId::kDecimal:
+      return CastIntegerToDecimal(long_val, target_type);
     default:
       return NotSupported("Cast from Long to {} is not supported",
                           target_type->ToString());

--- a/src/iceberg/expression/literal.cc
+++ b/src/iceberg/expression/literal.cc
@@ -130,12 +130,18 @@ Result<Decimal> RescaleHalfUp(const Decimal& unscaled, int32_t from_scale,
     return unscaled;
   }
   if (delta > 0) {
-    // Growing the scale multiplies by 10^delta and is exact; Rescale rejects overflow.
+    // Growing the scale multiplies the coefficient by 10^delta. Report an overflow as an
+    // invalid argument (consistent with the other rejections here) rather than leaking
+    // Rescale's "data loss" error to callers.
     if (delta > Decimal::kMaxScale) {
       return InvalidArgument("scale change {} exceeds the maximum {}", delta,
                              Decimal::kMaxScale);
     }
-    return unscaled.Rescale(from_scale, to_scale);
+    auto rescaled = unscaled.Rescale(from_scale, to_scale);
+    if (!rescaled.has_value()) {
+      return InvalidArgument("value does not fit the target decimal scale");
+    }
+    return rescaled.value();
   }
   // Shrinking the scale drops `drop` digits with HALF_UP rounding. A drop larger than the
   // digits any decimal can hold rounds everything away, so the result is zero (e.g.
@@ -155,6 +161,55 @@ Result<Decimal> RescaleHalfUp(const Decimal& unscaled, int32_t from_scale,
     quotient += negative ? Decimal(-1) : Decimal(1);
   }
   return quotient;
+}
+
+// Parse a `std::to_chars` double rendering (`[-]digits[.digits][e[+-]exp]`) into an
+// integer coefficient and the scale at which it is interpreted (value == coefficient *
+// 10^-scale). The coefficient is just the significant digits, so it never overflows
+// int128; the exponent is folded into the returned scale rather than expanded, leaving
+// RescaleHalfUp to combine it with the target scale.
+Result<Decimal> ParseRealCoefficient(std::string_view str, int32_t* scale) {
+  bool negative = !str.empty() && str.front() == '-';
+  if (negative) {
+    str.remove_prefix(1);
+  }
+
+  int32_t exponent = 0;
+  if (auto e = str.find_first_of("eE"); e != std::string_view::npos) {
+    auto exp_str = str.substr(e + 1);
+    // std::to_chars writes a leading '+' for positive exponents, which from_chars
+    // rejects.
+    if (!exp_str.empty() && exp_str.front() == '+') {
+      exp_str.remove_prefix(1);
+    }
+    if (std::from_chars(exp_str.data(), exp_str.data() + exp_str.size(), exponent).ec !=
+        std::errc{}) {
+      return InvalidArgument("Invalid real value '{}'", str);
+    }
+    str = str.substr(0, e);
+  }
+
+  int32_t frac_digits = 0;
+  std::string digits;
+  digits.reserve(str.size());
+  if (auto dot = str.find('.'); dot != std::string_view::npos) {
+    frac_digits = static_cast<int32_t>(str.size() - dot - 1);
+    digits.append(str.substr(0, dot));
+    digits.append(str.substr(dot + 1));
+  } else {
+    digits.append(str);
+  }
+  if (digits.empty() || digits.find_first_not_of("0123456789") != std::string::npos) {
+    return InvalidArgument("Invalid real value '{}'", str);
+  }
+
+  // Coefficient has scale `frac_digits`; a positive base-10 exponent lowers that scale.
+  *scale = frac_digits - exponent;
+  ICEBERG_ASSIGN_OR_RAISE(auto coefficient, Decimal::FromString(digits));
+  if (negative) {
+    coefficient.Negate();
+  }
+  return coefficient;
 }
 
 }  // namespace
@@ -193,12 +248,18 @@ Result<Literal> LiteralCaster::CastRealToDecimal(
     return InvalidArgument("Cannot cast {} as a {} value", value,
                            target_type->ToString());
   }
-  int32_t parsed_scale = 0;
-  ICEBERG_ASSIGN_OR_RAISE(
-      auto parsed,
-      Decimal::FromString(std::string_view(buf.data(), ptr), nullptr, &parsed_scale));
 
-  ICEBERG_ASSIGN_OR_RAISE(auto unscaled, RescaleHalfUp(parsed, parsed_scale,
+  // Parse the coefficient and its scale directly instead of via Decimal::FromString,
+  // which normalizes a negative scale by multiplying the coefficient by 10^-scale and can
+  // overflow int128 for large magnitudes (e.g. 4e38). The coefficient itself always fits,
+  // and RescaleHalfUp handles the exponent against the target scale (and rejects
+  // overflow).
+  int32_t coeff_scale = 0;
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto coefficient,
+      ParseRealCoefficient(std::string_view(buf.data(), ptr), &coeff_scale));
+
+  ICEBERG_ASSIGN_OR_RAISE(auto unscaled, RescaleHalfUp(coefficient, coeff_scale,
                                                        decimal_type.scale(), value < 0));
   if (!unscaled.FitsInPrecision(decimal_type.precision())) {
     return InvalidArgument("Cannot cast {} as a {} value", value,

--- a/src/iceberg/test/literal_test.cc
+++ b/src/iceberg/test/literal_test.cc
@@ -173,6 +173,8 @@ TEST(LiteralTest, IntegerCastToDecimal) {
   // (DecimalType does not bound its scale on construction).
   EXPECT_THAT(Literal::Int(1).CastTo(std::make_shared<DecimalType>(9, 40)),
               IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(Literal::Int(1).CastTo(std::make_shared<DecimalType>(9, -40)),
+              IsError(ErrorKind::kInvalidArgument));
 
   // Negative scale: decimal(9, -2) scales by 10^2, so 149 rounds HALF_UP to 100 (unscaled
   // value 1 at scale -2), matching Java's setScale(-2, HALF_UP).
@@ -207,6 +209,11 @@ TEST(LiteralTest, RealCastToDecimal) {
   ASSERT_THAT(round_down, IsOk());
   EXPECT_EQ(*round_down, Literal::Decimal(2, 2, 0));
 
+  // Shortest round-trip conversion keeps digits beyond a default 6-digit %g.
+  auto precise = Literal::Double(1.23456789).CastTo(decimal(20, 8));
+  ASSERT_THAT(precise, IsOk());
+  EXPECT_EQ(*precise, Literal::Decimal(123456789, 20, 8));
+
   // A value whose rounded form exceeds the target precision is rejected.
   EXPECT_THAT(Literal::Double(123.4).CastTo(decimal(2, 0)),
               IsError(ErrorKind::kInvalidArgument));
@@ -214,6 +221,8 @@ TEST(LiteralTest, RealCastToDecimal) {
   EXPECT_THAT(
       Literal::Double(std::numeric_limits<double>::quiet_NaN()).CastTo(decimal(4, 2)),
       IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(Literal::Double(1.0).CastTo(std::make_shared<DecimalType>(9, -40)),
+              IsError(ErrorKind::kInvalidArgument));
 
   // A magnitude far smaller than the target scale rounds to zero rather than indexing
   // past the powers-of-ten table (Java rounds 1e-100 to 0.00).

--- a/src/iceberg/test/literal_test.cc
+++ b/src/iceberg/test/literal_test.cc
@@ -173,6 +173,41 @@ TEST(LiteralTest, IntegerCastToDecimal) {
               IsError(ErrorKind::kInvalidArgument));
 }
 
+TEST(LiteralTest, RealCastToDecimal) {
+  // A double is scaled to the target scale keeping its unscaled value: 9.99 ->
+  // 999@(10,2).
+  auto d = Literal::Double(9.99).CastTo(decimal(10, 2));
+  ASSERT_THAT(d, IsOk());
+  EXPECT_EQ(*d, Literal::Decimal(999, 10, 2));
+
+  auto f = Literal::Float(1.5f).CastTo(decimal(4, 3));
+  ASSERT_THAT(f, IsOk());
+  EXPECT_EQ(*f, Literal::Decimal(1500, 4, 3));
+
+  // Rounding is HALF_UP (round half away from zero), matching Java: 2.5 -> 3 (not the
+  // banker's-rounding 2), and -2.5 -> -3.
+  auto half_up = Literal::Double(2.5).CastTo(decimal(2, 0));
+  ASSERT_THAT(half_up, IsOk());
+  EXPECT_EQ(*half_up, Literal::Decimal(3, 2, 0));
+
+  auto neg_half_up = Literal::Double(-2.5).CastTo(decimal(2, 0));
+  ASSERT_THAT(neg_half_up, IsOk());
+  EXPECT_EQ(*neg_half_up, Literal::Decimal(-3, 2, 0));
+
+  // Below the halfway point rounds down.
+  auto round_down = Literal::Double(2.4).CastTo(decimal(2, 0));
+  ASSERT_THAT(round_down, IsOk());
+  EXPECT_EQ(*round_down, Literal::Decimal(2, 2, 0));
+
+  // A value whose rounded form exceeds the target precision is rejected.
+  EXPECT_THAT(Literal::Double(123.4).CastTo(decimal(2, 0)),
+              IsError(ErrorKind::kInvalidArgument));
+  // Non-finite values cannot be represented as a decimal.
+  EXPECT_THAT(
+      Literal::Double(std::numeric_limits<double>::quiet_NaN()).CastTo(decimal(4, 2)),
+      IsError(ErrorKind::kInvalidArgument));
+}
+
 // Error cases for casts
 TEST(LiteralTest, CastToError) {
   std::vector<uint8_t> data = {0x01, 0x02, 0x03, 0x04};

--- a/src/iceberg/test/literal_test.cc
+++ b/src/iceberg/test/literal_test.cc
@@ -20,12 +20,14 @@
 #include "iceberg/expression/literal.h"
 
 #include <limits>
+#include <memory>
 #include <numbers>
 #include <unordered_set>
 #include <vector>
 
 #include <gtest/gtest.h>
 
+#include "iceberg/result.h"
 #include "iceberg/test/matchers.h"
 #include "iceberg/test/temporal_test_helper.h"
 #include "iceberg/type.h"

--- a/src/iceberg/test/literal_test.cc
+++ b/src/iceberg/test/literal_test.cc
@@ -150,6 +150,24 @@ TEST(LiteralTest, DoubleCastToOverflow) {
   EXPECT_TRUE(min_result->IsBelowMin());
 }
 
+TEST(LiteralTest, IntegerCastToDecimal) {
+  // An integer default is scaled up to the target decimal scale: 12 -> 12.00 keeps the
+  // unscaled value 1200 at precision/scale (9, 2).
+  auto int_result = Literal::Int(12).CastTo(decimal(9, 2));
+  ASSERT_THAT(int_result, IsOk());
+  EXPECT_EQ(*int_result, Literal::Decimal(1200, 9, 2));
+
+  auto long_result = Literal::Long(int64_t{12}).CastTo(decimal(18, 3));
+  ASSERT_THAT(long_result, IsOk());
+  EXPECT_EQ(*long_result, Literal::Decimal(12000, 18, 3));
+
+  // A value whose scaled form needs more digits than the target precision is rejected.
+  EXPECT_THAT(Literal::Int(12345).CastTo(decimal(4, 0)),
+              IsError(ErrorKind::kInvalidArgument));
+  EXPECT_THAT(Literal::Long(int64_t{100}).CastTo(decimal(4, 2)),
+              IsError(ErrorKind::kInvalidArgument));
+}
+
 // Error cases for casts
 TEST(LiteralTest, CastToError) {
   std::vector<uint8_t> data = {0x01, 0x02, 0x03, 0x04};

--- a/src/iceberg/test/literal_test.cc
+++ b/src/iceberg/test/literal_test.cc
@@ -171,6 +171,12 @@ TEST(LiteralTest, IntegerCastToDecimal) {
   // (DecimalType does not bound its scale on construction).
   EXPECT_THAT(Literal::Int(1).CastTo(std::make_shared<DecimalType>(9, 40)),
               IsError(ErrorKind::kInvalidArgument));
+
+  // Negative scale: decimal(9, -2) scales by 10^2, so 149 rounds HALF_UP to 100 (unscaled
+  // value 1 at scale -2), matching Java's setScale(-2, HALF_UP).
+  auto neg_scale = Literal::Int(149).CastTo(decimal(9, -2));
+  ASSERT_THAT(neg_scale, IsOk());
+  EXPECT_EQ(*neg_scale, Literal::Decimal(1, 9, -2));
 }
 
 TEST(LiteralTest, RealCastToDecimal) {
@@ -206,6 +212,18 @@ TEST(LiteralTest, RealCastToDecimal) {
   EXPECT_THAT(
       Literal::Double(std::numeric_limits<double>::quiet_NaN()).CastTo(decimal(4, 2)),
       IsError(ErrorKind::kInvalidArgument));
+
+  // A magnitude far smaller than the target scale rounds to zero rather than indexing
+  // past the powers-of-ten table (Java rounds 1e-100 to 0.00).
+  auto tiny = Literal::Double(1e-100).CastTo(decimal(9, 2));
+  ASSERT_THAT(tiny, IsOk());
+  EXPECT_EQ(*tiny, Literal::Decimal(0, 9, 2));
+
+  // Negative scale: decimal(9, -2) scales by 10^2, so 149 rounds HALF_UP to 100 (unscaled
+  // value 1 at scale -2), matching Java's setScale(-2, HALF_UP).
+  auto neg_scale = Literal::Double(149.0).CastTo(decimal(9, -2));
+  ASSERT_THAT(neg_scale, IsOk());
+  EXPECT_EQ(*neg_scale, Literal::Decimal(1, 9, -2));
 }
 
 // Error cases for casts

--- a/src/iceberg/test/literal_test.cc
+++ b/src/iceberg/test/literal_test.cc
@@ -166,6 +166,11 @@ TEST(LiteralTest, IntegerCastToDecimal) {
               IsError(ErrorKind::kInvalidArgument));
   EXPECT_THAT(Literal::Long(int64_t{100}).CastTo(decimal(4, 2)),
               IsError(ErrorKind::kInvalidArgument));
+
+  // A scale beyond the decimal powers-of-ten table is rejected rather than read past it
+  // (DecimalType does not bound its scale on construction).
+  EXPECT_THAT(Literal::Int(1).CastTo(std::make_shared<DecimalType>(9, 40)),
+              IsError(ErrorKind::kInvalidArgument));
 }
 
 // Error cases for casts

--- a/src/iceberg/test/literal_test.cc
+++ b/src/iceberg/test/literal_test.cc
@@ -235,6 +235,17 @@ TEST(LiteralTest, RealCastToDecimal) {
   auto neg_scale = Literal::Double(149.0).CastTo(decimal(9, -2));
   ASSERT_THAT(neg_scale, IsOk());
   EXPECT_EQ(*neg_scale, Literal::Decimal(1, 9, -2));
+
+  // A large magnitude must be rejected for exceeding precision, not wrap the int128
+  // coefficient: 4e38 needs 39 digits, over decimal(38, 0)'s precision.
+  EXPECT_THAT(Literal::Double(4e38).CastTo(decimal(38, 0)),
+              IsError(ErrorKind::kInvalidArgument));
+
+  // A large magnitude that IS representable at a negative scale is accepted: 1e39 as
+  // decimal(2, -38) is the unscaled value 10 (10 * 10^38).
+  auto big_neg_scale = Literal::Double(1e39).CastTo(decimal(2, -38));
+  ASSERT_THAT(big_neg_scale, IsOk());
+  EXPECT_EQ(*big_neg_scale, Literal::Decimal(10, 2, -38));
 }
 
 // Error cases for casts


### PR DESCRIPTION
## What

Add casting of numeric literals (`int`, `long`, `float`, `double`) to a decimal target type in `Literal::CastTo`, so a numeric value can be used as a default for a decimal column.

Previously `CastFromInt` / `CastFromLong` / `CastFromFloat` / `CastFromDouble` had no `kDecimal` case and fell through to `NotSupported`, so a default like `Literal::Int(12)` or `Literal::Double(9.99)` for a `decimal(9, 2)` column was rejected. Java allows these (`IntegerLiteral.to`, `DoubleLiteral.to`, etc. scale the value to the target scale), so this brings the C++ literal cast layer to parity for numeric sources.

## How

- **Integer → decimal**: `CastIntegerToDecimal` treats the integer as scale 0 and rescales it to the target scale via `RescaleHalfUp` (exact when increasing scale, HALF_UP when decreasing it), then verifies the result fits the target precision (`FitsInPrecision`). Example: `12` → `decimal(9,2)` yields unscaled `1200` (`12.00`).
- **Float/double → decimal**: `CastRealToDecimal` parses the value's shortest round-tripping decimal representation (matching Java's `BigDecimal.valueOf(double)` via `Double.toString`) into an integer coefficient and exponent-derived scale without expanding scientific notation, then rounds to the target scale with **HALF_UP** rounding (round half away from zero, as Java does — `2.5` → `3`, `-2.5` → `-3`) and checks precision. Non-finite values are rejected.
- Both paths reject an out-of-range decimal scale before indexing the powers-of-ten table (`DecimalType` does not bound its scale on construction, so `decimal(9, 40)` would otherwise read past the table).

## Scope

Follow-up split out from the v3 default-value work (see the `CastDefaultToType` discussion on #793). It only extends the shared `Literal::CastTo` layer for numeric sources.

## Testing

`LiteralTest.IntegerCastToDecimal` (int/long scaling, out-of-precision rejection, out-of-range scale rejection) and `LiteralTest.RealCastToDecimal` (float/double scaling, HALF_UP rounding incl. negative, round-down, out-of-precision and non-finite rejection, scientific-notation overflow rejection and negative-scale acceptance), all verified fail-without / pass-with. Full `expression_test` passes (495 tests).
