### PR TITLE
fix: validate decimal default fits the field precision

### DIFF
--- a/src/iceberg/schema_field.cc
+++ b/src/iceberg/schema_field.cc
@@ -29,6 +29,7 @@
 #include "iceberg/result.h"
 #include "iceberg/type.h"
 #include "iceberg/util/checked_cast.h"
+#include "iceberg/util/decimal.h"
 #include "iceberg/util/formatter.h"  // IWYU pragma: keep
 #include "iceberg/util/macros.h"
 
@@ -184,6 +185,18 @@ Status ValidateDefault(const SchemaField& field, const Literal& value,
       !std::isfinite(std::get<double>(value.value()))) {
     return InvalidSchema("Invalid {} value for {}: value must be finite", kind,
                          field.name());
+  }
+  // A decimal literal carries a precision in its type but stores only an unscaled value,
+  // so a value that does not fit the field precision would pass the type check above yet
+  // be rejected when the metadata is parsed back. Reject it here to keep the default
+  // consistent with what the reader accepts.
+  if (field.type()->type_id() == TypeId::kDecimal &&
+      std::holds_alternative<Decimal>(value.value())) {
+    const auto& decimal_type = internal::checked_cast<const DecimalType&>(*field.type());
+    if (!std::get<Decimal>(value.value()).FitsInPrecision(decimal_type.precision())) {
+      return InvalidSchema("{} of field {} does not fit precision {}", kind, field.name(),
+                           decimal_type.precision());
+    }
   }
   return {};
 }

--- a/src/iceberg/schema_field.cc
+++ b/src/iceberg/schema_field.cc
@@ -190,12 +190,14 @@ Status ValidateDefault(const SchemaField& field, const Literal& value,
   // so a value that does not fit the field precision would pass the type check above yet
   // be rejected when the metadata is parsed back. Reject it here to keep the default
   // consistent with what the reader accepts.
-  if (field.type()->type_id() == TypeId::kDecimal &&
-      std::holds_alternative<Decimal>(value.value())) {
-    const auto& decimal_type = internal::checked_cast<const DecimalType&>(*field.type());
-    if (!std::get<Decimal>(value.value()).FitsInPrecision(decimal_type.precision())) {
-      return InvalidSchema("{} of field {} does not fit precision {}", kind, field.name(),
-                           decimal_type.precision());
+  if (field.type()->type_id() == TypeId::kDecimal) {
+    if (const auto* dec = std::get_if<Decimal>(&value.value())) {
+      const auto& decimal_type =
+          internal::checked_cast<const DecimalType&>(*field.type());
+      if (!dec->FitsInPrecision(decimal_type.precision())) {
+        return InvalidSchema("{} of field {} does not fit precision {}", kind,
+                             field.name(), decimal_type.precision());
+      }
     }
   }
   return {};

--- a/src/iceberg/test/schema_field_test.cc
+++ b/src/iceberg/test/schema_field_test.cc
@@ -203,4 +203,22 @@ TEST(SchemaFieldTest, ValidateAcceptsFiniteFloatingDefault) {
   EXPECT_THAT(field.Validate(), IsOk());
 }
 
+TEST(SchemaFieldTest, ValidateRejectsDecimalDefaultExceedingPrecision) {
+  // A decimal default whose unscaled value needs more digits than the field precision has
+  // the matching literal type (decimal(2, 1)) but does not fit; Validate must reject it
+  // so it is never serialized to metadata the reader would later refuse to parse.
+  SchemaField field(/*field_id=*/1, /*name=*/"d", decimal(2, 1),
+                    /*optional=*/true, /*doc=*/"",
+                    std::make_shared<const Literal>(Literal::Decimal(999, 2, 1)));
+  EXPECT_THAT(field.Validate(), IsError(ErrorKind::kInvalidSchema));
+  EXPECT_THAT(field.Validate(), HasErrorMessage("does not fit precision"));
+}
+
+TEST(SchemaFieldTest, ValidateAcceptsDecimalDefaultWithinPrecision) {
+  SchemaField field(/*field_id=*/1, /*name=*/"d", decimal(4, 1),
+                    /*optional=*/true, /*doc=*/"",
+                    std::make_shared<const Literal>(Literal::Decimal(999, 4, 1)));
+  EXPECT_THAT(field.Validate(), IsOk());
+}
+
 }  // namespace iceberg

--- a/src/iceberg/test/schema_field_test.cc
+++ b/src/iceberg/test/schema_field_test.cc
@@ -210,8 +210,9 @@ TEST(SchemaFieldTest, ValidateRejectsDecimalDefaultExceedingPrecision) {
   SchemaField field(/*field_id=*/1, /*name=*/"d", decimal(2, 1),
                     /*optional=*/true, /*doc=*/"",
                     std::make_shared<const Literal>(Literal::Decimal(999, 2, 1)));
-  EXPECT_THAT(field.Validate(), IsError(ErrorKind::kInvalidSchema));
-  EXPECT_THAT(field.Validate(), HasErrorMessage("does not fit precision"));
+  auto status = field.Validate();
+  EXPECT_THAT(status, IsError(ErrorKind::kInvalidSchema));
+  EXPECT_THAT(status, HasErrorMessage("does not fit precision"));
 }
 
 TEST(SchemaFieldTest, ValidateAcceptsDecimalDefaultWithinPrecision) {


### PR DESCRIPTION
## What

`SchemaField::Validate` accepts a decimal default whose unscaled value does not fit the field's declared precision, even though the JSON reader rejects exactly that value on read-back — so a validated field can serialize to metadata that the same reader then refuses to parse.

Example: a `decimal(2, 1)` field with an `initial-default` of `Literal::Decimal(999, 2, 1)` (`99.9`, which needs 3 significant digits). `ValidateDefault` only checked that the literal's type matches the field type (`decimal(2,1) == decimal(2,1)`), so it passed; the value was serialized to `"99.9"`; on read-back `Decimal::FromString` yields precision 3 > 2 and the decimal literal parser (`expression/json_serde.cc`, and `Literal::CastTo`) rejects it. The field's own metadata becomes unreadable.

## How

`ValidateDefault` now checks `Decimal::FitsInPrecision(field precision)` for decimal defaults after the type-equality check, rejecting an out-of-range value up front so it is consistent with what the reader accepts. This mirrors the same guard already applied when casting defaults during schema evolution.

## Testing

`SchemaFieldTest.ValidateRejectsDecimalDefaultExceedingPrecision` (rejects `99.9` for `decimal(2,1)`) and `ValidateAcceptsDecimalDefaultWithinPrecision` (accepts a fitting value), verified fail-without / pass-with. Full `schema_test` passes (551 tests).
