### PR TITLE
ci: retry build dir cleanup on Windows

### DIFF
--- a/ci/scripts/build_example.sh
+++ b/ci/scripts/build_example.sh
@@ -31,6 +31,8 @@ for attempt in 1 2 3; do
     fi
     if [[ "${attempt}" != "3" ]]; then
         sleep 2
+    else
+        echo "Failed to remove build directory after 3 attempts: ${build_dir}" >&2
     fi
 done
 mkdir "${build_dir}"

--- a/ci/scripts/build_example.sh
+++ b/ci/scripts/build_example.sh
@@ -23,7 +23,16 @@ source_dir=${1}
 build_dir=${1}/build
 run_example=${ICEBERG_RUN_EXAMPLE:-OFF}
 
-rm -rf "${build_dir}"
+# Clean up before configuring. If Windows still holds a just-built exe/dll
+# after the retries, let mkdir fail rather than reuse a half-deleted tree.
+for attempt in 1 2 3; do
+    if rm -rf "${build_dir}"; then
+        break
+    fi
+    if [[ "${attempt}" != "3" ]]; then
+        sleep 2
+    fi
+done
 mkdir "${build_dir}"
 pushd ${build_dir}
 

--- a/ci/scripts/build_iceberg.sh
+++ b/ci/scripts/build_iceberg.sh
@@ -99,5 +99,13 @@ fi
 
 popd
 
-# clean up between builds
-rm -rf ${build_dir}
+# Clean up after the build. Windows can briefly hold a just-built exe/dll,
+# so retry but do not fail an otherwise successful CI job.
+for attempt in 1 2 3; do
+    if rm -rf "${build_dir}"; then
+        break
+    fi
+    if [[ "${attempt}" != "3" ]]; then
+        sleep 2
+    fi
+done

--- a/ci/scripts/build_iceberg.sh
+++ b/ci/scripts/build_iceberg.sh
@@ -107,5 +107,7 @@ for attempt in 1 2 3; do
     fi
     if [[ "${attempt}" != "3" ]]; then
         sleep 2
+    else
+        echo "Failed to remove build directory after 3 attempts: ${build_dir}" >&2
     fi
 done


### PR DESCRIPTION
## What
Retry `rm -rf` cleanup in the CMake CI helper scripts. Windows can briefly keep a just-built executable or DLL open, which can make cleanup fail even after the build and tests have passed.

`build_example.sh` retries before configuring and still lets `mkdir` fail if the directory remains, so it will not build in a half-deleted tree. `build_iceberg.sh` retries after the build and does not fail an otherwise successful job if final cleanup is still blocked.
