### PR TITLE
fix: reject non-finite floating-point default values

### DIFF
--- a/src/iceberg/schema_field.cc
+++ b/src/iceberg/schema_field.cc
@@ -19,6 +19,7 @@
 
 #include "iceberg/schema_field.h"
 
+#include <cmath>
 #include <format>
 #include <string_view>
 #include <utility>
@@ -167,6 +168,21 @@ Status ValidateDefault(const SchemaField& field, const Literal& value,
   if (*value.type() != *field.type()) {
     return InvalidSchema("{} of field {} has type {} but expected {}", kind, field.name(),
                          *value.type(), *field.type());
+  }
+  // A non-finite float/double default cannot be represented in JSON: the serializer emits
+  // it as `null`, which reads back as an absent default. Reject it so the default is not
+  // silently lost when the metadata round-trips. The literal type already matches the
+  // field type here, so this only inspects the value for actual floating fields and other
+  // types pay nothing.
+  if (field.type()->type_id() == TypeId::kFloat &&
+      !std::isfinite(std::get<float>(value.value()))) {
+    return InvalidSchema("Invalid {} value for {}: value must be finite", kind,
+                         field.name());
+  }
+  if (field.type()->type_id() == TypeId::kDouble &&
+      !std::isfinite(std::get<double>(value.value()))) {
+    return InvalidSchema("Invalid {} value for {}: value must be finite", kind,
+                         field.name());
   }
   return {};
 }

--- a/src/iceberg/schema_field.cc
+++ b/src/iceberg/schema_field.cc
@@ -26,6 +26,7 @@
 #include <variant>
 
 #include "iceberg/expression/literal.h"
+#include "iceberg/result.h"
 #include "iceberg/type.h"
 #include "iceberg/util/checked_cast.h"
 #include "iceberg/util/formatter.h"  // IWYU pragma: keep

--- a/src/iceberg/test/schema_field_test.cc
+++ b/src/iceberg/test/schema_field_test.cc
@@ -26,6 +26,7 @@
 #include <gtest/gtest.h>
 
 #include "iceberg/expression/literal.h"
+#include "iceberg/result.h"
 #include "iceberg/test/matchers.h"
 #include "iceberg/type.h"
 #include "iceberg/util/formatter.h"  // IWYU pragma: keep

--- a/src/iceberg/test/schema_field_test.cc
+++ b/src/iceberg/test/schema_field_test.cc
@@ -20,11 +20,13 @@
 #include "iceberg/schema_field.h"
 
 #include <format>
+#include <limits>
 #include <memory>
 
 #include <gtest/gtest.h>
 
 #include "iceberg/expression/literal.h"
+#include "iceberg/test/matchers.h"
 #include "iceberg/type.h"
 #include "iceberg/util/formatter.h"  // IWYU pragma: keep
 
@@ -168,6 +170,36 @@ TEST(SchemaFieldTest, CastDefaultValue) {
         SchemaField::CastDefaultValue(Literal::Decimal(1234567, 9, 2), decimal(4, 2));
     EXPECT_FALSE(result.has_value());
   }
+}
+
+TEST(SchemaFieldTest, ValidateRejectsNonFiniteFloatingDefault) {
+  // NaN / infinity cannot be represented in JSON (the serializer emits `null`, which
+  // reads back as an absent default), so a non-finite floating default must be rejected.
+  SchemaField nan_field(/*field_id=*/1, /*name=*/"f", float32(),
+                        /*optional=*/true, /*doc=*/"",
+                        std::make_shared<const Literal>(
+                            Literal::Float(std::numeric_limits<float>::quiet_NaN())));
+  EXPECT_THAT(nan_field.Validate(), IsError(ErrorKind::kInvalidSchema));
+  EXPECT_THAT(nan_field.Validate(), HasErrorMessage("must be finite"));
+
+  SchemaField inf_field(/*field_id=*/2, /*name=*/"d", float64(),
+                        /*optional=*/true, /*doc=*/"",
+                        std::make_shared<const Literal>(
+                            Literal::Double(std::numeric_limits<double>::infinity())));
+  EXPECT_THAT(inf_field.Validate(), IsError(ErrorKind::kInvalidSchema));
+
+  SchemaField neg_inf_field(/*field_id=*/3, /*name=*/"d2", float64(),
+                            /*optional=*/true, /*doc=*/"",
+                            std::make_shared<const Literal>(Literal::Double(
+                                -std::numeric_limits<double>::infinity())));
+  EXPECT_THAT(neg_inf_field.Validate(), IsError(ErrorKind::kInvalidSchema));
+}
+
+TEST(SchemaFieldTest, ValidateAcceptsFiniteFloatingDefault) {
+  SchemaField field(/*field_id=*/1, /*name=*/"f", float32(),
+                    /*optional=*/true, /*doc=*/"",
+                    std::make_shared<const Literal>(Literal::Float(1.5f)));
+  EXPECT_THAT(field.Validate(), IsOk());
 }
 
 }  // namespace iceberg


### PR DESCRIPTION
## What

A `float` / `double` column default of `NaN` or `±Infinity` passes `SchemaField::Validate` but cannot survive a metadata round-trip: the JSON serializer emits a non-finite number as `null`, which reads back as an *absent* default. The declared default is silently lost (and, because the key is present but null, the reader then errors on it).

## How

`ValidateDefault` now rejects a non-finite floating default with a clear "value must be finite" error, so an unrepresentable default is caught up front rather than silently dropped on serialization.

The check uses `std::isfinite`, which is false for **both** `NaN` and `±Infinity` — so a single condition covers all three cases (there is no separate `IsNaN` branch because `isfinite` already rejects NaN).

## Testing

`SchemaFieldTest.ValidateRejectsNonFiniteFloatingDefault` explicitly covers `NaN`, `+Inf` and `-Inf`, and `ValidateAcceptsFiniteFloatingDefault` covers a normal value; verified fail-without / pass-with. Full `schema_test` passes (551 tests).
