### PR TITLE
ci: add RelWithDebInfo build and fix free-nonheap-object error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: AMD64 Ubuntu 26.04 (${{ matrix.cmake_build_type }})
     runs-on: ubuntu-26.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -64,9 +64,9 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ github.workspace }}/.sccache
-          key: sccache-test-ubuntu-${{ github.run_id }}
+          key: sccache-test-ubuntu-${{ matrix.cmake_build_type }}-${{ github.run_id }}
           restore-keys: |
-            sccache-test-ubuntu-
+            sccache-test-ubuntu-${{ matrix.cmake_build_type }}-
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Build Iceberg
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ github.workspace }}/.sccache
-          key: sccache-test-ubuntu-${{ github.run_id }}
+          key: sccache-test-ubuntu-${{ matrix.cmake_build_type }}-${{ github.run_id }}
       - name: Build Example
         shell: bash
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,15 @@ env:
 jobs:
   ubuntu:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
-    name: AMD64 Ubuntu 26.04
+    name: AMD64 Ubuntu 26.04 (${{ matrix.cmake_build_type }})
     runs-on: ubuntu-26.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
+      matrix:
+        cmake_build_type:
+          - Debug
+          - RelWithDebInfo
     env:
       SCCACHE_DIR: ${{ github.workspace }}/.sccache
       SCCACHE_CACHE_SIZE: "2G"
@@ -70,7 +74,7 @@ jobs:
         env:
           CC: gcc-14
           CXX: g++-14
-        run: ci/scripts/build_iceberg.sh $(pwd) ON ON
+        run: ci/scripts/build_iceberg.sh $(pwd) ON ON OFF OFF ON ${{ matrix.cmake_build_type }}
       - name: Show sccache stats
         shell: bash
         run: sccache --show-stats

--- a/ci/scripts/build_iceberg.sh
+++ b/ci/scripts/build_iceberg.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Usage: build_iceberg.sh <source_dir> [rest_integration_tests=OFF] [sccache=OFF] [s3=OFF] [sigv4=OFF] [bundle_awssdk=ON]
+# Usage: build_iceberg.sh <source_dir> [rest_integration_tests=OFF] [sccache=OFF] [s3=OFF] [sigv4=OFF] [bundle_awssdk=ON] [build_type=Debug]
 
 set -eux
 
@@ -36,6 +36,12 @@ pushd ${build_dir}
 is_windows() {
     [[ "${OSTYPE}" == "msys" || "${OSTYPE}" == "win32" || "${OSTYPE}" == "cygwin" ]]
 }
+
+if is_windows; then
+    build_type=${7:-Release}
+else
+    build_type=${7:-Debug}
+fi
 
 CMAKE_ARGS=(
     "-G Ninja"
@@ -65,13 +71,13 @@ fi
 
 if is_windows; then
     CMAKE_ARGS+=("-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake")
-    CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Release")
+    CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=${build_type}")
 else
     # Pass an externally provided toolchain (e.g. vcpkg for the SigV4 job)
     if [[ -n "${CMAKE_TOOLCHAIN_FILE:-}" ]]; then
         CMAKE_ARGS+=("-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
     fi
-    CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Debug")
+    CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=${build_type}")
 fi
 
 if [[ "${build_enable_sccache}" == "ON" ]]; then
@@ -86,9 +92,9 @@ fi
 
 cmake "${CMAKE_ARGS[@]}" ${source_dir}
 if is_windows; then
-  cmake --build . --config Release --target install
+  cmake --build . --config "${build_type}" --target install
   if [[ "${run_tests}" == "ON" ]]; then
-    ctest --output-on-failure -C Release
+    ctest --output-on-failure -C "${build_type}"
   fi
 else
   cmake --build . --target install

--- a/src/iceberg/json_serde.cc
+++ b/src/iceberg/json_serde.cc
@@ -1377,9 +1377,9 @@ Result<std::unique_ptr<TableMetadata>> TableMetadataFromJson(const nlohmann::jso
       TimePointMs{std::chrono::milliseconds(last_updated_ms)};
 
   if (json.contains(kRefs)) {
-    ICEBERG_ASSIGN_OR_RAISE(
-        table_metadata->refs,
-        FromJsonMap<std::shared_ptr<SnapshotRef>>(json, kRefs, SnapshotRefFromJson));
+    ICEBERG_ASSIGN_OR_RAISE(auto refs, FromJsonMap<std::shared_ptr<SnapshotRef>>(
+                                           json, kRefs, SnapshotRefFromJson));
+    table_metadata->refs = std::move(refs);
   } else if (table_metadata->current_snapshot_id != kInvalidSnapshotId) {
     table_metadata->refs["main"] = std::make_unique<SnapshotRef>(SnapshotRef{
         .snapshot_id = table_metadata->current_snapshot_id,


### PR DESCRIPTION
Adding a RelWithDebInfo build revealed a build error. This PR fixes the issue.

```
error: ‘void operator delete(void*, std::size_t)’ called on a pointer to an unallocated object ‘1’ [-Werror=free-nonheap-object]
```

