### PR TITLE
feat: read v3 row lineage metadata columns

### DIFF
--- a/src/iceberg/arrow/metadata_column_util.cc
+++ b/src/iceberg/arrow/metadata_column_util.cc
@@ -25,6 +25,7 @@
 #include "iceberg/arrow/arrow_status_internal.h"
 #include "iceberg/arrow/metadata_column_util_internal.h"
 #include "iceberg/metadata_columns.h"
+#include "iceberg/util/checked_cast.h"
 
 namespace iceberg::arrow {
 
@@ -34,6 +35,22 @@ bool HasRowLineageValue(int32_t field_id, const MetadataColumnContext& metadata_
   }
   return field_id != MetadataColumns::kLastUpdatedSequenceNumberColumnId ||
          metadata_context.data_sequence_number.has_value();
+}
+
+Status AppendRowLineageValue(int32_t field_id,
+                             const MetadataColumnContext& metadata_context,
+                             ::arrow::ArrayBuilder* array_builder) {
+  auto* int_builder = internal::checked_cast<::arrow::Int64Builder*>(array_builder);
+  if (!HasRowLineageValue(field_id, metadata_context)) {
+    ICEBERG_ARROW_RETURN_NOT_OK(int_builder->AppendNull());
+  } else if (field_id == MetadataColumns::kRowIdColumnId) {
+    ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(
+        metadata_context.first_row_id.value() + metadata_context.next_file_pos));
+  } else {
+    ICEBERG_ARROW_RETURN_NOT_OK(
+        int_builder->Append(metadata_context.data_sequence_number.value()));
+  }
+  return {};
 }
 
 Result<std::shared_ptr<::arrow::Array>> MakeFilePathArray(const std::string& file_path,

--- a/src/iceberg/arrow/metadata_column_util.cc
+++ b/src/iceberg/arrow/metadata_column_util.cc
@@ -29,19 +29,22 @@
 
 namespace iceberg::arrow {
 
-bool HasRowLineageValue(int32_t field_id, const MetadataColumnContext& metadata_context) {
-  if (!metadata_context.first_row_id.has_value()) {
-    return false;
+bool CanInheritRowLineageValue(int32_t field_id,
+                               const MetadataColumnContext& metadata_context) {
+  if (field_id == MetadataColumns::kRowIdColumnId) {
+    return metadata_context.first_row_id.has_value();
   }
-  return field_id != MetadataColumns::kLastUpdatedSequenceNumberColumnId ||
-         metadata_context.data_sequence_number.has_value();
+  if (field_id == MetadataColumns::kLastUpdatedSequenceNumberColumnId) {
+    return metadata_context.data_sequence_number.has_value();
+  }
+  return false;
 }
 
-Status AppendRowLineageValue(int32_t field_id,
-                             const MetadataColumnContext& metadata_context,
-                             ::arrow::ArrayBuilder* array_builder) {
+Status AppendInheritedRowLineageValue(int32_t field_id,
+                                      const MetadataColumnContext& metadata_context,
+                                      ::arrow::ArrayBuilder* array_builder) {
   auto* int_builder = internal::checked_cast<::arrow::Int64Builder*>(array_builder);
-  if (!HasRowLineageValue(field_id, metadata_context)) {
+  if (!CanInheritRowLineageValue(field_id, metadata_context)) {
     ICEBERG_ARROW_RETURN_NOT_OK(int_builder->AppendNull());
   } else if (field_id == MetadataColumns::kRowIdColumnId) {
     ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(
@@ -99,11 +102,11 @@ Result<std::shared_ptr<::arrow::Array>> MakeRowIdArray(
 }
 
 Result<std::shared_ptr<::arrow::Array>> MakeLastUpdatedSequenceNumberArray(
-    std::optional<int64_t> first_row_id, std::optional<int64_t> data_sequence_number,
-    int64_t num_rows, ::arrow::MemoryPool* pool) {
+    std::optional<int64_t> data_sequence_number, int64_t num_rows,
+    ::arrow::MemoryPool* pool) {
   ::arrow::Int64Builder builder(pool);
   ICEBERG_ARROW_RETURN_NOT_OK(builder.Reserve(num_rows));
-  if (!first_row_id.has_value() || !data_sequence_number.has_value()) {
+  if (!data_sequence_number.has_value()) {
     ICEBERG_ARROW_RETURN_NOT_OK(builder.AppendNulls(num_rows));
   } else {
     for (int64_t row_index = 0; row_index < num_rows; ++row_index) {

--- a/src/iceberg/arrow/metadata_column_util.cc
+++ b/src/iceberg/arrow/metadata_column_util.cc
@@ -24,8 +24,17 @@
 
 #include "iceberg/arrow/arrow_status_internal.h"
 #include "iceberg/arrow/metadata_column_util_internal.h"
+#include "iceberg/metadata_columns.h"
 
 namespace iceberg::arrow {
+
+bool HasRowLineageValue(int32_t field_id, const MetadataColumnContext& metadata_context) {
+  if (!metadata_context.first_row_id.has_value()) {
+    return false;
+  }
+  return field_id != MetadataColumns::kLastUpdatedSequenceNumberColumnId ||
+         metadata_context.data_sequence_number.has_value();
+}
 
 Result<std::shared_ptr<::arrow::Array>> MakeFilePathArray(const std::string& file_path,
                                                           int64_t num_rows,
@@ -48,6 +57,43 @@ Result<std::shared_ptr<::arrow::Array>> MakeRowPositionArray(int64_t start_posit
   for (int64_t i = 0; i < num_rows; ++i) {
     ICEBERG_ARROW_RETURN_NOT_OK(builder.Append(start_position + i));
   }
+  std::shared_ptr<::arrow::Array> array;
+  ICEBERG_ARROW_RETURN_NOT_OK(builder.Finish(&array));
+  return array;
+}
+
+Result<std::shared_ptr<::arrow::Array>> MakeRowIdArray(
+    std::optional<int64_t> first_row_id, int64_t start_position, int64_t num_rows,
+    ::arrow::MemoryPool* pool) {
+  ::arrow::Int64Builder builder(pool);
+  ICEBERG_ARROW_RETURN_NOT_OK(builder.Reserve(num_rows));
+  if (!first_row_id.has_value()) {
+    ICEBERG_ARROW_RETURN_NOT_OK(builder.AppendNulls(num_rows));
+  } else {
+    for (int64_t row_index = 0; row_index < num_rows; ++row_index) {
+      ICEBERG_ARROW_RETURN_NOT_OK(
+          builder.Append(first_row_id.value() + start_position + row_index));
+    }
+  }
+
+  std::shared_ptr<::arrow::Array> array;
+  ICEBERG_ARROW_RETURN_NOT_OK(builder.Finish(&array));
+  return array;
+}
+
+Result<std::shared_ptr<::arrow::Array>> MakeLastUpdatedSequenceNumberArray(
+    std::optional<int64_t> first_row_id, std::optional<int64_t> data_sequence_number,
+    int64_t num_rows, ::arrow::MemoryPool* pool) {
+  ::arrow::Int64Builder builder(pool);
+  ICEBERG_ARROW_RETURN_NOT_OK(builder.Reserve(num_rows));
+  if (!first_row_id.has_value() || !data_sequence_number.has_value()) {
+    ICEBERG_ARROW_RETURN_NOT_OK(builder.AppendNulls(num_rows));
+  } else {
+    for (int64_t row_index = 0; row_index < num_rows; ++row_index) {
+      ICEBERG_ARROW_RETURN_NOT_OK(builder.Append(data_sequence_number.value()));
+    }
+  }
+
   std::shared_ptr<::arrow::Array> array;
   ICEBERG_ARROW_RETURN_NOT_OK(builder.Finish(&array));
   return array;

--- a/src/iceberg/arrow/metadata_column_util_internal.h
+++ b/src/iceberg/arrow/metadata_column_util_internal.h
@@ -31,6 +31,10 @@
 
 #include "iceberg/result.h"
 
+namespace arrow {
+class ArrayBuilder;
+}  // namespace arrow
+
 namespace iceberg::arrow {
 
 /// \brief Context for populating metadata columns during reading.
@@ -43,6 +47,11 @@ struct MetadataColumnContext {
 
 /// \brief Check if row lineage metadata can be inherited for the column.
 bool HasRowLineageValue(int32_t field_id, const MetadataColumnContext& metadata_context);
+
+/// \brief Append one inherited row lineage value to an int64 builder.
+Status AppendRowLineageValue(int32_t field_id,
+                             const MetadataColumnContext& metadata_context,
+                             ::arrow::ArrayBuilder* array_builder);
 
 /// \brief Create a constant string array for _file column.
 ///

--- a/src/iceberg/arrow/metadata_column_util_internal.h
+++ b/src/iceberg/arrow/metadata_column_util_internal.h
@@ -46,12 +46,13 @@ struct MetadataColumnContext {
 };
 
 /// \brief Check if row lineage metadata can be inherited for the column.
-bool HasRowLineageValue(int32_t field_id, const MetadataColumnContext& metadata_context);
+bool CanInheritRowLineageValue(int32_t field_id,
+                               const MetadataColumnContext& metadata_context);
 
-/// \brief Append one inherited row lineage value to an int64 builder.
-Status AppendRowLineageValue(int32_t field_id,
-                             const MetadataColumnContext& metadata_context,
-                             ::arrow::ArrayBuilder* array_builder);
+/// \brief Append one inherited row lineage value, or null if unavailable.
+Status AppendInheritedRowLineageValue(int32_t field_id,
+                                      const MetadataColumnContext& metadata_context,
+                                      ::arrow::ArrayBuilder* array_builder);
 
 /// \brief Create a constant string array for _file column.
 ///
@@ -90,13 +91,12 @@ Result<std::shared_ptr<::arrow::Array>> MakeRowIdArray(
 
 /// \brief Create a sequence number array for _last_updated_sequence_number column.
 ///
-/// \param first_row_id First row ID of the data file.
 /// \param data_sequence_number Data sequence number of the data file.
 /// \param num_rows Number of rows in the batch.
 /// \param pool Arrow memory pool.
 /// \return Arrow Int64Array for _last_updated_sequence_number.
 Result<std::shared_ptr<::arrow::Array>> MakeLastUpdatedSequenceNumberArray(
-    std::optional<int64_t> first_row_id, std::optional<int64_t> data_sequence_number,
-    int64_t num_rows, ::arrow::MemoryPool* pool);
+    std::optional<int64_t> data_sequence_number, int64_t num_rows,
+    ::arrow::MemoryPool* pool);
 
 }  // namespace iceberg::arrow

--- a/src/iceberg/arrow/metadata_column_util_internal.h
+++ b/src/iceberg/arrow/metadata_column_util_internal.h
@@ -24,6 +24,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <arrow/type_fwd.h>
@@ -36,7 +37,12 @@ namespace iceberg::arrow {
 struct MetadataColumnContext {
   std::string file_path;      // The file path to populate _file column.
   int64_t next_file_pos = 0;  // The next row position for populating _pos column.
+  std::optional<int64_t> first_row_id;          // First row ID used to populate _row_id.
+  std::optional<int64_t> data_sequence_number;  // Data sequence number for lineage.
 };
+
+/// \brief Check if row lineage metadata can be inherited for the column.
+bool HasRowLineageValue(int32_t field_id, const MetadataColumnContext& metadata_context);
 
 /// \brief Create a constant string array for _file column.
 ///
@@ -61,5 +67,27 @@ Result<std::shared_ptr<::arrow::Array>> MakeFilePathArray(const std::string& fil
 Result<std::shared_ptr<::arrow::Array>> MakeRowPositionArray(int64_t start_position,
                                                              int64_t num_rows,
                                                              ::arrow::MemoryPool* pool);
+
+/// \brief Create a row ID array for _row_id column.
+///
+/// \param first_row_id First row ID of the data file.
+/// \param start_position Starting row position (inclusive).
+/// \param num_rows Number of rows in the batch.
+/// \param pool Arrow memory pool.
+/// \return Arrow Int64Array for _row_id.
+Result<std::shared_ptr<::arrow::Array>> MakeRowIdArray(
+    std::optional<int64_t> first_row_id, int64_t start_position, int64_t num_rows,
+    ::arrow::MemoryPool* pool);
+
+/// \brief Create a sequence number array for _last_updated_sequence_number column.
+///
+/// \param first_row_id First row ID of the data file.
+/// \param data_sequence_number Data sequence number of the data file.
+/// \param num_rows Number of rows in the batch.
+/// \param pool Arrow memory pool.
+/// \return Arrow Int64Array for _last_updated_sequence_number.
+Result<std::shared_ptr<::arrow::Array>> MakeLastUpdatedSequenceNumberArray(
+    std::optional<int64_t> first_row_id, std::optional<int64_t> data_sequence_number,
+    int64_t num_rows, ::arrow::MemoryPool* pool);
 
 }  // namespace iceberg::arrow

--- a/src/iceberg/avro/avro_data_util.cc
+++ b/src/iceberg/avro/avro_data_util.cc
@@ -54,6 +54,22 @@ Status AppendFieldToBuilder(const ::avro::NodePtr& avro_node,
                             const arrow::MetadataColumnContext& metadata_context,
                             ::arrow::ArrayBuilder* array_builder);
 
+Status AppendRowLineageValue(int32_t field_id,
+                             const arrow::MetadataColumnContext& metadata_context,
+                             ::arrow::ArrayBuilder* array_builder) {
+  auto* int_builder = internal::checked_cast<::arrow::Int64Builder*>(array_builder);
+  if (!arrow::HasRowLineageValue(field_id, metadata_context)) {
+    ICEBERG_ARROW_RETURN_NOT_OK(int_builder->AppendNull());
+  } else if (field_id == MetadataColumns::kRowIdColumnId) {
+    ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(
+        metadata_context.first_row_id.value() + metadata_context.next_file_pos));
+  } else {
+    ICEBERG_ARROW_RETURN_NOT_OK(
+        int_builder->Append(metadata_context.data_sequence_number.value()));
+  }
+  return {};
+}
+
 /// \brief Append Avro record data to Arrow struct builder.
 Status AppendStructToBuilder(const ::avro::NodePtr& avro_node,
                              const ::avro::GenericDatum& avro_datum,
@@ -97,6 +113,9 @@ Status AppendStructToBuilder(const ::avro::NodePtr& avro_node,
       } else if (field_id == MetadataColumns::kFilePositionColumnId) {
         auto int_builder = internal::checked_cast<::arrow::Int64Builder*>(field_builder);
         ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(metadata_context.next_file_pos));
+      } else if (MetadataColumns::IsRowLineageColumn(field_id)) {
+        ICEBERG_RETURN_UNEXPECTED(
+            AppendRowLineageValue(field_id, metadata_context, field_builder));
       } else {
         return NotSupported("Unsupported metadata column field id: {}", field_id);
       }
@@ -463,9 +482,21 @@ Status AppendFieldToBuilder(const ::avro::NodePtr& avro_node,
     return {};
   }
 
+  const bool is_row_lineage =
+      MetadataColumns::IsRowLineageColumn(projected_field.field_id());
+  if (is_row_lineage &&
+      !arrow::HasRowLineageValue(projected_field.field_id(), metadata_context)) {
+    ICEBERG_ARROW_RETURN_NOT_OK(array_builder->AppendNull());
+    return {};
+  }
+
   if (avro_node->type() == ::avro::AVRO_UNION) {
     size_t branch = avro_datum.unionBranch();
     if (avro_node->leafAt(branch)->type() == ::avro::AVRO_NULL) {
+      if (is_row_lineage) {
+        return AppendRowLineageValue(projected_field.field_id(), metadata_context,
+                                     array_builder);
+      }
       ICEBERG_ARROW_RETURN_NOT_OK(array_builder->AppendNull());
       return {};
     } else {

--- a/src/iceberg/avro/avro_data_util.cc
+++ b/src/iceberg/avro/avro_data_util.cc
@@ -98,8 +98,8 @@ Status AppendStructToBuilder(const ::avro::NodePtr& avro_node,
         auto int_builder = internal::checked_cast<::arrow::Int64Builder*>(field_builder);
         ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(metadata_context.next_file_pos));
       } else if (MetadataColumns::IsRowLineageColumn(field_id)) {
-        ICEBERG_RETURN_UNEXPECTED(
-            arrow::AppendRowLineageValue(field_id, metadata_context, field_builder));
+        ICEBERG_RETURN_UNEXPECTED(arrow::AppendInheritedRowLineageValue(
+            field_id, metadata_context, field_builder));
       } else {
         return NotSupported("Unsupported metadata column field id: {}", field_id);
       }
@@ -468,18 +468,13 @@ Status AppendFieldToBuilder(const ::avro::NodePtr& avro_node,
 
   const bool is_row_lineage =
       MetadataColumns::IsRowLineageColumn(projected_field.field_id());
-  if (is_row_lineage &&
-      !arrow::HasRowLineageValue(projected_field.field_id(), metadata_context)) {
-    ICEBERG_ARROW_RETURN_NOT_OK(array_builder->AppendNull());
-    return {};
-  }
 
   if (avro_node->type() == ::avro::AVRO_UNION) {
     size_t branch = avro_datum.unionBranch();
     if (avro_node->leafAt(branch)->type() == ::avro::AVRO_NULL) {
       if (is_row_lineage) {
-        return arrow::AppendRowLineageValue(projected_field.field_id(), metadata_context,
-                                            array_builder);
+        return arrow::AppendInheritedRowLineageValue(projected_field.field_id(),
+                                                     metadata_context, array_builder);
       }
       ICEBERG_ARROW_RETURN_NOT_OK(array_builder->AppendNull());
       return {};

--- a/src/iceberg/avro/avro_data_util.cc
+++ b/src/iceberg/avro/avro_data_util.cc
@@ -54,22 +54,6 @@ Status AppendFieldToBuilder(const ::avro::NodePtr& avro_node,
                             const arrow::MetadataColumnContext& metadata_context,
                             ::arrow::ArrayBuilder* array_builder);
 
-Status AppendRowLineageValue(int32_t field_id,
-                             const arrow::MetadataColumnContext& metadata_context,
-                             ::arrow::ArrayBuilder* array_builder) {
-  auto* int_builder = internal::checked_cast<::arrow::Int64Builder*>(array_builder);
-  if (!arrow::HasRowLineageValue(field_id, metadata_context)) {
-    ICEBERG_ARROW_RETURN_NOT_OK(int_builder->AppendNull());
-  } else if (field_id == MetadataColumns::kRowIdColumnId) {
-    ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(
-        metadata_context.first_row_id.value() + metadata_context.next_file_pos));
-  } else {
-    ICEBERG_ARROW_RETURN_NOT_OK(
-        int_builder->Append(metadata_context.data_sequence_number.value()));
-  }
-  return {};
-}
-
 /// \brief Append Avro record data to Arrow struct builder.
 Status AppendStructToBuilder(const ::avro::NodePtr& avro_node,
                              const ::avro::GenericDatum& avro_datum,
@@ -115,7 +99,7 @@ Status AppendStructToBuilder(const ::avro::NodePtr& avro_node,
         ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(metadata_context.next_file_pos));
       } else if (MetadataColumns::IsRowLineageColumn(field_id)) {
         ICEBERG_RETURN_UNEXPECTED(
-            AppendRowLineageValue(field_id, metadata_context, field_builder));
+            arrow::AppendRowLineageValue(field_id, metadata_context, field_builder));
       } else {
         return NotSupported("Unsupported metadata column field id: {}", field_id);
       }
@@ -494,8 +478,8 @@ Status AppendFieldToBuilder(const ::avro::NodePtr& avro_node,
     size_t branch = avro_datum.unionBranch();
     if (avro_node->leafAt(branch)->type() == ::avro::AVRO_NULL) {
       if (is_row_lineage) {
-        return AppendRowLineageValue(projected_field.field_id(), metadata_context,
-                                     array_builder);
+        return arrow::AppendRowLineageValue(projected_field.field_id(), metadata_context,
+                                            array_builder);
       }
       ICEBERG_ARROW_RETURN_NOT_OK(array_builder->AppendNull());
       return {};

--- a/src/iceberg/avro/avro_direct_decoder.cc
+++ b/src/iceberg/avro/avro_direct_decoder.cc
@@ -144,22 +144,6 @@ Status SkipAvroValue(const ::avro::NodePtr& avro_node, ::avro::Decoder& decoder)
   }
 }
 
-Status AppendRowLineageValue(int32_t field_id,
-                             const arrow::MetadataColumnContext& metadata_context,
-                             ::arrow::ArrayBuilder* array_builder) {
-  auto* int_builder = internal::checked_cast<::arrow::Int64Builder*>(array_builder);
-  if (!arrow::HasRowLineageValue(field_id, metadata_context)) {
-    ICEBERG_ARROW_RETURN_NOT_OK(int_builder->AppendNull());
-  } else if (field_id == MetadataColumns::kRowIdColumnId) {
-    ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(
-        metadata_context.first_row_id.value() + metadata_context.next_file_pos));
-  } else {
-    ICEBERG_ARROW_RETURN_NOT_OK(
-        int_builder->Append(metadata_context.data_sequence_number.value()));
-  }
-  return {};
-}
-
 /// \brief Decode Avro record directly to Arrow struct builder.
 Status DecodeStructToBuilder(const ::avro::NodePtr& avro_node, ::avro::Decoder& decoder,
                              const std::span<const FieldProjection>& projections,
@@ -236,7 +220,7 @@ Status DecodeStructToBuilder(const ::avro::NodePtr& avro_node, ::avro::Decoder& 
         ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(metadata_context.next_file_pos));
       } else if (MetadataColumns::IsRowLineageColumn(field_id)) {
         ICEBERG_RETURN_UNEXPECTED(
-            AppendRowLineageValue(field_id, metadata_context, field_builder));
+            arrow::AppendRowLineageValue(field_id, metadata_context, field_builder));
       } else {
         return NotSupported("Unsupported metadata column field id: {}", field_id);
       }
@@ -635,8 +619,8 @@ Status DecodeFieldToBuilder(const ::avro::NodePtr& avro_node, ::avro::Decoder& d
     const auto& branch_node = avro_node->leafAt(branch_index);
     if (branch_node->type() == ::avro::AVRO_NULL) {
       if (is_row_lineage) {
-        return AppendRowLineageValue(projected_field.field_id(), metadata_context,
-                                     array_builder);
+        return arrow::AppendRowLineageValue(projected_field.field_id(), metadata_context,
+                                            array_builder);
       }
       ICEBERG_ARROW_RETURN_NOT_OK(array_builder->AppendNull());
       return {};

--- a/src/iceberg/avro/avro_direct_decoder.cc
+++ b/src/iceberg/avro/avro_direct_decoder.cc
@@ -219,8 +219,8 @@ Status DecodeStructToBuilder(const ::avro::NodePtr& avro_node, ::avro::Decoder& 
         auto int_builder = internal::checked_cast<::arrow::Int64Builder*>(field_builder);
         ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(metadata_context.next_file_pos));
       } else if (MetadataColumns::IsRowLineageColumn(field_id)) {
-        ICEBERG_RETURN_UNEXPECTED(
-            arrow::AppendRowLineageValue(field_id, metadata_context, field_builder));
+        ICEBERG_RETURN_UNEXPECTED(arrow::AppendInheritedRowLineageValue(
+            field_id, metadata_context, field_builder));
       } else {
         return NotSupported("Unsupported metadata column field id: {}", field_id);
       }
@@ -599,12 +599,6 @@ Status DecodeFieldToBuilder(const ::avro::NodePtr& avro_node, ::avro::Decoder& d
 
   const bool is_row_lineage =
       MetadataColumns::IsRowLineageColumn(projected_field.field_id());
-  if (is_row_lineage &&
-      !arrow::HasRowLineageValue(projected_field.field_id(), metadata_context)) {
-    ICEBERG_RETURN_UNEXPECTED(SkipAvroValue(avro_node, decoder));
-    ICEBERG_ARROW_RETURN_NOT_OK(array_builder->AppendNull());
-    return {};
-  }
 
   if (avro_node->type() == ::avro::AVRO_UNION) {
     const size_t branch_index = decoder.decodeUnionIndex();
@@ -619,8 +613,8 @@ Status DecodeFieldToBuilder(const ::avro::NodePtr& avro_node, ::avro::Decoder& d
     const auto& branch_node = avro_node->leafAt(branch_index);
     if (branch_node->type() == ::avro::AVRO_NULL) {
       if (is_row_lineage) {
-        return arrow::AppendRowLineageValue(projected_field.field_id(), metadata_context,
-                                            array_builder);
+        return arrow::AppendInheritedRowLineageValue(projected_field.field_id(),
+                                                     metadata_context, array_builder);
       }
       ICEBERG_ARROW_RETURN_NOT_OK(array_builder->AppendNull());
       return {};

--- a/src/iceberg/avro/avro_direct_decoder.cc
+++ b/src/iceberg/avro/avro_direct_decoder.cc
@@ -144,6 +144,22 @@ Status SkipAvroValue(const ::avro::NodePtr& avro_node, ::avro::Decoder& decoder)
   }
 }
 
+Status AppendRowLineageValue(int32_t field_id,
+                             const arrow::MetadataColumnContext& metadata_context,
+                             ::arrow::ArrayBuilder* array_builder) {
+  auto* int_builder = internal::checked_cast<::arrow::Int64Builder*>(array_builder);
+  if (!arrow::HasRowLineageValue(field_id, metadata_context)) {
+    ICEBERG_ARROW_RETURN_NOT_OK(int_builder->AppendNull());
+  } else if (field_id == MetadataColumns::kRowIdColumnId) {
+    ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(
+        metadata_context.first_row_id.value() + metadata_context.next_file_pos));
+  } else {
+    ICEBERG_ARROW_RETURN_NOT_OK(
+        int_builder->Append(metadata_context.data_sequence_number.value()));
+  }
+  return {};
+}
+
 /// \brief Decode Avro record directly to Arrow struct builder.
 Status DecodeStructToBuilder(const ::avro::NodePtr& avro_node, ::avro::Decoder& decoder,
                              const std::span<const FieldProjection>& projections,
@@ -218,6 +234,9 @@ Status DecodeStructToBuilder(const ::avro::NodePtr& avro_node, ::avro::Decoder& 
       } else if (field_id == MetadataColumns::kFilePositionColumnId) {
         auto int_builder = internal::checked_cast<::arrow::Int64Builder*>(field_builder);
         ICEBERG_ARROW_RETURN_NOT_OK(int_builder->Append(metadata_context.next_file_pos));
+      } else if (MetadataColumns::IsRowLineageColumn(field_id)) {
+        ICEBERG_RETURN_UNEXPECTED(
+            AppendRowLineageValue(field_id, metadata_context, field_builder));
       } else {
         return NotSupported("Unsupported metadata column field id: {}", field_id);
       }
@@ -594,6 +613,15 @@ Status DecodeFieldToBuilder(const ::avro::NodePtr& avro_node, ::avro::Decoder& d
     return {};
   }
 
+  const bool is_row_lineage =
+      MetadataColumns::IsRowLineageColumn(projected_field.field_id());
+  if (is_row_lineage &&
+      !arrow::HasRowLineageValue(projected_field.field_id(), metadata_context)) {
+    ICEBERG_RETURN_UNEXPECTED(SkipAvroValue(avro_node, decoder));
+    ICEBERG_ARROW_RETURN_NOT_OK(array_builder->AppendNull());
+    return {};
+  }
+
   if (avro_node->type() == ::avro::AVRO_UNION) {
     const size_t branch_index = decoder.decodeUnionIndex();
 
@@ -606,6 +634,10 @@ Status DecodeFieldToBuilder(const ::avro::NodePtr& avro_node, ::avro::Decoder& d
 
     const auto& branch_node = avro_node->leafAt(branch_index);
     if (branch_node->type() == ::avro::AVRO_NULL) {
+      if (is_row_lineage) {
+        return AppendRowLineageValue(projected_field.field_id(), metadata_context,
+                                     array_builder);
+      }
       ICEBERG_ARROW_RETURN_NOT_OK(array_builder->AppendNull());
       return {};
     } else {

--- a/src/iceberg/avro/avro_reader.cc
+++ b/src/iceberg/avro/avro_reader.cc
@@ -68,6 +68,15 @@ bool HasRowPositionColumn(const Schema& schema) {
   return false;
 }
 
+bool HasRowIdColumn(const Schema& schema) {
+  for (const auto& field : schema.fields()) {
+    if (field.field_id() == MetadataColumns::kRowIdColumnId) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // Abstract base class for Avro read backends.
 class AvroReadBackend {
  public:
@@ -332,9 +341,17 @@ class AvroReader::Impl {
         return NotSupported(
             "Reading '_pos' metadata column with split is not supported for Avro files.");
       }
+      if (options.split->offset != 0 && HasRowIdColumn(*read_schema_)) {
+        return NotSupported(
+            "Reading '_row_id' metadata column with split is not supported for Avro "
+            "files.");
+      }
     }
 
-    metadata_context_ = {.file_path = options.path, .next_file_pos = 0};
+    metadata_context_ = {.file_path = options.path,
+                         .next_file_pos = 0,
+                         .first_row_id = options.first_row_id,
+                         .data_sequence_number = options.data_sequence_number};
 
     return {};
   }

--- a/src/iceberg/catalog/rest/json_serde.cc
+++ b/src/iceberg/catalog/rest/json_serde.cc
@@ -323,6 +323,9 @@ Result<std::vector<std::shared_ptr<FileScanTask>>> FileScanTasksFromJson(
                             GetJsonValue<nlohmann::json>(task_json, kDataFile));
     ICEBERG_ASSIGN_OR_RAISE(
         auto data_file, DataFileFromJson(data_file_json, partition_spec_by_id, schema));
+    // FIXME: REST scan-task DataFile JSON currently carries first-row-id,
+    // but not the manifest-entry data sequence number. Until the REST API exposes
+    // it, REST-planned tasks cannot inherit _last_updated_sequence_number.
 
     std::vector<std::shared_ptr<DataFile>> task_delete_files;
     if (task_json.contains(kDeleteFileReferences) &&

--- a/src/iceberg/catalog/rest/json_serde.cc
+++ b/src/iceberg/catalog/rest/json_serde.cc
@@ -326,6 +326,7 @@ Result<std::vector<std::shared_ptr<FileScanTask>>> FileScanTasksFromJson(
     // FIXME: REST scan-task DataFile JSON currently carries first-row-id,
     // but not the manifest-entry data sequence number. Until the REST API exposes
     // it, REST-planned tasks cannot inherit _last_updated_sequence_number.
+    // See https://github.com/apache/iceberg-cpp/issues/834.
 
     std::vector<std::shared_ptr<DataFile>> task_delete_files;
     if (task_json.contains(kDeleteFileReferences) &&

--- a/src/iceberg/data/file_scan_task_reader.cc
+++ b/src/iceberg/data/file_scan_task_reader.cc
@@ -43,7 +43,9 @@ ReaderOptions MakeReaderOptions(const DataFile& data_file, std::shared_ptr<FileI
                                 std::shared_ptr<Schema> projection,
                                 std::shared_ptr<Expression> filter,
                                 std::shared_ptr<NameMapping> name_mapping,
-                                ReaderProperties properties) {
+                                ReaderProperties properties,
+                                std::optional<int64_t> first_row_id,
+                                std::optional<int64_t> data_sequence_number) {
   return ReaderOptions{
       .path = data_file.file_path,
       .length = static_cast<size_t>(data_file.file_size_in_bytes),
@@ -51,6 +53,8 @@ ReaderOptions MakeReaderOptions(const DataFile& data_file, std::shared_ptr<FileI
       .projection = std::move(projection),
       .filter = std::move(filter),
       .name_mapping = std::move(name_mapping),
+      .first_row_id = first_row_id,
+      .data_sequence_number = data_sequence_number,
       .properties = std::move(properties),
   };
 }
@@ -161,9 +165,9 @@ class FileScanTaskReader::Impl {
                      data_file->file_size_in_bytes);
 
     if (task.delete_files().empty()) {
-      auto options =
-          MakeReaderOptions(*data_file, io_, projected_schema_, task.residual_filter(),
-                            name_mapping_, properties_);
+      auto options = MakeReaderOptions(
+          *data_file, io_, projected_schema_, task.residual_filter(), name_mapping_,
+          properties_, data_file->first_row_id, data_file->data_sequence_number);
       ICEBERG_ASSIGN_OR_RAISE(
           auto reader, ReaderFactoryRegistry::Open(data_file->file_format, options));
       return MakeArrowArrayStream(std::move(reader));
@@ -187,8 +191,9 @@ class FileScanTaskReader::Impl {
                             ProjectionContext::Make(*required_schema, *projected_schema_,
                                                     project_batch_function));
 
-    auto options = MakeReaderOptions(*data_file, io_, required_schema,
-                                     task.residual_filter(), name_mapping_, properties_);
+    auto options = MakeReaderOptions(
+        *data_file, io_, required_schema, task.residual_filter(), name_mapping_,
+        properties_, data_file->first_row_id, data_file->data_sequence_number);
     ICEBERG_ASSIGN_OR_RAISE(auto reader,
                             ReaderFactoryRegistry::Open(data_file->file_format, options));
 

--- a/src/iceberg/file_reader.h
+++ b/src/iceberg/file_reader.h
@@ -22,6 +22,7 @@
 /// \file iceberg/file_reader.h
 /// Reader interface for file formats like Parquet, Avro and ORC.
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -105,6 +106,10 @@ struct ICEBERG_EXPORT ReaderOptions {
   /// \brief Name mapping for schema evolution compatibility. Used when reading files
   /// that may have different field names than the current schema.
   std::shared_ptr<class NameMapping> name_mapping;
+  /// \brief First row ID inherited by the data file, if assigned.
+  std::optional<int64_t> first_row_id;
+  /// \brief Data sequence number inherited by the manifest entry, if assigned.
+  std::optional<int64_t> data_sequence_number;
   /// \brief Format-specific or implementation-specific properties.
   ReaderProperties properties;
 };

--- a/src/iceberg/inheritable_metadata.cc
+++ b/src/iceberg/inheritable_metadata.cc
@@ -65,6 +65,8 @@ Status BaseInheritableMetadata::Apply(ManifestEntry& entry) {
   if (entry.data_file) {
     entry.data_file->partition_spec_id = spec_id_;
     entry.data_file->data_sequence_number = entry.sequence_number;
+    // TODO(gangwu): Also propagate file_sequence_number and manifest_location
+    // when C++ adds consumers that need Java-style inherited file metadata.
   } else {
     return InvalidManifest("Manifest entry has no data file");
   }

--- a/src/iceberg/inheritable_metadata.cc
+++ b/src/iceberg/inheritable_metadata.cc
@@ -64,6 +64,7 @@ Status BaseInheritableMetadata::Apply(ManifestEntry& entry) {
 
   if (entry.data_file) {
     entry.data_file->partition_spec_id = spec_id_;
+    entry.data_file->data_sequence_number = entry.sequence_number;
   } else {
     return InvalidManifest("Manifest entry has no data file");
   }

--- a/src/iceberg/manifest/manifest_entry.h
+++ b/src/iceberg/manifest/manifest_entry.h
@@ -174,10 +174,17 @@ struct ICEBERG_EXPORT DataFile {
   /// present
   std::optional<int64_t> content_size_in_bytes;
 
+  /// \note Fields defined below are inherited and not persisted to the DataFile struct.
+
   /// \brief Partition spec id for this data file.
-  /// \note This field is for internal use only and will not be persisted to manifest
-  /// entry.
+  /// \note This inherited field is for internal use only and will not be persisted to
+  /// the DataFile struct.
   std::optional<int32_t> partition_spec_id;
+
+  /// \brief Data sequence number for this data file.
+  /// \note This inherited field is for internal use only and will not be persisted to
+  /// the DataFile struct.
+  std::optional<int64_t> data_sequence_number;
 
   static constexpr int32_t kContentFieldId = 134;
   inline static const SchemaField kContent = SchemaField::MakeOptional(

--- a/src/iceberg/metadata_columns.cc
+++ b/src/iceberg/metadata_columns.cc
@@ -66,6 +66,10 @@ bool MetadataColumns::IsMetadataColumn(int32_t id) {
   return GetMetadataFieldIdSet().find(id) != GetMetadataFieldIdSet().end();
 }
 
+bool MetadataColumns::IsRowLineageColumn(int32_t id) {
+  return id == kRowIdColumnId || id == kLastUpdatedSequenceNumberColumnId;
+}
+
 Result<const SchemaField*> MetadataColumns::MetadataColumn(std::string_view name) {
   const auto& metadata_column_map = GetMetadataColumnMap();
   const auto it = metadata_column_map.find(name);

--- a/src/iceberg/metadata_columns.h
+++ b/src/iceberg/metadata_columns.h
@@ -113,6 +113,9 @@ struct ICEBERG_EXPORT MetadataColumns {
   /// \brief Check if a column ID is a metadata column.
   static bool IsMetadataColumn(int32_t id);
 
+  /// \brief Check if a column ID is a row lineage column.
+  static bool IsRowLineageColumn(int32_t id);
+
   /// \brief Get a metadata column by name.
   ///
   /// \param name The name of the metadata column.

--- a/src/iceberg/parquet/parquet_data_util.cc
+++ b/src/iceberg/parquet/parquet_data_util.cc
@@ -70,6 +70,53 @@ Result<std::shared_ptr<::arrow::Array>> ProjectPrimitiveArray(
   return cast_result.make_array();
 }
 
+Result<std::shared_ptr<::arrow::Array>> MakeInheritedRowLineageArray(
+    int32_t field_id, int64_t num_rows,
+    const arrow::MetadataColumnContext& metadata_context, ::arrow::MemoryPool* pool) {
+  if (field_id == MetadataColumns::kRowIdColumnId) {
+    return arrow::MakeRowIdArray(metadata_context.first_row_id,
+                                 metadata_context.next_file_pos, num_rows, pool);
+  }
+  if (field_id == MetadataColumns::kLastUpdatedSequenceNumberColumnId) {
+    return arrow::MakeLastUpdatedSequenceNumberArray(
+        metadata_context.first_row_id, metadata_context.data_sequence_number, num_rows,
+        pool);
+  }
+  return NotSupported("Unsupported row lineage field id: {}", field_id);
+}
+
+Result<std::shared_ptr<::arrow::Array>> ProjectRowLineageArray(
+    const std::shared_ptr<::arrow::Array>& physical_array, int32_t field_id,
+    const arrow::MetadataColumnContext& metadata_context, ::arrow::MemoryPool* pool) {
+  if (!arrow::HasRowLineageValue(field_id, metadata_context)) {
+    return MakeInheritedRowLineageArray(field_id, physical_array->length(),
+                                        metadata_context, pool);
+  }
+  if (physical_array->null_count() == 0) {
+    return physical_array;
+  }
+
+  auto values = internal::checked_pointer_cast<::arrow::Int64Array>(physical_array);
+  ::arrow::Int64Builder builder(pool);
+  ICEBERG_ARROW_RETURN_NOT_OK(builder.Reserve(values->length()));
+  for (int64_t row_index = 0; row_index < values->length(); ++row_index) {
+    if (!values->IsNull(row_index)) {
+      ICEBERG_ARROW_RETURN_NOT_OK(builder.Append(values->Value(row_index)));
+    } else if (field_id == MetadataColumns::kRowIdColumnId) {
+      ICEBERG_ARROW_RETURN_NOT_OK(builder.Append(metadata_context.first_row_id.value() +
+                                                 metadata_context.next_file_pos +
+                                                 row_index));
+    } else {
+      ICEBERG_ARROW_RETURN_NOT_OK(
+          builder.Append(metadata_context.data_sequence_number.value()));
+    }
+  }
+
+  std::shared_ptr<::arrow::Array> output;
+  ICEBERG_ARROW_RETURN_NOT_OK(builder.Finish(&output));
+  return output;
+}
+
 Result<std::shared_ptr<::arrow::Array>> ProjectStructArray(
     const std::shared_ptr<::arrow::StructArray>& struct_array,
     const std::shared_ptr<::arrow::StructType>& output_struct_type,
@@ -111,6 +158,11 @@ Result<std::shared_ptr<::arrow::Array>> ProjectStructArray(
             projected_array,
             ProjectNestedArray(parquet_array, output_arrow_type, nested_type,
                                field_projection.children, metadata_context, pool));
+      } else if (MetadataColumns::IsRowLineageColumn(projected_field.field_id())) {
+        ICEBERG_ASSIGN_OR_RAISE(
+            projected_array,
+            ProjectRowLineageArray(parquet_array, projected_field.field_id(),
+                                   metadata_context, pool));
       } else {
         ICEBERG_ASSIGN_OR_RAISE(
             projected_array,
@@ -135,6 +187,10 @@ Result<std::shared_ptr<::arrow::Array>> ProjectStructArray(
         ICEBERG_ASSIGN_OR_RAISE(
             projected_array, arrow::MakeRowPositionArray(metadata_context.next_file_pos,
                                                          struct_array->length(), pool));
+      } else if (MetadataColumns::IsRowLineageColumn(field_id)) {
+        ICEBERG_ASSIGN_OR_RAISE(projected_array, MakeInheritedRowLineageArray(
+                                                     field_id, struct_array->length(),
+                                                     metadata_context, pool));
       } else {
         return NotSupported("Unsupported metadata field id: {}", field_id);
       }

--- a/src/iceberg/parquet/parquet_data_util.cc
+++ b/src/iceberg/parquet/parquet_data_util.cc
@@ -79,8 +79,7 @@ Result<std::shared_ptr<::arrow::Array>> MakeInheritedRowLineageArray(
   }
   if (field_id == MetadataColumns::kLastUpdatedSequenceNumberColumnId) {
     return arrow::MakeLastUpdatedSequenceNumberArray(
-        metadata_context.first_row_id, metadata_context.data_sequence_number, num_rows,
-        pool);
+        metadata_context.data_sequence_number, num_rows, pool);
   }
   return NotSupported("Unsupported row lineage field id: {}", field_id);
 }
@@ -88,27 +87,21 @@ Result<std::shared_ptr<::arrow::Array>> MakeInheritedRowLineageArray(
 Result<std::shared_ptr<::arrow::Array>> ProjectRowLineageArray(
     const std::shared_ptr<::arrow::Array>& physical_array, int32_t field_id,
     const arrow::MetadataColumnContext& metadata_context, ::arrow::MemoryPool* pool) {
-  if (!arrow::HasRowLineageValue(field_id, metadata_context)) {
-    return MakeInheritedRowLineageArray(field_id, physical_array->length(),
-                                        metadata_context, pool);
-  }
   if (physical_array->null_count() == 0) {
     return physical_array;
   }
 
   auto values = internal::checked_pointer_cast<::arrow::Int64Array>(physical_array);
+  auto row_metadata_context = metadata_context;
   ::arrow::Int64Builder builder(pool);
   ICEBERG_ARROW_RETURN_NOT_OK(builder.Reserve(values->length()));
   for (int64_t row_index = 0; row_index < values->length(); ++row_index) {
     if (!values->IsNull(row_index)) {
       ICEBERG_ARROW_RETURN_NOT_OK(builder.Append(values->Value(row_index)));
-    } else if (field_id == MetadataColumns::kRowIdColumnId) {
-      ICEBERG_ARROW_RETURN_NOT_OK(builder.Append(metadata_context.first_row_id.value() +
-                                                 metadata_context.next_file_pos +
-                                                 row_index));
     } else {
-      ICEBERG_ARROW_RETURN_NOT_OK(
-          builder.Append(metadata_context.data_sequence_number.value()));
+      row_metadata_context.next_file_pos = metadata_context.next_file_pos + row_index;
+      ICEBERG_RETURN_UNEXPECTED(arrow::AppendInheritedRowLineageValue(
+          field_id, row_metadata_context, &builder));
     }
   }
 

--- a/src/iceberg/parquet/parquet_reader.cc
+++ b/src/iceberg/parquet/parquet_reader.cc
@@ -129,7 +129,10 @@ class ParquetReader::Impl {
 
     // Project read schema onto the Parquet file schema
     ICEBERG_ASSIGN_OR_RAISE(projection_, BuildProjection(reader_.get(), *read_schema_));
-    metadata_context_ = {.file_path = options.path, .next_file_pos = 0};
+    metadata_context_ = {.file_path = options.path,
+                         .next_file_pos = 0,
+                         .first_row_id = options.first_row_id,
+                         .data_sequence_number = options.data_sequence_number};
 
     return {};
   }

--- a/src/iceberg/table_scan.cc
+++ b/src/iceberg/table_scan.cc
@@ -182,6 +182,18 @@ int64_t FileScanTask::estimated_row_count() const { return data_file_->record_co
 
 // ChangelogScanTask implementation
 
+ChangelogScanTask::ChangelogScanTask(int32_t change_ordinal, int64_t commit_snapshot_id,
+                                     std::shared_ptr<DataFile> data_file,
+                                     std::vector<std::shared_ptr<DataFile>> delete_files,
+                                     std::shared_ptr<Expression> residual_filter)
+    : change_ordinal_(change_ordinal),
+      commit_snapshot_id_(commit_snapshot_id),
+      data_file_(std::move(data_file)),
+      delete_files_(std::move(delete_files)),
+      residual_filter_(std::move(residual_filter)) {
+  ICEBERG_DCHECK(data_file_ != nullptr, "Data file cannot be null for ChangelogScanTask");
+}
+
 int64_t ChangelogScanTask::size_bytes() const {
   int64_t total_size = data_file_->file_size_in_bytes;
   for (const auto& delete_file : delete_files_) {
@@ -790,7 +802,6 @@ IncrementalChangelogScan::PlanFiles(std::optional<int64_t> from_snapshot_id_excl
 
       ICEBERG_ASSIGN_OR_RAISE(auto residual,
                               ctx.residuals->ResidualFor(entry.data_file->partition));
-
       switch (entry.status) {
         case ManifestStatus::kAdded:
           tasks.push_back(std::make_shared<AddedRowsScanTask>(

--- a/src/iceberg/table_scan.h
+++ b/src/iceberg/table_scan.h
@@ -116,12 +116,7 @@ class ICEBERG_EXPORT ChangelogScanTask : public ScanTask {
   ChangelogScanTask(int32_t change_ordinal, int64_t commit_snapshot_id,
                     std::shared_ptr<DataFile> data_file,
                     std::vector<std::shared_ptr<DataFile>> delete_files = {},
-                    std::shared_ptr<Expression> residual_filter = nullptr)
-      : change_ordinal_(change_ordinal),
-        commit_snapshot_id_(commit_snapshot_id),
-        data_file_(std::move(data_file)),
-        delete_files_(std::move(delete_files)),
-        residual_filter_(std::move(residual_filter)) {}
+                    std::shared_ptr<Expression> residual_filter = nullptr);
 
   Kind kind() const override { return Kind::kChangelogScanTask; }
 

--- a/src/iceberg/test/avro_test.cc
+++ b/src/iceberg/test/avro_test.cc
@@ -162,6 +162,29 @@ class AvroReaderTest : public TempFileTestBase {
     ASSERT_THAT(writer->Close(), IsOk());
   }
 
+  std::shared_ptr<Schema> RowLineageSchema() {
+    return std::make_shared<Schema>(std::vector<SchemaField>{
+        SchemaField::MakeRequired(1, "id", int32()),
+        MetadataColumns::kRowId,
+        MetadataColumns::kLastUpdatedSequenceNumber,
+    });
+  }
+
+  Result<std::unique_ptr<Reader>> OpenRowLineageReader(
+      const std::shared_ptr<Schema>& schema,
+      std::optional<int64_t> first_row_id = std::nullopt,
+      std::optional<int64_t> data_sequence_number = std::nullopt) {
+    ReaderProperties properties;
+    properties.Set(ReaderProperties::kAvroSkipDatum, skip_datum_);
+    return ReaderFactoryRegistry::Open(FileFormatType::kAvro,
+                                       {.path = temp_avro_file_,
+                                        .io = file_io_,
+                                        .projection = schema,
+                                        .first_row_id = first_row_id,
+                                        .data_sequence_number = data_sequence_number,
+                                        .properties = std::move(properties)});
+  }
+
   void VerifyNextBatch(Reader& reader, std::string_view expected_json) {
     // Boilerplate to get Arrow schema
     auto schema_result = reader.Schema();
@@ -694,6 +717,30 @@ TEST_P(AvroReaderParameterizedTest, ReadMetadataOnlyProjection) {
   VerifyNextBatch(*reader, expected_string);
 }
 
+TEST_P(AvroReaderParameterizedTest, ReadRowLineage) {
+  temp_avro_file_ = "avro_row_lineage.avro";
+  CreateSimpleAvroFile();
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, OpenRowLineageReader(RowLineageSchema(), 100L, 7L));
+
+  VerifyNextBatch(*reader, R"([[1, 100, 7], [2, 101, 7], [3, 102, 7]])");
+}
+
+TEST_P(AvroReaderParameterizedTest, ReadPartialLineage) {
+  temp_avro_file_ = "avro_partial_lineage.avro";
+  CreateSimpleAvroFile();
+
+  auto schema = RowLineageSchema();
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, OpenRowLineageReader(schema));
+
+  VerifyNextBatch(*reader, R"([[1, null, null], [2, null, null], [3, null, null]])");
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader_with_row_id, OpenRowLineageReader(schema, 100L));
+
+  VerifyNextBatch(*reader_with_row_id,
+                  R"([[1, 100, null], [2, 101, null], [3, 102, null]])");
+}
+
 TEST_P(AvroReaderParameterizedTest, SplitWithRowPositionNotSupported) {
   CreateSimpleAvroFile();
 
@@ -712,6 +759,29 @@ TEST_P(AvroReaderParameterizedTest, SplitWithRowPositionNotSupported) {
   ASSERT_THAT(reader_result, IsError(ErrorKind::kNotSupported));
   EXPECT_THAT(reader_result,
               HasErrorMessage("'_pos' metadata column with split is not supported"));
+}
+
+TEST_P(AvroReaderParameterizedTest, SplitWithRowIdNotSupported) {
+  CreateSimpleAvroFile();
+
+  auto schema = std::make_shared<Schema>(std::vector<SchemaField>{
+      SchemaField::MakeRequired(1, "id", int32()),
+      MetadataColumns::kRowId,
+  });
+
+  ReaderProperties properties;
+  properties.Set(ReaderProperties::kAvroSkipDatum, skip_datum_);
+  auto reader_result = ReaderFactoryRegistry::Open(
+      FileFormatType::kAvro, {.path = temp_avro_file_,
+                              .split = Split{.offset = 100, .length = 200},
+                              .io = file_io_,
+                              .projection = schema,
+                              .first_row_id = 100L,
+                              .properties = std::move(properties)});
+
+  ASSERT_THAT(reader_result, IsError(ErrorKind::kNotSupported));
+  EXPECT_THAT(reader_result,
+              HasErrorMessage("'_row_id' metadata column with split is not supported"));
 }
 
 INSTANTIATE_TEST_SUITE_P(DirectDecoderModes, AvroReaderParameterizedTest,

--- a/src/iceberg/test/avro_test.cc
+++ b/src/iceberg/test/avro_test.cc
@@ -162,6 +162,36 @@ class AvroReaderTest : public TempFileTestBase {
     ASSERT_THAT(writer->Close(), IsOk());
   }
 
+  void CreateRowLineageAvroFile() {
+    auto schema = RowLineageSchema();
+
+    ArrowSchema arrow_c_schema;
+    ASSERT_THAT(ToArrowSchema(*schema, &arrow_c_schema), IsOk());
+    auto arrow_schema = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+
+    auto array =
+        ::arrow::json::ArrayFromJSONString(::arrow::struct_(arrow_schema->fields()),
+                                           R"([[1, null, null],
+                                              [2, 777, 8],
+                                              [3, null, null]])")
+            .ValueOrDie();
+
+    struct ArrowArray arrow_array;
+    auto export_result = ::arrow::ExportArray(*array, &arrow_array);
+    ASSERT_TRUE(export_result.ok());
+
+    auto writer_result =
+        WriterFactoryRegistry::Open(FileFormatType::kAvro, {
+                                                               .path = temp_avro_file_,
+                                                               .schema = schema,
+                                                               .io = file_io_,
+                                                           });
+    ASSERT_TRUE(writer_result.has_value());
+    auto writer = std::move(writer_result.value());
+    ASSERT_THAT(writer->Write(&arrow_array), IsOk());
+    ASSERT_THAT(writer->Close(), IsOk());
+  }
+
   std::shared_ptr<Schema> RowLineageSchema() {
     return std::make_shared<Schema>(std::vector<SchemaField>{
         SchemaField::MakeRequired(1, "id", int32()),
@@ -739,6 +769,21 @@ TEST_P(AvroReaderParameterizedTest, ReadPartialLineage) {
 
   VerifyNextBatch(*reader_with_row_id,
                   R"([[1, 100, null], [2, 101, null], [3, 102, null]])");
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader_with_sequence,
+                         OpenRowLineageReader(schema, std::nullopt, 7L));
+
+  VerifyNextBatch(*reader_with_sequence, R"([[1, null, 7], [2, null, 7], [3, null, 7]])");
+}
+
+TEST_P(AvroReaderParameterizedTest, ReadPhysicalLineage) {
+  temp_avro_file_ = "avro_physical_lineage.avro";
+  CreateRowLineageAvroFile();
+
+  auto schema = RowLineageSchema();
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, OpenRowLineageReader(schema, 100L));
+
+  VerifyNextBatch(*reader, R"([[1, 100, null], [2, 777, 8], [3, 102, null]])");
 }
 
 TEST_P(AvroReaderParameterizedTest, SplitWithRowPositionNotSupported) {

--- a/src/iceberg/test/data_writer_test.cc
+++ b/src/iceberg/test/data_writer_test.cc
@@ -30,6 +30,7 @@
 #include "iceberg/data/equality_delete_writer.h"
 #include "iceberg/data/position_delete_writer.h"
 #include "iceberg/file_format.h"
+#include "iceberg/file_reader.h"
 #include "iceberg/manifest/manifest_entry.h"
 #include "iceberg/metadata_columns.h"
 #include "iceberg/parquet/parquet_register.h"
@@ -76,15 +77,32 @@ class DataWriterTest : public ::testing::Test {
     };
   }
 
-  std::shared_ptr<::arrow::Array> CreateTestData() {
+  std::shared_ptr<::arrow::Array> CreateArray(const Schema& schema,
+                                              std::string_view json) {
     ArrowSchema arrow_c_schema;
-    ICEBERG_THROW_NOT_OK(ToArrowSchema(*schema_, &arrow_c_schema));
+    ICEBERG_THROW_NOT_OK(ToArrowSchema(schema, &arrow_c_schema));
     auto arrow_schema = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
 
-    return ::arrow::json::ArrayFromJSONString(
-               ::arrow::struct_(arrow_schema->fields()),
-               R"([[1, "Alice"], [2, "Bob"], [3, "Charlie"]])")
+    return ::arrow::json::ArrayFromJSONString(::arrow::struct_(arrow_schema->fields()),
+                                              std::string(json))
         .ValueOrDie();
+  }
+
+  std::shared_ptr<::arrow::Array> CreateTestData() {
+    return CreateArray(*schema_, R"([[1, "Alice"], [2, "Bob"], [3, "Charlie"]])");
+  }
+
+  std::shared_ptr<Schema> RowLineageSchema() {
+    return std::make_shared<Schema>(std::vector<SchemaField>{
+        SchemaField::MakeRequired(1, "id", int32()), MetadataColumns::kRowId,
+        MetadataColumns::kLastUpdatedSequenceNumber});
+  }
+
+  std::unordered_map<std::string, std::string> FormatProperties(FileFormatType format) {
+    if (format == FileFormatType::kParquet) {
+      return {{"write.parquet.compression-codec", "uncompressed"}};
+    }
+    return {};
   }
 
   void WriteTestDataToWriter(DataWriter* writer) {
@@ -92,6 +110,20 @@ class DataWriterTest : public ::testing::Test {
     ArrowArray arrow_array;
     ASSERT_TRUE(::arrow::ExportArray(*test_data, &arrow_array).ok());
     ASSERT_THAT(writer->Write(&arrow_array), IsOk());
+  }
+
+  void VerifyNextBatch(Reader& reader, const Schema& schema,
+                       std::string_view expected_json) {
+    auto data = reader.Next();
+    ASSERT_THAT(data, IsOk()) << "Reader.Next() failed: " << data.error().message;
+    ASSERT_TRUE(data.value().has_value()) << "Reader.Next() returned no data";
+
+    auto expected_array = CreateArray(schema, expected_json);
+    auto actual_array =
+        ::arrow::ImportArray(&data.value().value(), expected_array->type()).ValueOrDie();
+    ASSERT_TRUE(actual_array->Equals(expected_array))
+        << "Expected: " << expected_array->ToString()
+        << "\nActual: " << actual_array->ToString();
   }
 
   std::shared_ptr<FileIO> file_io_;
@@ -112,18 +144,48 @@ TEST_P(DataWriterFormatTest, CreateWithFormat) {
       .partition = PartitionValues{},
       .format = format,
       .io = file_io_,
-      .properties =
-          format == FileFormatType::kParquet
-              ? std::unordered_map<std::string,
-                                   std::string>{{"write.parquet.compression-codec",
-                                                 "uncompressed"}}
-              : std::unordered_map<std::string, std::string>{},
+      .properties = FormatProperties(format),
   };
 
   auto writer_result = DataWriter::Make(options);
   ASSERT_THAT(writer_result, IsOk());
   auto writer = std::move(writer_result.value());
   ASSERT_NE(writer, nullptr);
+}
+
+TEST_P(DataWriterFormatTest, WriteRowLineage) {
+  auto [format, path] = GetParam();
+  auto schema = RowLineageSchema();
+  DataWriterOptions options{
+      .path = path,
+      .schema = schema,
+      .spec = partition_spec_,
+      .partition = PartitionValues{},
+      .format = format,
+      .io = file_io_,
+      .properties = FormatProperties(format),
+  };
+
+  ICEBERG_UNWRAP_OR_FAIL(auto writer, DataWriter::Make(options));
+
+  auto array = CreateArray(*schema, R"([[1, null, null],
+                                       [2, 777, 8],
+                                       [3, null, null]])");
+  ArrowArray arrow_array;
+  ASSERT_TRUE(::arrow::ExportArray(*array, &arrow_array).ok());
+  ASSERT_THAT(writer->Write(&arrow_array), IsOk());
+  ASSERT_THAT(writer->Close(), IsOk());
+
+  ICEBERG_UNWRAP_OR_FAIL(
+      auto reader, ReaderFactoryRegistry::Open(format, {.path = path,
+                                                        .io = file_io_,
+                                                        .projection = schema,
+                                                        .first_row_id = 100L,
+                                                        .data_sequence_number = 7L}));
+
+  ASSERT_NO_FATAL_FAILURE(VerifyNextBatch(*reader, *schema, R"([[1, 100, 7],
+                                                               [2, 777, 8],
+                                                               [3, 102, 7]])"));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/iceberg/test/file_scan_task_reader_test.cc
+++ b/src/iceberg/test/file_scan_task_reader_test.cc
@@ -43,6 +43,7 @@
 #include "iceberg/file_format.h"
 #include "iceberg/file_reader.h"
 #include "iceberg/manifest/manifest_entry.h"
+#include "iceberg/metadata_columns.h"
 #include "iceberg/parquet/parquet_register.h"
 #include "iceberg/partition_spec.h"
 #include "iceberg/row/partition_values.h"
@@ -375,6 +376,36 @@ TEST_F(FileScanTaskReaderTest, OpenWithoutDeletesReadsProjectedSchema) {
 
   ASSERT_NO_FATAL_FAILURE(
       VerifyStream(&stream, R"([[1, "Foo"], [2, "Bar"], [3, "Baz"]])"));
+}
+
+TEST_F(FileScanTaskReaderTest, ReadLastUpdatedFromDataSeq) {
+  ICEBERG_UNWRAP_OR_FAIL(
+      auto data_file,
+      MakeDataFile(table_schema_,
+                   R"([[1, "Foo", "blue"], [2, "Bar", "red"], [3, "Baz", "green"]])"));
+  data_file->first_row_id = 100L;
+  data_file->data_sequence_number = 5L;
+  FileScanTask task(data_file);
+  auto projected_schema = std::make_shared<Schema>(
+      std::vector<SchemaField>{SchemaField::MakeRequired(1, "id", int32()),
+                               MetadataColumns::kRowId,
+                               MetadataColumns::kLastUpdatedSequenceNumber},
+      table_schema_->schema_id());
+
+  FileScanTaskReader::Options options{
+      .io = file_io_,
+      .table_schema = table_schema_,
+      .schemas = {table_schema_},
+      .projected_schema = projected_schema,
+  };
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, FileScanTaskReader::Make(std::move(options)));
+  auto stream_result = reader->Open(task);
+  ASSERT_THAT(stream_result, IsOk());
+  auto stream = std::move(stream_result.value());
+
+  ASSERT_NO_FATAL_FAILURE(VerifyStream(&stream, R"([[1, 100, 5],
+                                                   [2, 101, 5],
+                                                   [3, 102, 5]])"));
 }
 
 TEST_F(FileScanTaskReaderTest, OpenWithPositionDeletesFiltersRowsAndPrunesPos) {

--- a/src/iceberg/test/parquet_test.cc
+++ b/src/iceberg/test/parquet_test.cc
@@ -198,6 +198,30 @@ class ParquetReaderTest : public TempFileTestBase {
                                    .properties = std::move(writer_properties)}));
   }
 
+  void CreateRowLineageParquetFile() {
+    auto schema = RowLineageSchema();
+
+    ArrowSchema arrow_c_schema;
+    ASSERT_THAT(ToArrowSchema(*schema, &arrow_c_schema), IsOk());
+    auto arrow_schema = ::arrow::ImportType(&arrow_c_schema).ValueOrDie();
+
+    auto array =
+        ::arrow::json::ArrayFromJSONString(::arrow::struct_(arrow_schema->fields()),
+                                           R"([[1, null, null],
+                                              [2, 777, 8],
+                                              [3, null, null]])")
+            .ValueOrDie();
+
+    WriterProperties writer_properties;
+    writer_properties.Set(WriterProperties::kParquetCompression,
+                          std::string("uncompressed"));
+
+    ASSERT_TRUE(WriteArray(array, {.path = temp_parquet_file_,
+                                   .schema = schema,
+                                   .io = file_io_,
+                                   .properties = std::move(writer_properties)}));
+  }
+
   void CreateSplitParquetFile() {
     const std::string kParquetFieldIdKey = "PARQUET:field_id";
     auto arrow_schema = ::arrow::schema(
@@ -573,6 +597,26 @@ TEST_F(ParquetReaderTest, ReadPartialLineage) {
                                           R"([[1, 100, null],
                                              [2, 101, null],
                                              [3, 102, null]])"));
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader_with_sequence,
+                         OpenRowLineageReader(schema, std::nullopt, 7L));
+
+  ASSERT_NO_FATAL_FAILURE(VerifyNextBatch(*reader_with_sequence,
+                                          R"([[1, null, 7],
+                                             [2, null, 7],
+                                             [3, null, 7]])"));
+}
+
+TEST_F(ParquetReaderTest, ReadPhysicalLineage) {
+  temp_parquet_file_ = "physical_lineage.parquet";
+  CreateRowLineageParquetFile();
+
+  auto schema = RowLineageSchema();
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, OpenRowLineageReader(schema, 100L));
+
+  ASSERT_NO_FATAL_FAILURE(VerifyNextBatch(*reader, R"([[1, 100, null],
+                                                       [2, 777, 8],
+                                                       [3, 102, null]])"));
 }
 
 TEST_F(ParquetReaderTest, ReadNestedUnknownProjection) {

--- a/src/iceberg/test/parquet_test.cc
+++ b/src/iceberg/test/parquet_test.cc
@@ -223,6 +223,26 @@ class ParquetReaderTest : public TempFileTestBase {
     ASSERT_TRUE(outfile->Close().ok());
   }
 
+  std::shared_ptr<Schema> RowLineageSchema() {
+    return std::make_shared<Schema>(std::vector<SchemaField>{
+        SchemaField::MakeRequired(1, "id", int32()),
+        MetadataColumns::kRowId,
+        MetadataColumns::kLastUpdatedSequenceNumber,
+    });
+  }
+
+  Result<std::unique_ptr<Reader>> OpenRowLineageReader(
+      const std::shared_ptr<Schema>& schema,
+      std::optional<int64_t> first_row_id = std::nullopt,
+      std::optional<int64_t> data_sequence_number = std::nullopt) {
+    return ReaderFactoryRegistry::Open(FileFormatType::kParquet,
+                                       {.path = temp_parquet_file_,
+                                        .io = file_io_,
+                                        .projection = schema,
+                                        .first_row_id = first_row_id,
+                                        .data_sequence_number = data_sequence_number});
+  }
+
   void VerifyNextBatch(Reader& reader, std::string_view expected_json) {
     // Boilerplate to get Arrow schema
     auto schema_result = reader.Schema();
@@ -523,6 +543,36 @@ TEST_F(ParquetReaderTest, ReadMetadataOnlyProjection) {
           {.path = temp_parquet_file_, .io = file_io_, .projection = schema}));
 
   ASSERT_NO_FATAL_FAILURE(VerifyNextBatch(*reader, kExpectedJson));
+}
+
+TEST_F(ParquetReaderTest, ReadRowLineage) {
+  temp_parquet_file_ = "row_lineage.parquet";
+  CreateSimpleParquetFile();
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, OpenRowLineageReader(RowLineageSchema(), 100L, 7L));
+
+  ASSERT_NO_FATAL_FAILURE(VerifyNextBatch(*reader, R"([[1, 100, 7],
+                                                       [2, 101, 7],
+                                                       [3, 102, 7]])"));
+}
+
+TEST_F(ParquetReaderTest, ReadPartialLineage) {
+  temp_parquet_file_ = "partial_lineage.parquet";
+  CreateSimpleParquetFile();
+
+  auto schema = RowLineageSchema();
+  ICEBERG_UNWRAP_OR_FAIL(auto reader, OpenRowLineageReader(schema));
+
+  ASSERT_NO_FATAL_FAILURE(VerifyNextBatch(*reader, R"([[1, null, null],
+                                                       [2, null, null],
+                                                       [3, null, null]])"));
+
+  ICEBERG_UNWRAP_OR_FAIL(auto reader_with_row_id, OpenRowLineageReader(schema, 100L));
+
+  ASSERT_NO_FATAL_FAILURE(VerifyNextBatch(*reader_with_row_id,
+                                          R"([[1, 100, null],
+                                             [2, 101, null],
+                                             [3, 102, null]])"));
 }
 
 TEST_F(ParquetReaderTest, ReadNestedUnknownProjection) {

--- a/src/iceberg/test/rest_json_serde_test.cc
+++ b/src/iceberg/test/rest_json_serde_test.cc
@@ -2284,6 +2284,33 @@ TEST(FileScanTasksFromJsonTest, SingleTaskNoDeleteFiles) {
   EXPECT_EQ(task->residual_filter(), nullptr);
 }
 
+TEST(FileScanTasksFromJsonTest, RowLineageSequence) {
+  GTEST_SKIP() << "REST scan-task JSON does not expose data-sequence-number yet: "
+               << "https://github.com/apache/iceberg-cpp/issues/834";
+
+  auto json = R"([{
+    "data-file": {
+      "content": "data",
+      "file-path": "s3://bucket/data/file.parquet",
+      "file-format": "PARQUET",
+      "spec-id": 0,
+      "partition": [],
+      "file-size-in-bytes": 12345,
+      "record-count": 100,
+      "first-row-id": 100,
+      "data-sequence-number": 7
+    }
+  }])"_json;
+
+  auto result = FileScanTasksFromJson(json, {}, UnpartitionedSpecs(), Schema({}, 0));
+  ASSERT_THAT(result, IsOk());
+  ASSERT_EQ(result.value().size(), 1U);
+  const auto& data_file = result.value()[0]->data_file();
+  ASSERT_NE(data_file, nullptr);
+  EXPECT_EQ(data_file->first_row_id, 100);
+  EXPECT_EQ(data_file->data_sequence_number, 7);
+}
+
 TEST(FileScanTasksFromJsonTest, TaskWithDeleteFileReferences) {
   DataFile delete_file;
   delete_file.content = DataFile::Content::kPositionDeletes;

--- a/src/iceberg/test/table_scan_test.cc
+++ b/src/iceberg/test/table_scan_test.cc
@@ -399,6 +399,50 @@ TEST_P(TableScanTest, PlanFilesWithDataManifests) {
                                                              "/path/to/data2.parquet"));
 }
 
+TEST_P(TableScanTest, PlanRowLineage) {
+  auto version = GetParam();
+  if (version < 3) {
+    GTEST_SKIP() << "row lineage is only assigned in v3 manifests";
+  }
+
+  constexpr int64_t kSnapshotId = 1000L;
+  constexpr int64_t kDataSequenceNumber = 5L;
+  constexpr int64_t kFileSequenceNumber = 7L;
+
+  std::vector<ManifestEntry> data_entries{MakeEntry(
+      ManifestStatus::kAdded, kSnapshotId, kDataSequenceNumber,
+      MakeDataFile("/path/to/data.parquet", PartitionValues(std::vector<Literal>{}),
+                   unpartitioned_spec_->spec_id(), /*record_count=*/3))};
+  data_entries[0].file_sequence_number = kFileSequenceNumber;
+  auto data_manifest = WriteDataManifest(version, kSnapshotId, std::move(data_entries),
+                                         unpartitioned_spec_);
+  std::string manifest_list_path =
+      WriteManifestList(version, kSnapshotId, kFileSequenceNumber, {data_manifest});
+
+  auto timestamp_ms = TimePointMsFromUnixMs(1609459200000L);
+  auto snapshot =
+      std::make_shared<Snapshot>(Snapshot{.snapshot_id = kSnapshotId,
+                                          .parent_snapshot_id = std::nullopt,
+                                          .sequence_number = kFileSequenceNumber,
+                                          .timestamp_ms = timestamp_ms,
+                                          .manifest_list = manifest_list_path,
+                                          .schema_id = schema_->schema_id(),
+                                          .first_row_id = 0L,
+                                          .added_rows = 3L});
+  auto metadata = ScanTestBase::MakeTableMetadata(
+      {snapshot}, kSnapshotId,
+      {{"main", std::make_shared<SnapshotRef>(SnapshotRef{
+                    .snapshot_id = kSnapshotId, .retention = SnapshotRef::Branch{}})}},
+      unpartitioned_spec_);
+
+  ICEBERG_UNWRAP_OR_FAIL(auto builder, DataTableScanBuilder::Make(metadata, file_io_));
+  ICEBERG_UNWRAP_OR_FAIL(auto scan, builder->Build());
+  ICEBERG_UNWRAP_OR_FAIL(auto tasks, scan->PlanFiles());
+  ASSERT_EQ(tasks.size(), 1);
+  EXPECT_EQ(tasks[0]->data_file()->first_row_id, 0L);
+  EXPECT_EQ(tasks[0]->data_file()->data_sequence_number, kDataSequenceNumber);
+}
+
 TEST_P(TableScanTest, PlanFilesWithMultipleManifests) {
   auto version = GetParam();
 


### PR DESCRIPTION
Synthesize _row_id and _last_updated_sequence_number when reading data files that omit row lineage columns, and preserve physical non-null lineage values when present.

Carry inherited data sequence numbers on DataFile metadata so scan planning and readers follow the same model as Java.