### PR TITLE
Infra: Group github/codeql-action bumps into a single dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,10 @@ updates:
       day: "sunday"
     cooldown:
       default-days: 7
+    groups:
+      # The codeql-action init/autobuild/analyze steps must all run the
+      # same version - split PRs cause a version mismatch that fails the
+      # Analyze jobs. Group them so a single PR bumps all of them together.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
Thus, dependabot can update these two jobs in a single PR:

https://github.com/apache/iceberg-cpp/blob/f4f6359fa9a95bde4bb2627bd8a5d45273644294/.github/workflows/codeql.yml#L56-L62

- https://github.com/apache/infrastructure-actions/pull/1028