### PR TITLE
fix: use kLegacyPartitionDataIdStart as partition field ID baseline

### DIFF
--- a/src/iceberg/table_metadata.cc
+++ b/src/iceberg/table_metadata.cc
@@ -71,7 +71,7 @@ Result<std::unique_ptr<PartitionSpec>> FreshPartitionSpec(int32_t spec_id,
                                                           const Schema& fresh_schema) {
   std::vector<PartitionField> partition_fields;
   partition_fields.reserve(spec.fields().size());
-  int32_t last_partition_field_id = PartitionSpec::kInvalidPartitionFieldId;
+  int32_t last_partition_field_id = PartitionSpec::kLegacyPartitionDataIdStart - 1;
   for (auto& field : spec.fields()) {
     ICEBERG_ASSIGN_OR_RAISE(auto source_name,
                             base_schema.FindColumnNameById(field.source_id()));
@@ -556,7 +556,7 @@ class TableMetadataBuilder::Impl {
     metadata_.last_updated_ms = kInvalidLastUpdatedMs;
     metadata_.last_column_id = Schema::kInvalidColumnId;
     metadata_.default_spec_id = PartitionSpec::kInitialSpecId;
-    metadata_.last_partition_id = PartitionSpec::kInvalidPartitionFieldId;
+    metadata_.last_partition_id = PartitionSpec::kLegacyPartitionDataIdStart - 1;
     metadata_.current_snapshot_id = kInvalidSnapshotId;
     metadata_.default_sort_order_id = SortOrder::kInitialSortOrderId;
     metadata_.next_row_id = TableMetadata::kInitialRowId;

--- a/src/iceberg/test/table_metadata_builder_test.cc
+++ b/src/iceberg/test/table_metadata_builder_test.cc
@@ -125,7 +125,7 @@ TEST(TableMetadataTest, Make) {
   auto spec_fields =
       metadata->partition_specs[0]->fields() | std::ranges::to<std::vector>();
   ASSERT_EQ(1, spec_fields.size());
-  EXPECT_EQ(PartitionSpec::kInvalidPartitionFieldId + 1, spec_fields[0].field_id());
+  EXPECT_EQ(PartitionSpec::kLegacyPartitionDataIdStart, spec_fields[0].field_id());
   EXPECT_EQ(2, spec_fields[0].source_id());
   EXPECT_EQ("part_name", spec_fields[0].name());
 


### PR DESCRIPTION
FreshPartitionSpec and TableMetadataBuilder::Impl both initialized the
partition field ID counter to `kInvalidPartitionFieldId` (-1), causing
the first partition field to get ID **0** instead of **1000**. Partition field
ID 0 collides with ManifestEntry internal fields:

| Field | ID |
|---|---|
| `ManifestEntry.status` | 0 |
| `ManifestEntry.snapshot_id` | 1 |
| `ManifestEntry.data_file` | 2 |

This corrupts manifest file schemas during serialization and breaks
partition pruning.

## Fix

Change both initializers to `kLegacyPartitionDataIdStart - 1` (999),
consistent with Java Iceberg's `PARTITION_DATA_ID_START` convention and
the rest of the C++ codebase (`PartitionSpec` constructor,
`Unpartitioned()`, `UpdatePartitionSpec`). The first partition field
now correctly gets ID **1000**.

| Location | Before | After |
|---|---|---|
| `FreshPartitionSpec` counter | -1 | 999 |
| `TableMetadataBuilder::Impl::last_partition_id` | -1 | 999 |
| First partition field ID | 0 | **1000** |