### PR TITLE
ci: build Windows test leg in Debug

### DIFF
--- a/.github/workflows/sql_catalog_test.yml
+++ b/.github/workflows/sql_catalog_test.yml
@@ -58,7 +58,7 @@ jobs:
             cmake_extra_args: ""
           - title: AMD64 Windows 2025
             runs-on: windows-2025
-            cmake_build_type: Release
+            cmake_build_type: Debug
             cmake_extra_args: -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
     env:
       SCCACHE_DIR: ${{ github.workspace }}/.sccache

--- a/ci/scripts/build_example.sh
+++ b/ci/scripts/build_example.sh
@@ -49,26 +49,19 @@ CMAKE_ARGS=(
 
 if is_windows; then
     CMAKE_ARGS+=("-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake")
-    CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Release")
-else
-    CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Debug")
 fi
 
+build_type="${ICEBERG_BUILD_TYPE:-Debug}"
+CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=${build_type}")
+
 cmake "${CMAKE_ARGS[@]}" ${source_dir}
-if is_windows; then
-  cmake --build . --config Release
-  if [[ "${run_example}" == "ON" ]]; then
-    if [[ -x ./demo_example.exe ]]; then
-      ./demo_example.exe
+cmake --build .
+if [[ "${run_example}" == "ON" ]]; then
+    if is_windows; then
+        ./demo_example.exe
     else
-      ./Release/demo_example.exe
+        ./demo_example
     fi
-  fi
-else
-  cmake --build .
-  if [[ "${run_example}" == "ON" ]]; then
-    ./demo_example
-  fi
 fi
 
 popd

--- a/ci/scripts/build_iceberg.sh
+++ b/ci/scripts/build_iceberg.sh
@@ -37,11 +37,7 @@ is_windows() {
     [[ "${OSTYPE}" == "msys" || "${OSTYPE}" == "win32" || "${OSTYPE}" == "cygwin" ]]
 }
 
-if is_windows; then
-    build_type=${7:-Release}
-else
-    build_type=${7:-Debug}
-fi
+build_type=${7:-Debug}
 
 CMAKE_ARGS=(
     "-G Ninja"
@@ -70,15 +66,15 @@ else
 fi
 
 if is_windows; then
-    CMAKE_ARGS+=("-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake")
-    CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=${build_type}")
-else
-    # Pass an externally provided toolchain (e.g. vcpkg for the SigV4 job)
-    if [[ -n "${CMAKE_TOOLCHAIN_FILE:-}" ]]; then
-        CMAKE_ARGS+=("-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
-    fi
-    CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=${build_type}")
+    CMAKE_TOOLCHAIN_FILE="${CMAKE_TOOLCHAIN_FILE:-C:/vcpkg/scripts/buildsystems/vcpkg.cmake}"
 fi
+
+# Pass an externally provided toolchain, or the default Windows vcpkg toolchain.
+if [[ -n "${CMAKE_TOOLCHAIN_FILE:-}" ]]; then
+    CMAKE_ARGS+=("-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
+fi
+
+CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=${build_type}")
 
 if [[ "${build_enable_sccache}" == "ON" ]]; then
     CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER_LAUNCHER=sccache")
@@ -91,16 +87,10 @@ if [[ -n "${ICEBERG_EXTRA_CMAKE_ARGS:-}" ]]; then
 fi
 
 cmake "${CMAKE_ARGS[@]}" ${source_dir}
-if is_windows; then
-  cmake --build . --config "${build_type}" --target install
-  if [[ "${run_tests}" == "ON" ]]; then
-    ctest --output-on-failure -C "${build_type}"
-  fi
-else
-  cmake --build . --target install
-  if [[ "${run_tests}" == "ON" ]]; then
+
+cmake --build . --target install
+if [[ "${run_tests}" == "ON" ]]; then
     ctest --output-on-failure
-  fi
 fi
 
 popd

--- a/cmake_modules/IcebergSccache.cmake
+++ b/cmake_modules/IcebergSccache.cmake
@@ -18,19 +18,12 @@
 if(MSVC_TOOLCHAIN AND "${CMAKE_CXX_COMPILER_LAUNCHER}" STREQUAL "sccache")
   message(STATUS "Configuring sccache for MSVC")
 
-  # Remove /Zi or /ZI
-  string(REGEX REPLACE "/Z[iI]" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-  string(REGEX REPLACE "/Z[iI]" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  # Keep MSVC Debug objects cacheable by sccache without affecting Release.
+  set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 
-  string(REGEX REPLACE "/Z[iI]" "" CMAKE_C_FLAGS_RELWITHDEBINFO
-                       "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
-  string(REGEX REPLACE "/Z[iI]" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO
-                       "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
-
-  # Add /Z7
-  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /Z7")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Z7")
-
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} /Z7")
-  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /Z7")
+  # CMP0141 normally handles these flags; normalize any flags injected elsewhere.
+  foreach(flag_var CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG CMAKE_C_FLAGS_RELWITHDEBINFO
+                   CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+    string(REGEX REPLACE "/Z[iI]" "/Z7" ${flag_var} "${${flag_var}}")
+  endforeach()
 endif()

--- a/src/iceberg/test/scan_test_base.h
+++ b/src/iceberg/test/scan_test_base.h
@@ -221,7 +221,7 @@ class ScanTestBase : public testing::TestWithParam<int8_t> {
       std::shared_ptr<PartitionSpec> spec = nullptr) {
     std::vector<std::pair<std::string, PartitionValues>> files_with_partitions;
     for (const auto& path : added_files) {
-      files_with_partitions.emplace_back(path, kEmptyPartition);
+      files_with_partitions.emplace_back(path, PartitionValues{});
     }
     return MakeAppendSnapshotWithPartitionValues(format_version, snapshot_id,
                                                  parent_snapshot_id, sequence_number,
@@ -350,7 +350,6 @@ class ScanTestBase : public testing::TestWithParam<int8_t> {
  private:
   int manifest_counter_ = 0;
   int manifest_list_counter_ = 0;
-  constexpr static PartitionValues kEmptyPartition{};
 };
 
 }  // namespace iceberg


### PR DESCRIPTION
## What
Let the CMake CI scripts use `ICEBERG_BUILD_TYPE` and default to `Debug`, including on Windows. MSVC builds with debug info now use embedded `/Z7` debug info through `CMP0141` and `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` so Debug objects remain cacheable by sccache.

The build scripts also use the same single-config Ninja build path on every platform. Since these jobs pass `-G Ninja`, `CMAKE_BUILD_TYPE` controls the build and `--config Release` / `ctest -C Release` were not needed.

## Why
Windows was the only main `Test` workflow leg still forcing the helper scripts through `Release`. After this change, the helper-script CMake test jobs default to `Debug` on pull requests and `main`; `ICEBERG_BUILD_TYPE` remains available if the project wants an override. Release verification and the SQL Catalog workflow's explicit Windows `Release` matrix entry are unchanged.

The original Windows Debug blocker in #39 was an `IMPORTED_LOCATION` failure from a multi-config CMake path. That specific failure no longer applies because the helper scripts now use Ninja single-config builds. The remaining Debug-only blocker was MSVC rejecting a `constexpr static PartitionValues` test helper: `PartitionValues` owns a `std::vector`, and MSVC Debug's checked-iterator mode (`_ITERATOR_DEBUG_LEVEL != 0`) makes that construction fail constant evaluation. This PR constructs the empty `PartitionValues` at the call site instead.

This follows the CI direction discussed in #799.

## Validation
Fork validation passed:

- `Test / AMD64 Windows 2025` passed in 23m48s on the pull-request run: https://github.com/abnobdoss/iceberg-cpp/actions/runs/28638474339/job/84929642907
- `SQL Catalog / AMD64 Windows 2025` passed in 4m13s: https://github.com/abnobdoss/iceberg-cpp/actions/runs/28638474303/job/84929643407
- `Meson / AMD64 Windows 2025` passed in 3m21s: https://github.com/abnobdoss/iceberg-cpp/actions/runs/28638474339/job/84929642897

The Windows Debug test job reported 45% sccache hits, 385 hits, 477 misses, and 0 errors. The first post-merge Apache `main` run will reseed Windows cache entries because the previous entries were built from Release objects.

Closes #39.