### PR TITLE
chore: update ASF GitHub collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -45,12 +45,8 @@ github:
     issues: true
     projects: true
   collaborators:
-    - gaborkaszab
-    - lidavidm
-    - pitrou
-    - raulcd
-    - wgtmac
     - zhjwpku
+    - manuzhang
   ghp_branch: gh-pages
   ghp_path: /
 


### PR DESCRIPTION
### Rationale for this change

The ASF GitHub collaborators list needs to reflect the current project collaborators.

### What changes are included in this PR?

- Remove inactive GitHub collaborators from `.asf.yaml`
- Add `manuzhang` as a GitHub collaborator

### Are these changes tested?

Yes. `.asf.yaml` was parsed successfully as YAML, and `git diff --check` passed.

### Are there any user-facing changes?

No.