### PR TITLE
ci: enable ASF Copilot code review

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -53,6 +53,10 @@ github:
     - zhjwpku
   ghp_branch: gh-pages
   ghp_path: /
+  copilot_code_review:
+    enabled: true
+    review_drafts: false
+    review_on_push: true
 
 notifications:
   commits:      commits@iceberg.apache.org

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,21 @@
+# Instructions
+
+## Code review
+
+You are a pragmatic senior developer. When reviewing pull requests,
+follow these rules to avoid noise and redundancy:
+
+- Be concise: Keep comments brief and to the point. Avoid
+  conversational filler or praising the code unless it's exceptional.
+- High-impact only: Focus on logic errors, security vulnerabilities,
+  performance bottlenecks, and breaking changes.
+- Skip the Obvious: Do not describe what the code is doing. Assume the
+  reader understands the code.
+- Ignore trivialities: Do not comment on minor style issues or things
+  that an automated linter should catch.
+- Single comment per issue: If the same pattern occurs multiple times,
+  mention it once and suggest a global fix instead of commenting on
+  every line.
+- First-time contributors: For users new to this repository,
+  explicitly instruct them to "Please check and address all review
+  comments in this PR."

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -16,8 +16,8 @@
 # under the License.
 
 .gitignore
-LICENSE
 .github/copilot-instructions.md
+LICENSE
 NOTICE
 build/**
 dist/**

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -17,6 +17,7 @@
 
 .gitignore
 LICENSE
+.github/copilot-instructions.md
 NOTICE
 build/**
 dist/**

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-.gitignore
 .github/copilot-instructions.md
+.gitignore
 LICENSE
 NOTICE
 build/**


### PR DESCRIPTION
### Rationale for this change

GitHub Copilot code review may help provide preliminary feedback on pull requests and reduce reviewer load while keeping human maintainers responsible for final review decisions.

### What changes are included in this PR?

- Enable ASF-managed GitHub Copilot code review in `.asf.yaml`
- Disable automatic reviews for draft PRs
- Enable automatic reviews on new pushes
- Add Copilot review instructions to reduce noisy comments

### Are these changes tested?

Yes. `.asf.yaml` was parsed successfully as YAML, and `git diff --check` passed.

### Are there any user-facing changes?

No.