### PR TITLE
build: enable clang-tidy misc-include-cleaner for include hygiene

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -43,6 +43,6 @@ CheckOptions:
   - key:    modernize-use-scoped-lock.WarnOnSingleLocks
     value:  'false'
   - key:    misc-include-cleaner.IgnoreHeaders
-    value:  'arrow/.*;nanoarrow/.*;nlohmann/.*;spdlog/.*;roaring/.*;cpr/.*'
+    value:  'arrow/.*;avro/.*;aws/.*;cpr/.*;gmock/.*;gtest/.*;nanoarrow/.*;nlohmann/.*;parquet/.*;roaring/.*;spdlog/.*;sqlpp23/.*;sqlite3\.h;thrift/.*;utf8proc\.h;zlib\.h'
 
 HeaderFilterRegex: 'src/iceberg|example'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@ Checks: |
   clang-analyzer-*,
   google-*,
   modernize-*,
+  misc-include-cleaner,
   readability-identifier-naming,
   readability-isolate-declaration,
   -modernize-use-nodiscard,
@@ -41,5 +42,7 @@ CheckOptions:
     value:  '_'
   - key:    modernize-use-scoped-lock.WarnOnSingleLocks
     value:  'false'
+  - key:    misc-include-cleaner.IgnoreHeaders
+    value:  'arrow/.*;nanoarrow/.*;nlohmann/.*;spdlog/.*;roaring/.*;cpr/.*'
 
 HeaderFilterRegex: 'src/iceberg|example'


### PR DESCRIPTION
## What

Closes #73. Enables clang-tidy's `misc-include-cleaner` check to enforce include hygiene.

## How

Adds `misc-include-cleaner` to `.clang-tidy`. Because the project already runs clang-tidy 22 incrementally (changed-lines-only) via the cpp-linter workflow, include hygiene is now enforced on new/changed code with no additional tooling, workflow, or mapping file. `IgnoreHeaders` is configured for third-party headers (arrow, nanoarrow, nlohmann-json, spdlog, CRoaring, cpr) to suppress noise from vendored includes.

## Notes

This supersedes the original IWYU-based approach (a separate workflow + `iwyu.imp` mapping + CMake option), per the review discussion with @zhjwpku: `misc-include-cleaner` integrates with the existing clang-tidy setup and is far lower-maintenance for the same goal.

---
This contribution was authored with assistance from Claude Opus 4.8, in line with the Iceberg guidelines for AI-assisted contributions (https://iceberg.apache.org/contribute/#guidelines-for-ai-assisted-contributions). All changes were reviewed and tested by the author.
