### PR TITLE
ci: share sccache setup across workflows

### DIFF
--- a/.github/actions/save-sccache/action.yml
+++ b/.github/actions/save-sccache/action.yml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Save sccache
+description: Show sccache stats and save the cache on main branch runs after setup-sccache.
+
+inputs:
+  key-prefix:
+    description: Cache key prefix without the run id or Windows compiler suffix.
+    required: true
+  job-status:
+    description: >-
+      Pass `job.status` so the cache is only saved when the job has not failed;
+      `success()` inside a composite action cannot see the caller's steps.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Show sccache stats
+      if: always()
+      shell: bash
+      run: sccache --show-stats
+
+    - name: Save sccache cache
+      if: ${{ inputs.job-status == 'success' && github.ref == 'refs/heads/main' }}
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ github.workspace }}/.sccache
+        key: ${{ inputs.key-prefix }}${{ env.SCCACHE_KEY_SUFFIX }}-${{ github.run_id }}

--- a/.github/actions/sccache/resolve-msvc-key-suffix.ps1
+++ b/.github/actions/sccache/resolve-msvc-key-suffix.ps1
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Resolve the MSVC toolset version for use as an sccache cache key suffix.
+# GitHub runner images roll out new cl.exe builds roughly weekly; keying the
+# cache on the toolset version avoids silent misses after each bump.
+
+$PSNativeCommandUseErrorActionPreference = $false
+
+function Resolve-Suffix {
+  # Locate vswhere, which ships with every VS installation.
+  $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+  if (-not (Test-Path $vswhere)) { return $null }
+
+  # Ask vswhere for the newest installation that includes the C++ toolset.
+  $installationPath = (& $vswhere -latest -products * `
+    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    -property installationPath | Select-Object -First 1)
+  if (-not $installationPath) { return $null }
+
+  # Read the default toolset version (e.g. "14.44.35217").
+  $versionFile = Join-Path $installationPath.Trim() 'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt'
+  if (-not (Test-Path $versionFile)) { return $null }
+
+  $version = (Get-Content -Path $versionFile -Raw).Trim()
+  if ($version) { return "-$version" }
+  return $null
+}
+
+$suffix = Resolve-Suffix
+if (-not $suffix) {
+  # Degrade gracefully: a shared bucket is better than a failed build.
+  $suffix = '-unknown'
+  Write-Host "::warning::could not resolve MSVC toolset version for sccache key, using '$suffix'"
+}
+
+# Export to both step outputs (for setup-sccache's restore key) and env (for
+# save-sccache's save key later in the same job).
+Add-Content -Path $env:GITHUB_OUTPUT -Value "suffix=$suffix"
+Add-Content -Path $env:GITHUB_ENV -Value "SCCACHE_KEY_SUFFIX=$suffix"
+Write-Host "Resolved SCCACHE_KEY_SUFFIX=$suffix"

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Set up sccache
+description: Configure sccache, restore its cache, and start the sccache action.
+
+inputs:
+  key-prefix:
+    description: Cache key prefix without the run id or Windows compiler suffix.
+    required: true
+  cache-size:
+    description: Maximum sccache cache size.
+    required: false
+    default: 2G
+
+runs:
+  using: composite
+  steps:
+    - name: Configure sccache environment
+      shell: bash
+      env:
+        CACHE_SIZE: ${{ inputs.cache-size }}
+      run: |
+        echo "SCCACHE_DIR=${{ github.workspace }}/.sccache" >> "$GITHUB_ENV"
+        echo "SCCACHE_CACHE_SIZE=${CACHE_SIZE}" >> "$GITHUB_ENV"
+        echo "SCCACHE_KEY_SUFFIX=" >> "$GITHUB_ENV"
+
+    # Windows caches include the MSVC toolset version because GitHub runner image
+    # rollouts can change the compiler while keeping the same image label.
+    - name: Resolve MSVC toolset version for sccache key
+      if: ${{ runner.os == 'Windows' }}
+      id: msvc-key
+      shell: pwsh
+      run: '& "${{ github.action_path }}/../sccache/resolve-msvc-key-suffix.ps1"'
+
+    - name: Restore sccache cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ github.workspace }}/.sccache
+        key: ${{ inputs.key-prefix }}${{ steps.msvc-key.outputs.suffix }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ inputs.key-prefix }}${{ steps.msvc-key.outputs.suffix }}-
+
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/aws_test.yml
+++ b/.github/workflows/aws_test.yml
@@ -73,8 +73,6 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
       AWS_ENDPOINT_URL: http://127.0.0.1:9000
       AWS_EC2_METADATA_DISABLED: "TRUE"
-      SCCACHE_DIR: ${{ github.workspace }}/.sccache
-      SCCACHE_CACHE_SIZE: "2G"
     steps:
       - name: Checkout iceberg-cpp
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -114,26 +112,18 @@ jobs:
         if: ${{ matrix.s3 == 'ON' }}
         shell: bash
         run: bash ci/scripts/start_minio.sh
-      - name: Restore sccache cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Set up sccache
+        uses: ./.github/actions/setup-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-aws-${{ matrix.runs-on }}-bundle${{ matrix.bundle_awssdk }}-s3${{ matrix.s3 }}-sigv4${{ matrix.sigv4 }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-aws-${{ matrix.runs-on }}-bundle${{ matrix.bundle_awssdk }}-s3${{ matrix.s3 }}-sigv4${{ matrix.sigv4 }}-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+          key-prefix: sccache-aws-${{ matrix.runs-on }}-bundle${{ matrix.bundle_awssdk }}-s3${{ matrix.s3 }}-sigv4${{ matrix.sigv4 }}
       - name: Build and test Iceberg
         shell: bash
         env:
           CMAKE_TOOLCHAIN_FILE: ${{ startsWith(matrix.runs-on, 'ubuntu') && matrix.bundle_awssdk == 'OFF' && '/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake' || '' }}
         run: ci/scripts/build_iceberg.sh "$(pwd)" OFF ON ${{ matrix.s3 }} ${{ matrix.sigv4 }} ${{ matrix.bundle_awssdk }}
-      - name: Show sccache stats
-        shell: bash
-        run: sccache --show-stats
-      - name: Save sccache cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Save sccache
+        if: always()
+        uses: ./.github/actions/save-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-aws-${{ matrix.runs-on }}-bundle${{ matrix.bundle_awssdk }}-s3${{ matrix.s3 }}-sigv4${{ matrix.sigv4 }}-${{ github.run_id }}
+          key-prefix: sccache-aws-${{ matrix.runs-on }}-bundle${{ matrix.bundle_awssdk }}-s3${{ matrix.s3 }}-sigv4${{ matrix.sigv4 }}
+          job-status: ${{ job.status }}

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -46,8 +46,6 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      SCCACHE_DIR: ${{ github.workspace }}/.sccache
-      SCCACHE_CACHE_SIZE: "2G"
       CPP_LINTER_VERSION: "1.13.0"
       # clang-format is handled by the pre-commit workflow; cpp-linter runs
       # clang-tidy only.
@@ -62,15 +60,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libcurl4-openssl-dev libsqlite3-dev libpq-dev default-libmysqlclient-dev
-      - name: Restore sccache cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Set up sccache
+        uses: ./.github/actions/setup-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-cpp-linter-ubuntu-${{ github.run_id }}
-          restore-keys: |
-            sccache-cpp-linter-ubuntu-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+          key-prefix: sccache-cpp-linter-ubuntu
       - name: Run build
         env:
           CC: gcc-14
@@ -86,15 +79,12 @@ jobs:
             -DICEBERG_SQL_POSTGRESQL=ON \
             -DICEBERG_SQL_MYSQL=ON
           cmake --build .
-      - name: Show sccache stats
-        shell: bash
-        run: sccache --show-stats
-      - name: Save sccache cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Save sccache
+        if: always()
+        uses: ./.github/actions/save-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-cpp-linter-ubuntu-${{ github.run_id }}
+          key-prefix: sccache-cpp-linter-ubuntu
+          job-status: ${{ job.status }}
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         if: github.event_name == 'pull_request'
         with:

--- a/.github/workflows/sanitizer_test.yml
+++ b/.github/workflows/sanitizer_test.yml
@@ -38,9 +38,6 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: "ASAN and UBSAN Tests"
     runs-on: ubuntu-26.04
-    env:
-      SCCACHE_DIR: ${{ github.workspace }}/.sccache
-      SCCACHE_CACHE_SIZE: "2G"
     steps:
       - name: Checkout iceberg-cpp
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -49,15 +46,10 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
-      - name: Restore sccache cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Set up sccache
+        uses: ./.github/actions/setup-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-sanitizer-ubuntu-${{ github.run_id }}
-          restore-keys: |
-            sccache-sanitizer-ubuntu-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+          key-prefix: sccache-sanitizer-ubuntu
       - name: Configure and Build with ASAN & UBSAN
         env:
           CC: gcc-14
@@ -67,15 +59,12 @@ jobs:
           cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug -DICEBERG_ENABLE_ASAN=ON -DICEBERG_ENABLE_UBSAN=ON \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           cmake --build . --verbose
-      - name: Show sccache stats
-        shell: bash
-        run: sccache --show-stats
-      - name: Save sccache cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Save sccache
+        if: always()
+        uses: ./.github/actions/save-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-sanitizer-ubuntu-${{ github.run_id }}
+          key-prefix: sccache-sanitizer-ubuntu
+          job-status: ${{ job.status }}
       - name: Run Tests
         working-directory: build
         env:

--- a/.github/workflows/sql_catalog_test.yml
+++ b/.github/workflows/sql_catalog_test.yml
@@ -60,9 +60,6 @@ jobs:
             runs-on: windows-2025
             cmake_build_type: Debug
             cmake_extra_args: -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
-    env:
-      SCCACHE_DIR: ${{ github.workspace }}/.sccache
-      SCCACHE_CACHE_SIZE: "2G"
     steps:
       - name: Checkout iceberg-cpp
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -73,26 +70,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
           arch: x64
-      # GitHub patches the Windows image roughly weekly via gradual rollouts, so
-      # back-to-back runs can hit different cl.exe builds. sccache keys on the compiler,
-      # so a shared key would miss after each bump; the version keeps caches separate.
-      # Non-Windows legs get an empty suffix, leaving their keys unchanged.
-      - name: Resolve MSVC version for sccache key
-        if: ${{ startsWith(matrix.runs-on, 'windows') }}
-        shell: pwsh
-        run: |
-          $PSNativeCommandUseErrorActionPreference = $false
-          $banner = (cl.exe 2>&1 | Out-String)
-          if ($banner -match 'Version ([\d.]+)') {
-            $suffix = "-$($Matches[1])"
-          } else {
-            # The key is only a cache hint, so degrade to a shared bucket rather than
-            # fail the build; the warning flags that the parse needs fixing.
-            $suffix = '-unknown'
-            Write-Host "::warning::could not parse cl.exe version for sccache key, using '$suffix'; banner was: $banner"
-          }
-          Add-Content -Path $env:GITHUB_ENV -Value "SCCACHE_KEY_SUFFIX=$suffix"
-          Write-Host "SCCACHE_KEY_SUFFIX=$suffix"
       - name: Install dependencies on Ubuntu
         if: ${{ startsWith(matrix.runs-on, 'ubuntu') }}
         shell: bash
@@ -114,15 +91,10 @@ jobs:
         shell: pwsh
         run: |
           vcpkg install zlib:x64-windows nlohmann-json:x64-windows nanoarrow:x64-windows roaring:x64-windows sqlite3:x64-windows
-      - name: Restore sccache cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Set up sccache
+        uses: ./.github/actions/setup-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-sqlcatalog-${{ matrix.runs-on }}${{ env.SCCACHE_KEY_SUFFIX }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-sqlcatalog-${{ matrix.runs-on }}${{ env.SCCACHE_KEY_SUFFIX }}-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+          key-prefix: sccache-sqlcatalog-${{ matrix.runs-on }}
       - name: Configure Iceberg
         shell: bash
         run: |
@@ -140,15 +112,12 @@ jobs:
       - name: Build SQL catalog tests
         shell: bash
         run: cmake --build build --target sql_catalog_test
-      - name: Show sccache stats
-        shell: bash
-        run: sccache --show-stats
-      - name: Save sccache cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Save sccache
+        if: always()
+        uses: ./.github/actions/save-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-sqlcatalog-${{ matrix.runs-on }}${{ env.SCCACHE_KEY_SUFFIX }}-${{ github.run_id }}
+          key-prefix: sccache-sqlcatalog-${{ matrix.runs-on }}
+          job-status: ${{ job.status }}
       - name: Run SQL catalog tests
         shell: bash
         run: ctest --test-dir build -R '^sql_catalog_test$' --output-on-failure -C ${{ matrix.cmake_build_type }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,6 @@ jobs:
         cmake_build_type:
           - Debug
           - RelWithDebInfo
-    env:
-      SCCACHE_DIR: ${{ github.workspace }}/.sccache
-      SCCACHE_CACHE_SIZE: "2G"
     steps:
       - name: Checkout iceberg-cpp
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -59,30 +56,22 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
-      - name: Restore sccache cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Set up sccache
+        uses: ./.github/actions/setup-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-test-ubuntu-${{ matrix.cmake_build_type }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-test-ubuntu-${{ matrix.cmake_build_type }}-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+          key-prefix: sccache-test-ubuntu-${{ matrix.cmake_build_type }}
       - name: Build Iceberg
         shell: bash
         env:
           CC: gcc-14
           CXX: g++-14
         run: ci/scripts/build_iceberg.sh $(pwd) ON ON OFF OFF ON ${{ matrix.cmake_build_type }}
-      - name: Show sccache stats
-        shell: bash
-        run: sccache --show-stats
-      - name: Save sccache cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Save sccache
+        if: always()
+        uses: ./.github/actions/save-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-test-ubuntu-${{ matrix.cmake_build_type }}-${{ github.run_id }}
+          key-prefix: sccache-test-ubuntu-${{ matrix.cmake_build_type }}
+          job-status: ${{ job.status }}
       - name: Build Example
         shell: bash
         env:
@@ -96,35 +85,24 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
-    env:
-      SCCACHE_DIR: ${{ github.workspace }}/.sccache
-      SCCACHE_CACHE_SIZE: "2G"
     steps:
       - name: Checkout iceberg-cpp
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Restore sccache cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Set up sccache
+        uses: ./.github/actions/setup-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-test-macos-${{ github.run_id }}
-          restore-keys: |
-            sccache-test-macos-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+          key-prefix: sccache-test-macos
       - name: Build Iceberg
         shell: bash
         run: ci/scripts/build_iceberg.sh $(pwd) OFF ON
-      - name: Show sccache stats
-        shell: bash
-        run: sccache --show-stats
-      - name: Save sccache cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Save sccache
+        if: always()
+        uses: ./.github/actions/save-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-test-macos-${{ github.run_id }}
+          key-prefix: sccache-test-macos
+          job-status: ${{ job.status }}
       - name: Build Example
         shell: bash
         run: ci/scripts/build_example.sh $(pwd)/example
@@ -135,9 +113,6 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-    env:
-      SCCACHE_DIR: ${{ github.workspace }}/.sccache
-      SCCACHE_CACHE_SIZE: "2G"
     steps:
       - name: Checkout iceberg-cpp
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -147,24 +122,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
           arch: x64
-      # GitHub patches the Windows image roughly weekly via gradual rollouts, so
-      # back-to-back runs can hit different cl.exe builds. sccache keys on the compiler,
-      # so a shared key would miss after each bump; the version keeps caches separate.
-      - name: Resolve MSVC version for sccache key
-        shell: pwsh
-        run: |
-          $PSNativeCommandUseErrorActionPreference = $false
-          $banner = (cl.exe 2>&1 | Out-String)
-          if ($banner -match 'Version ([\d.]+)') {
-            $msvc = $Matches[1]
-          } else {
-            # The key is only a cache hint, so degrade to a shared bucket rather than
-            # fail the build; the warning flags that the parse needs fixing.
-            $msvc = 'unknown'
-            Write-Host "::warning::could not parse cl.exe version for sccache key, using '$msvc'; banner was: $banner"
-          }
-          Add-Content -Path $env:GITHUB_ENV -Value "MSVC_VER=$msvc"
-          Write-Host "Resolved MSVC_VER=$msvc"
       - name: Cache vcpkg packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: vcpkg-cache
@@ -176,28 +133,22 @@ jobs:
         shell: pwsh
         run: |
           vcpkg install zlib:x64-windows nlohmann-json:x64-windows nanoarrow:x64-windows roaring:x64-windows cpr:x64-windows
-      - name: Restore sccache cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Set up sccache
+        uses: ./.github/actions/setup-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-test-windows-${{ env.MSVC_VER }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-test-windows-${{ env.MSVC_VER }}-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+          key-prefix: sccache-test-windows
       - name: Build Iceberg
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
           bash -lc 'ci/scripts/build_iceberg.sh $(pwd) OFF ON'
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          sccache --show-stats
-      - name: Save sccache cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Save sccache
+        if: always()
+        uses: ./.github/actions/save-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-test-windows-${{ env.MSVC_VER }}-${{ github.run_id }}
+          key-prefix: sccache-test-windows
+          job-status: ${{ job.status }}
       - name: Build Example
         shell: pwsh
         run: |
@@ -208,9 +159,6 @@ jobs:
     name: Meson - ${{ matrix.title }}
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
-    env:
-      SCCACHE_DIR: ${{ github.workspace }}/.sccache
-      SCCACHE_CACHE_SIZE: "2G"
     strategy:
       max-parallel: 15
       fail-fast: false
@@ -246,27 +194,20 @@ jobs:
         run: |
           echo "CC=sccache ${{ matrix.CC }}" >> $GITHUB_ENV
           echo "CXX=sccache ${{ matrix.CXX }}" >> $GITHUB_ENV
-      - name: Restore sccache cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Set up sccache
+        uses: ./.github/actions/setup-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-meson-${{ matrix.runs-on }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-meson-${{ matrix.runs-on }}-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+          key-prefix: sccache-meson-${{ matrix.runs-on }}
       - name: Build Iceberg
         run: |
           meson setup builddir ${{ matrix.meson-setup-args || '' }}
           meson compile -C builddir
-      - name: Show sccache stats
-        run: sccache --show-stats
-      - name: Save sccache cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Save sccache
+        if: always()
+        uses: ./.github/actions/save-sccache
         with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-meson-${{ matrix.runs-on }}-${{ github.run_id }}
+          key-prefix: sccache-meson-${{ matrix.runs-on }}
+          job-status: ${{ job.status }}
       - name: Test Iceberg
         run: |
           meson test -C builddir --timeout-multiplier 0 --print-errorlogs


### PR DESCRIPTION
## What
Add two composite actions for sccache:

- `.github/actions/setup-sccache` sets the sccache environment, restores the cache, resolves the MSVC compiler version on Windows, and starts `mozilla-actions/sccache-action`.
- `.github/actions/save-sccache` shows sccache stats for every run and saves the cache only on main branch runs.

The Test, SQL Catalog, sanitizer, C++ linter, and AWS workflows now pass only their cache key prefix at each call site.

This is part of the CI work discussed in https://github.com/apache/iceberg-cpp/issues/799.

## Notes
The existing cache key shapes are preserved for the current CMake workflow legs. The Meson Windows leg now also gets the MSVC-version key suffix, matching the other Windows sccache legs and avoids cache misses after runner image compiler updates.

The MSVC version source also changes for the existing Windows legs (test and SQL catalog): the inline `cl.exe` banner parse is replaced by reading `VCToolsVersion.default.txt` via vswhere, which is more reliable and does not require `cl.exe` on PATH. This produces a different version format (e.g. `14.44.35217` vs `19.44.35217.1`), so all Windows caches will miss once and reseed on the first post-merge main run.

Third-party actions stay pinned inside composite `action.yml` files, which are covered by the ASF allowlist checker glob.

## Validation
- Validated builds in fork: Test, AWS, SQL Catalog, ASAN/UBSAN, and pre-commit.
- The C++ linter workflow ignores `.github/**`, so this PR does not exercise that workflow until a source-touching run or post-merge.