### PR TITLE
Prototype logging macro API split

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,9 +31,12 @@ project(
 )
 
 cpp = meson.get_compiler('cpp')
-# Hide two noisy MSVC warnings (C4251/C4275) about standard-library types used in
-# our public classes. They're harmless because the whole library ships as one DLL.
-args = cpp.get_supported_arguments(['/bigobj', '/wd4251', '/wd4275'])
+# MSVC-specific options: /bigobj avoids object section limits, /wd4251 and
+# /wd4275 silence harmless DLL-interface warnings for standard-library members,
+# and /Zc:preprocessor is required by public headers that use __VA_OPT__.
+args = cpp.get_supported_arguments(
+    ['/bigobj', '/wd4251', '/wd4275', '/Zc:preprocessor'],
+)
 add_project_arguments(args, language: 'cpp')
 
 subdir('src')

--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -188,6 +188,14 @@ add_iceberg_lib(iceberg
                 OUTPUTS
                 ICEBERG_LIBRARIES)
 
+if(MSVC)
+  foreach(ICEBERG_LOGGING_TARGET iceberg_shared iceberg_static)
+    if(TARGET ${ICEBERG_LOGGING_TARGET})
+      target_compile_options(${ICEBERG_LOGGING_TARGET} PUBLIC /Zc:preprocessor)
+    endif()
+  endforeach()
+endif()
+
 set(ICEBERG_DATA_SOURCES
     data/data_writer.cc
     data/delete_filter.cc

--- a/src/iceberg/logging/log_macros.h
+++ b/src/iceberg/logging/log_macros.h
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+/// \file iceberg/logging/log_macros.h
+/// \brief Iceberg-prefixed logging macros.
+
+#include <cstdlib>
+#include <format>
+#include <memory>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "iceberg/logging/logger.h"
+
+#define ICEBERG_LOG_LEVEL_TRACE 0
+#define ICEBERG_LOG_LEVEL_DEBUG 1
+#define ICEBERG_LOG_LEVEL_INFO 2
+#define ICEBERG_LOG_LEVEL_WARN 3
+#define ICEBERG_LOG_LEVEL_ERROR 4
+#define ICEBERG_LOG_LEVEL_CRITICAL 5
+#define ICEBERG_LOG_LEVEL_FATAL 6
+#define ICEBERG_LOG_LEVEL_OFF 7
+
+#ifndef ICEBERG_LOG_ACTIVE_LEVEL
+#  define ICEBERG_LOG_ACTIVE_LEVEL ICEBERG_LOG_LEVEL_TRACE
+#endif
+
+static_assert(static_cast<int>(::iceberg::LogLevel::kTrace) == ICEBERG_LOG_LEVEL_TRACE);
+static_assert(static_cast<int>(::iceberg::LogLevel::kDebug) == ICEBERG_LOG_LEVEL_DEBUG);
+static_assert(static_cast<int>(::iceberg::LogLevel::kInfo) == ICEBERG_LOG_LEVEL_INFO);
+static_assert(static_cast<int>(::iceberg::LogLevel::kWarn) == ICEBERG_LOG_LEVEL_WARN);
+static_assert(static_cast<int>(::iceberg::LogLevel::kError) == ICEBERG_LOG_LEVEL_ERROR);
+static_assert(static_cast<int>(::iceberg::LogLevel::kCritical) ==
+              ICEBERG_LOG_LEVEL_CRITICAL);
+static_assert(static_cast<int>(::iceberg::LogLevel::kFatal) == ICEBERG_LOG_LEVEL_FATAL);
+static_assert(static_cast<int>(::iceberg::LogLevel::kOff) == ICEBERG_LOG_LEVEL_OFF);
+
+namespace iceberg::logging::detail {
+
+template <typename... Args>
+std::string VFormat(std::string_view fmt, Args&&... args) {
+  auto store = std::make_format_args(args...);
+  return std::vformat(fmt, store);
+}
+
+template <typename FormatMessage>
+void EmitIfEnabled(Logger& logger, LogLevel level, const std::source_location& location,
+                   FormatMessage&& format_message) noexcept {
+  if (level == LogLevel::kOff || !logger.ShouldLog(level)) return;
+
+  try {
+    ::iceberg::internal::Emit(logger, level, location,
+                              std::forward<FormatMessage>(format_message)());
+  } catch (...) {
+    ::iceberg::internal::EmitFormatError(logger, level, location);
+  }
+}
+
+template <typename FormatMessage>
+void LogCurrentIfEnabled(LogLevel level, const std::source_location& location,
+                         FormatMessage&& format_message) noexcept {
+  const std::shared_ptr<Logger>& logger = ::iceberg::internal::CurrentLogger();
+  if (logger) {
+    EmitIfEnabled(*logger, level, location, std::forward<FormatMessage>(format_message));
+  }
+}
+
+template <typename FormatMessage>
+void LogCurrentRuntime(LogLevel level, const std::source_location& location,
+                       FormatMessage&& format_message) noexcept {
+  const std::shared_ptr<Logger>& logger = ::iceberg::internal::CurrentLogger();
+  if (logger) {
+    EmitIfEnabled(*logger, level, location, std::forward<FormatMessage>(format_message));
+  }
+  if (level == LogLevel::kFatal) {
+    if (logger) logger->Flush();
+    std::abort();
+  }
+}
+
+template <typename FormatMessage>
+void LogToRuntime(Logger& logger, LogLevel level, const std::source_location& location,
+                  FormatMessage&& format_message) noexcept {
+  EmitIfEnabled(logger, level, location, std::forward<FormatMessage>(format_message));
+  if (level == LogLevel::kFatal) {
+    logger.Flush();
+    std::abort();
+  }
+}
+
+template <typename FormatMessage>
+[[noreturn]] void LogCurrentFatal(const std::source_location& location,
+                                  FormatMessage&& format_message) noexcept {
+  auto logger = ::iceberg::GetCurrentLogger();
+  if (logger) {
+    EmitIfEnabled(*logger, LogLevel::kFatal, location,
+                  std::forward<FormatMessage>(format_message));
+    logger->Flush();
+  }
+  std::abort();
+}
+
+}  // namespace iceberg::logging::detail
+
+#define ICEBERG_INTERNAL_LOG_CURRENT(level_, FMT_, ...)                       \
+  do {                                                                        \
+    ::iceberg::logging::detail::LogCurrentIfEnabled(                          \
+        (level_), ::std::source_location::current(), [&]() -> ::std::string { \
+          return ::std::format((FMT_)__VA_OPT__(, ) __VA_ARGS__);             \
+        });                                                                   \
+  } while (false)
+
+#define ICEBERG_INTERNAL_LOG_RUNTIME(level_, FMT_, ...)                       \
+  do {                                                                        \
+    ::iceberg::logging::detail::LogCurrentRuntime(                            \
+        (level_), ::std::source_location::current(), [&]() -> ::std::string { \
+          return ::std::format((FMT_)__VA_OPT__(, ) __VA_ARGS__);             \
+        });                                                                   \
+  } while (false)
+
+#define ICEBERG_INTERNAL_LOG_TO(logger_, level_, FMT_, ...)                              \
+  do {                                                                                   \
+    ::iceberg::logging::detail::LogToRuntime(                                            \
+        (logger_), (level_), ::std::source_location::current(), [&]() -> ::std::string { \
+          return ::std::format((FMT_)__VA_OPT__(, ) __VA_ARGS__);                        \
+        });                                                                              \
+  } while (false)
+
+#define ICEBERG_INTERNAL_LOG_RUNTIME_FMT(level_, FMT_, ...)                             \
+  do {                                                                                  \
+    ::iceberg::logging::detail::LogCurrentRuntime(                                      \
+        (level_), ::std::source_location::current(), [&]() -> ::std::string {           \
+          return ::iceberg::logging::detail::VFormat((FMT_)__VA_OPT__(, ) __VA_ARGS__); \
+        });                                                                             \
+  } while (false)
+
+#define ICEBERG_INTERNAL_LOG_FATAL(FMT_, ...)                       \
+  do {                                                              \
+    ::iceberg::logging::detail::LogCurrentFatal(                    \
+        ::std::source_location::current(), [&]() -> ::std::string { \
+          return ::std::format((FMT_)__VA_OPT__(, ) __VA_ARGS__);   \
+        });                                                         \
+  } while (false)
+
+#if ICEBERG_LOG_ACTIVE_LEVEL <= ICEBERG_LOG_LEVEL_TRACE
+#  define ICEBERG_LOG_TRACE(...) \
+    ICEBERG_INTERNAL_LOG_CURRENT(::iceberg::LogLevel::kTrace, __VA_ARGS__)
+#else
+#  define ICEBERG_LOG_TRACE(...) ((void)0)
+#endif
+
+#if ICEBERG_LOG_ACTIVE_LEVEL <= ICEBERG_LOG_LEVEL_DEBUG
+#  define ICEBERG_LOG_DEBUG(...) \
+    ICEBERG_INTERNAL_LOG_CURRENT(::iceberg::LogLevel::kDebug, __VA_ARGS__)
+#else
+#  define ICEBERG_LOG_DEBUG(...) ((void)0)
+#endif
+
+#if ICEBERG_LOG_ACTIVE_LEVEL <= ICEBERG_LOG_LEVEL_INFO
+#  define ICEBERG_LOG_INFO(...) \
+    ICEBERG_INTERNAL_LOG_CURRENT(::iceberg::LogLevel::kInfo, __VA_ARGS__)
+#else
+#  define ICEBERG_LOG_INFO(...) ((void)0)
+#endif
+
+#if ICEBERG_LOG_ACTIVE_LEVEL <= ICEBERG_LOG_LEVEL_WARN
+#  define ICEBERG_LOG_WARN(...) \
+    ICEBERG_INTERNAL_LOG_CURRENT(::iceberg::LogLevel::kWarn, __VA_ARGS__)
+#else
+#  define ICEBERG_LOG_WARN(...) ((void)0)
+#endif
+
+#if ICEBERG_LOG_ACTIVE_LEVEL <= ICEBERG_LOG_LEVEL_ERROR
+#  define ICEBERG_LOG_ERROR(...) \
+    ICEBERG_INTERNAL_LOG_CURRENT(::iceberg::LogLevel::kError, __VA_ARGS__)
+#else
+#  define ICEBERG_LOG_ERROR(...) ((void)0)
+#endif
+
+#if ICEBERG_LOG_ACTIVE_LEVEL <= ICEBERG_LOG_LEVEL_CRITICAL
+#  define ICEBERG_LOG_CRITICAL(...) \
+    ICEBERG_INTERNAL_LOG_CURRENT(::iceberg::LogLevel::kCritical, __VA_ARGS__)
+#else
+#  define ICEBERG_LOG_CRITICAL(...) ((void)0)
+#endif
+
+#define ICEBERG_LOG_FATAL(...) ICEBERG_INTERNAL_LOG_FATAL(__VA_ARGS__)
+
+#define ICEBERG_LOG(...) ICEBERG_INTERNAL_LOG_RUNTIME(__VA_ARGS__)
+
+#define ICEBERG_LOG_TO(...) ICEBERG_INTERNAL_LOG_TO(__VA_ARGS__)
+
+#define ICEBERG_LOG_RUNTIME_FMT(...) ICEBERG_INTERNAL_LOG_RUNTIME_FMT(__VA_ARGS__)

--- a/src/iceberg/logging/logger.h
+++ b/src/iceberg/logging/logger.h
@@ -56,7 +56,7 @@ struct ICEBERG_EXPORT LogAttribute {
 
 /// \brief A single log record handed to a Logger.
 ///
-/// The formatted message is owned (moved in by the logging macros), so a sink
+/// The formatted message is owned, so a sink
 /// may safely retain the record beyond the Log() call. The member set must not
 /// depend on the build's logging backend (the spdlog backend never appears here).
 /// Use LogMessage::Builder for a readable way to assemble one, especially with
@@ -134,11 +134,11 @@ inline constexpr std::string_view kPatternProperty = "pattern";
 
 /// \brief Pluggable logging sink.
 ///
-/// ShouldLog() is the single authority for runtime filtering -- the macros call
-/// it on every (compile-time-enabled) statement, so level changes by any path
-/// take effect immediately. Implementations must be thread-safe and must not
-/// throw. They must also obey:
-///   - No reentrancy: Log()/Flush() must not call the logging macros or
+/// ShouldLog() is the single authority for runtime filtering -- public logging
+/// helpers call it on every enabled statement, so level changes by any path take
+/// effect immediately. Implementations must be thread-safe and must not throw.
+/// They must also obey:
+///   - No reentrancy: Log()/Flush() must not call public logging helpers or
 ///     GetDefaultLogger() (UB -- deadlock with mutex-based sinks).
 ///   - level() is an accessor consistent with ShouldLog (used by SetDefaultLevel
 ///     and introspection); ShouldLog may implement finer logic than a level compare.
@@ -187,7 +187,7 @@ class ICEBERG_EXPORT Logger {
 /// \brief Return the process-global default logger (never null).
 ///
 /// Off the hot path -- acquires the slot lock and returns an owning copy. The
-/// logging macros use the cheaper internal hot-path accessor instead.
+/// public logging helpers use the cheaper internal hot-path accessor instead.
 ICEBERG_EXPORT std::shared_ptr<Logger> GetDefaultLogger();
 
 /// \brief Return the effective logger for this thread (never null): the active
@@ -214,7 +214,7 @@ ICEBERG_EXPORT void SetDefaultLevel(LogLevel level);
 /// \brief Bind a logger for the current thread until this object leaves scope.
 ///
 /// The default logging path on this thread -- CurrentLogger(), Log(level, ...),
-/// and the LOG_* macros -- routes to \p logger instead of the global default;
+/// and the ICEBERG_LOG_* macros -- routes to \p logger instead of the global default;
 /// explicit Log(logger, ...) is unaffected. Bindings nest and restore on exit, and
 /// nullptr masks any enclosing binding back to the global default. Lets an engine
 /// route Iceberg's own logs into a per catalog/session/query/task context with no
@@ -247,8 +247,8 @@ class ICEBERG_EXPORT ScopedLogger {
 };
 
 // ---------------------------------------------------------------------------
-// Using the API directly (the LOG_* macros that wrap this are added later in
-// the stack). Example: a custom sink, installed as the process default.
+// Using the API directly. Example: a custom sink, installed as the process
+// default.
 //
 //   class MySink : public Logger {
 //    public:
@@ -285,30 +285,18 @@ ICEBERG_EXPORT const std::shared_ptr<Logger>& CurrentLogger() noexcept;
 
 /// \brief Build a LogMessage from the already-formatted text and dispatch it.
 ///
-/// Declared ICEBERG_EXPORT because the logging macros expand into this call in
-/// consumer translation units.
+/// Declared ICEBERG_EXPORT because public inline logging helpers can expand into
+/// this call in consumer translation units.
 ICEBERG_EXPORT void Emit(Logger& logger, LogLevel level,
                          const std::source_location& location, std::string&& message);
 
 /// \brief Emit a fixed fallback record when formatting threw.
 ///
 /// noexcept, allocation-light (small/SSO literal), performs no std::format, and
-/// does not recurse -- so the macro's "logging never throws" guarantee holds
-/// even when a format argument throws.
+/// does not recurse -- so the public logging API's "logging never throws"
+/// guarantee holds even when a format argument throws.
 ICEBERG_EXPORT void EmitFormatError(Logger& logger, LogLevel level,
                                     const std::source_location& location) noexcept;
-
-/// \brief Runtime (non-literal) format-string helper.
-///
-/// std::format requires a compile-time format string; this routes a runtime
-/// string through std::vformat. Args are bound as named lvalues and the
-/// arg-store is held in a named variable so it outlives the vformat call
-/// (C++23 make_format_args rejects rvalues -- P2905 / LWG3631).
-template <typename... Args>
-std::string VFormat(std::string_view fmt, Args&&... args) {
-  auto store = std::make_format_args(args...);
-  return std::vformat(fmt, store);
-}
 
 /// \brief A checked format string bundled with the caller's source_location.
 ///
@@ -332,7 +320,7 @@ struct FmtWithLoc {
 /// \brief Shared gate -> format -> emit body for the function-style Log() API.
 ///
 /// Formats only when the logger is enabled for \p level, and never throws (a
-/// formatting failure routes to EmitFormatError, matching the macros).
+/// formatting failure routes to EmitFormatError, matching the macro helpers).
 template <typename... Args>
 void FormatAndEmit(Logger& logger, LogLevel level, const std::source_location& loc,
                    std::format_string<Args...> fmt, Args&&... args) noexcept {

--- a/src/iceberg/logging/meson.build
+++ b/src/iceberg/logging/meson.build
@@ -16,6 +16,12 @@
 # under the License.
 
 install_headers(
-    ['cerr_logger.h', 'log_level.h', 'logger.h'],
+    [
+        'cerr_logger.h',
+        'log_level.h',
+        'log_macros.h',
+        'logger.h',
+        'short_log_macros.h',
+    ],
     subdir: 'iceberg/logging',
 )

--- a/src/iceberg/logging/short_log_macros.h
+++ b/src/iceberg/logging/short_log_macros.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+/// \file iceberg/logging/short_log_macros.h
+/// \brief Opt-in short aliases for Iceberg logging macros.
+
+#include "iceberg/logging/log_macros.h"
+
+#define LOG_TRACE(...) ICEBERG_LOG_TRACE(__VA_ARGS__)
+#define LOG_DEBUG(...) ICEBERG_LOG_DEBUG(__VA_ARGS__)
+#define LOG_INFO(...) ICEBERG_LOG_INFO(__VA_ARGS__)
+#define LOG_WARN(...) ICEBERG_LOG_WARN(__VA_ARGS__)
+#define LOG_ERROR(...) ICEBERG_LOG_ERROR(__VA_ARGS__)
+#define LOG_CRITICAL(...) ICEBERG_LOG_CRITICAL(__VA_ARGS__)
+#define LOG_FATAL(...) ICEBERG_LOG_FATAL(__VA_ARGS__)

--- a/src/iceberg/test/CMakeLists.txt
+++ b/src/iceberg/test/CMakeLists.txt
@@ -103,6 +103,9 @@ add_iceberg_test(logging_test
                  SOURCES
                  cerr_logger_test.cc
                  log_level_test.cc
+                 log_macros_active_level_test.cc
+                 log_macros_header_test.cc
+                 log_macros_test.cc
                  logger_test.cc)
 
 add_iceberg_test(expression_test

--- a/src/iceberg/test/log_macros_active_level_test.cc
+++ b/src/iceberg/test/log_macros_active_level_test.cc
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define ICEBERG_LOG_ACTIVE_LEVEL ICEBERG_LOG_LEVEL_ERROR
+
+#include <gtest/gtest.h>
+
+#include "iceberg/logging/log_macros.h"
+
+namespace iceberg {
+namespace {
+
+struct NotFormattable {};
+
+}  // namespace
+
+TEST(LogMacrosActiveLevelTest, DisabledFixedLevelLogsDoNotEvaluateArguments) {
+  int evaluations = 0;
+
+  ICEBERG_LOG_DEBUG("debug side effect {}", ++evaluations);
+  ICEBERG_LOG_INFO("info side effect {}", ++evaluations);
+  ICEBERG_LOG_WARN("warn side effect {}", ++evaluations);
+
+  EXPECT_EQ(evaluations, 0);
+}
+
+TEST(LogMacrosActiveLevelTest, DisabledFixedLevelLogsNeedNotBeFormattable) {
+  ICEBERG_LOG_INFO("not formattable {}", NotFormattable{});
+  SUCCEED();
+}
+
+}  // namespace iceberg

--- a/src/iceberg/test/log_macros_header_test.cc
+++ b/src/iceberg/test/log_macros_header_test.cc
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/logging/logger.h"
+
+#ifdef ICEBERG_LOG_INFO
+#  error "logger.h must not define logging macros; include log_macros.h instead"
+#endif
+
+#ifdef LOG_INFO
+#  error "logger.h must not define short logging macros"
+#endif
+
+#include "iceberg/logging/log_macros.h"
+
+#ifndef ICEBERG_LOG_INFO
+#  error "log_macros.h must define Iceberg-prefixed logging macros"
+#endif
+
+#ifdef LOG_INFO
+#  error "log_macros.h must not define short logging macros by default"
+#endif
+
+#include "iceberg/logging/short_log_macros.h"
+
+#ifndef LOG_INFO
+#  error "short_log_macros.h must define opt-in short logging macros"
+#endif
+
+#include <gtest/gtest.h>
+
+namespace iceberg {
+
+TEST(LogMacrosHeaderTest, MacroHeadersExposeOnlyTheRequestedNames) { SUCCEED(); }
+
+}  // namespace iceberg

--- a/src/iceberg/test/log_macros_test.cc
+++ b/src/iceberg/test/log_macros_test.cc
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/logging/log_macros.h"
+
+#include <format>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "iceberg/test/logging_test_helpers.h"
+
+template <>
+struct std::formatter<iceberg::LogAttribute, char> {
+  constexpr auto parse(std::format_parse_context& context) { return context.begin(); }
+
+  auto format(const iceberg::LogAttribute&, std::format_context& context) const
+      -> std::format_context::iterator {
+    throw 7;
+    return context.out();
+  }
+};
+
+namespace iceberg {
+namespace {
+
+class DeathLogger : public Logger {
+ public:
+  explicit DeathLogger(std::string name) : name_(std::move(name)) {}
+
+  bool ShouldLog(LogLevel level) const noexcept override { return level >= level_; }
+
+  void Log(LogMessage&& message) noexcept override {
+    std::cerr << "log:" << name_ << ":" << message.message << "\n";
+  }
+
+  void SetLevel(LogLevel level) noexcept override { level_ = level; }
+
+  LogLevel level() const noexcept override { return level_; }
+
+  void Flush() noexcept override { std::cerr << "flush:" << name_ << "\n"; }
+
+ private:
+  std::string name_;
+  LogLevel level_ = LogLevel::kTrace;
+};
+
+LogLevel NextLevelEvaluationCount(LogLevel* level, int* evaluations) {
+  ++(*evaluations);
+  return *level;
+}
+
+}  // namespace
+
+TEST(LogMacrosTest, FixedLevelMacroLogsThroughCurrentLogger) {
+  auto logger = std::make_shared<CapturingLogger>();
+  ScopedDefaultLogger guard(logger);
+
+  const auto here = std::source_location::current();
+  ICEBERG_LOG_INFO("loaded {}", 3);
+
+  auto records = logger->records();
+  ASSERT_EQ(records.size(), 1);
+  EXPECT_EQ(records[0].level, LogLevel::kInfo);
+  EXPECT_EQ(records[0].message, "loaded 3");
+  EXPECT_STREQ(records[0].location.file_name(), here.file_name());
+  EXPECT_EQ(records[0].location.line(), here.line() + 1);
+}
+
+TEST(LogMacrosTest, DisabledRuntimeLevelDoesNotEvaluateFormatArguments) {
+  auto logger = std::make_shared<CapturingLogger>();
+  logger->SetLevel(LogLevel::kError);
+  ScopedDefaultLogger guard(logger);
+  int evaluations = 0;
+
+  ICEBERG_LOG(LogLevel::kInfo, "side effect {}", ++evaluations);
+
+  EXPECT_EQ(evaluations, 0);
+  EXPECT_EQ(logger->count(), 0);
+}
+
+TEST(LogMacrosTest, RuntimeLevelIsEvaluatedOnce) {
+  auto logger = std::make_shared<CapturingLogger>();
+  ScopedDefaultLogger guard(logger);
+  LogLevel level = LogLevel::kWarn;
+  int evaluations = 0;
+
+  ICEBERG_LOG(NextLevelEvaluationCount(&level, &evaluations), "warn {}", 1);
+
+  EXPECT_EQ(evaluations, 1);
+  ASSERT_EQ(logger->count(), 1);
+  EXPECT_EQ(logger->records()[0].level, LogLevel::kWarn);
+}
+
+TEST(LogMacrosTest, ExplicitLoggerIsEvaluatedOnce) {
+  CapturingLogger logger;
+  CapturingLogger* logger_ptr = &logger;
+  int evaluations = 0;
+
+  ICEBERG_LOG_TO(*([&] {
+    ++evaluations;
+    return logger_ptr;
+  }()),
+                 LogLevel::kError, "error {}", 5);
+
+  EXPECT_EQ(evaluations, 1);
+  ASSERT_EQ(logger.count(), 1);
+  EXPECT_EQ(logger.records()[0].message, "error 5");
+}
+
+TEST(LogMacrosTest, RuntimeFormatUsesVFormat) {
+  auto logger = std::make_shared<CapturingLogger>();
+  ScopedDefaultLogger guard(logger);
+  std::string fmt = "value {}";
+
+  ICEBERG_LOG_RUNTIME_FMT(LogLevel::kInfo, fmt, 42);
+
+  ASSERT_EQ(logger->count(), 1);
+  EXPECT_EQ(logger->records()[0].message, "value 42");
+}
+
+TEST(LogMacrosTest, OffRuntimeLevelDoesNotEvaluateFormatArgumentsOrEmit) {
+  auto logger = std::make_shared<CapturingLogger>();
+  ScopedDefaultLogger guard(logger);
+  int evaluations = 0;
+
+  ICEBERG_LOG(LogLevel::kOff, "side effect {}", ++evaluations);
+
+  EXPECT_EQ(evaluations, 0);
+  EXPECT_EQ(logger->count(), 0);
+}
+
+TEST(LogMacrosTest, FormatterFailuresDoNotEscape) {
+  auto logger = std::make_shared<CapturingLogger>();
+  ScopedDefaultLogger guard(logger);
+
+  ICEBERG_LOG_INFO("bad {}", LogAttribute{.key = "k", .value = "v"});
+
+  ASSERT_EQ(logger->count(), 1);
+  EXPECT_EQ(logger->records()[0].message, "<fmt error>");
+}
+
+TEST(LogMacrosTest, ScopedLoggerOverridesDefaultLogger) {
+  auto global = std::make_shared<CapturingLogger>();
+  auto scoped = std::make_shared<CapturingLogger>();
+  ScopedDefaultLogger guard(global);
+
+  {
+    ScopedLogger bind(scoped);
+    ICEBERG_LOG_INFO("scoped");
+  }
+
+  EXPECT_EQ(global->count(), 0);
+  ASSERT_EQ(scoped->count(), 1);
+  EXPECT_EQ(scoped->records()[0].message, "scoped");
+}
+
+TEST(LogMacrosTest, FatalUsesScopedLoggerFlushesThenAborts) {
+  auto global = std::make_shared<DeathLogger>("global");
+  auto scoped = std::make_shared<DeathLogger>("scoped");
+  ScopedDefaultLogger guard(global);
+
+  EXPECT_DEATH(
+      {
+        ScopedLogger bind(scoped);
+        ICEBERG_LOG_FATAL("fatal {}", 9);
+      },
+      "log:scoped:fatal 9(.|\n)*flush:scoped");
+}
+
+}  // namespace iceberg

--- a/src/iceberg/test/meson.build
+++ b/src/iceberg/test/meson.build
@@ -65,6 +65,9 @@ iceberg_tests = {
         'sources': files(
             'cerr_logger_test.cc',
             'log_level_test.cc',
+            'log_macros_active_level_test.cc',
+            'log_macros_header_test.cc',
+            'log_macros_test.cc',
             'logger_test.cc',
         ),
     },


### PR DESCRIPTION
## Summary

This is a prototype for the logging macro API shape discussed in #725.

It demonstrates a possible end state:
- keep `logger.h` focused on the C++ logging API;
- move Iceberg-prefixed macros to `log_macros.h`;
- put short `LOG_*` aliases behind an explicit opt-in header;
- use preprocessor active-level gating so disabled fixed-level logs are fully compiled out;
- centralize formatting, fallback, runtime filtering, and fatal handling in shared helpers.

This is meant as a design reference, not a replacement for #725.

## Test Plan

- `.venv/bin/pre-commit run clang-format --files src/iceberg/logging/log_macros.h src/iceberg/logging/short_log_macros.h src/iceberg/logging/logger.h src/iceberg/test/log_macros_header_test.cc src/iceberg/test/log_macros_active_level_test.cc src/iceberg/test/log_macros_test.cc`
- `.venv/bin/pre-commit run cmake-format --files src/iceberg/CMakeLists.txt src/iceberg/test/CMakeLists.txt`
- `.venv/bin/pre-commit run meson-fmt --files meson.build src/iceberg/logging/meson.build src/iceberg/test/meson.build`
- `ninja -C builddir src/iceberg/test/logging_test`
- `./builddir/src/iceberg/test/logging_test`
- `cmake --build build --target logging_test`
- `./build/src/iceberg/test/logging_test`
