### PR TITLE
build: move GTest and Google Benchmark setup into IcebergThirdpartyToolchain

### DIFF
--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -801,6 +801,57 @@ function(resolve_zstd_dependency)
   endif()
 endfunction()
 
+# ----------------------------------------------------------------------
+# GoogleTest (tests only)
+#
+# GTest is only consumed by the unit tests; it is neither installed nor exported
+# as a system dependency, so it does not touch ICEBERG_SYSTEM_DEPENDENCIES.
+
+function(resolve_gtest_dependency)
+  prepare_fetchcontent()
+
+  set(INSTALL_GTEST
+      OFF
+      CACHE BOOL "" FORCE)
+
+  fetchcontent_declare(googletest
+                       GIT_REPOSITORY https://github.com/google/googletest.git
+                       GIT_TAG b514bdc898e2951020cbdca1304b75f5950d1f59 # release-1.15.2
+                       FIND_PACKAGE_ARGS
+                       NAMES
+                       GTest)
+  fetchcontent_makeavailable(googletest)
+endfunction()
+
+# ----------------------------------------------------------------------
+# Google Benchmark (benchmarks only)
+#
+# Like GTest, benchmark is only consumed by the benchmark targets and is neither
+# installed nor exported as a system dependency.
+
+function(resolve_benchmark_dependency)
+  prepare_fetchcontent()
+
+  set(BENCHMARK_ENABLE_GTEST_TESTS
+      OFF
+      CACHE BOOL "" FORCE)
+  set(BENCHMARK_ENABLE_INSTALL
+      OFF
+      CACHE BOOL "" FORCE)
+  set(BENCHMARK_ENABLE_TESTING
+      OFF
+      CACHE BOOL "" FORCE)
+
+  fetchcontent_declare(google_benchmark
+                       GIT_REPOSITORY https://github.com/google/benchmark.git
+                       GIT_TAG a4cf155615c63e019ae549e31703bf367df5b471 # v1.8.4
+                       FIND_PACKAGE_ARGS
+                       NAMES
+                       benchmark
+                       CONFIG)
+  fetchcontent_makeavailable(google_benchmark)
+endfunction()
+
 resolve_zlib_dependency()
 resolve_nanoarrow_dependency()
 resolve_croaring_dependency()
@@ -863,4 +914,18 @@ endfunction()
 
 if(ICEBERG_BUILD_HIVE)
   resolve_thrift_dependency()
+endif()
+
+# ----------------------------------------------------------------------
+# Test and benchmark dependencies
+#
+# These are build-only tools, pulled in after the library dependencies and only
+# when the corresponding build option is enabled.
+
+if(ICEBERG_BUILD_TESTS)
+  resolve_gtest_dependency()
+endif()
+
+if(ICEBERG_BUILD_BENCHMARKS)
+  resolve_benchmark_dependency()
 endif()

--- a/src/iceberg/benchmark/CMakeLists.txt
+++ b/src/iceberg/benchmark/CMakeLists.txt
@@ -15,24 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set(BENCHMARK_ENABLE_GTEST_TESTS
-    OFF
-    CACHE BOOL "" FORCE)
-set(BENCHMARK_ENABLE_INSTALL
-    OFF
-    CACHE BOOL "" FORCE)
-set(BENCHMARK_ENABLE_TESTING
-    OFF
-    CACHE BOOL "" FORCE)
-
-fetchcontent_declare(google_benchmark
-                     GIT_REPOSITORY https://github.com/google/benchmark.git
-                     GIT_TAG a4cf155615c63e019ae549e31703bf367df5b471 # v1.8.4
-                     FIND_PACKAGE_ARGS
-                     NAMES
-                     benchmark
-                     CONFIG)
-fetchcontent_makeavailable(google_benchmark)
+# Google Benchmark is resolved in cmake_modules/IcebergThirdpartyToolchain.cmake.
 
 add_executable(benchmark_smoke benchmark_smoke.cc)
 target_link_libraries(benchmark_smoke

--- a/src/iceberg/test/CMakeLists.txt
+++ b/src/iceberg/test/CMakeLists.txt
@@ -15,18 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set(INSTALL_GTEST
-    OFF
-    CACHE BOOL "" FORCE)
-
-fetchcontent_declare(googletest
-                     GIT_REPOSITORY https://github.com/google/googletest.git
-                     GIT_TAG b514bdc898e2951020cbdca1304b75f5950d1f59 # release-1.15.2
-                     FIND_PACKAGE_ARGS
-                     NAMES
-                     GTest)
-
-fetchcontent_makeavailable(googletest)
+# GoogleTest is resolved in cmake_modules/IcebergThirdpartyToolchain.cmake.
 
 set(ICEBERG_TEST_RESOURCES "${CMAKE_SOURCE_DIR}/src/iceberg/test/resources")
 


### PR DESCRIPTION
## What

Fixes #829. The GoogleTest and Google Benchmark FetchContent setup lived in `src/iceberg/test/CMakeLists.txt` and `src/iceberg/benchmark/CMakeLists.txt`, apart from the other third-party dependencies. This follows the review discussion on #825, which suggested keeping dependency resolution in one place.

## How

- Add `resolve_gtest_dependency()` and `resolve_benchmark_dependency()` to `cmake_modules/IcebergThirdpartyToolchain.cmake`, next to the existing `resolve_*` functions.
- Gate them on `ICEBERG_BUILD_TESTS` and `ICEBERG_BUILD_BENCHMARKS`, the same conditions that already guard the test and benchmark subdirectories.
- Both functions call `prepare_fetchcontent()` like the other resolvers, so a command-line `-DCMAKE_COMPILE_WARNING_AS_ERROR=ON` does not build the vendored GTest/Benchmark sources with `-Werror`.
- Version pins are unchanged. Only CMake is affected; Meson resolves these through `subprojects/*.wrap`, so it needs no change.

## Verified

- `-DICEBERG_BUILD_BENCHMARKS=ON`: both dependencies fetch; `benchmark_smoke` and `schema_test` build; `ctest -R schema_test` passes.
- Tests and benchmarks both off: neither dependency is fetched.
- `-DCMAKE_COMPILE_WARNING_AS_ERROR=ON` with benchmarks on: configure and build succeed.
- `pre-commit run -a` clean.

---
This contribution was authored with assistance from Claude Opus 4.8, in line with the Iceberg guidelines for AI-assisted contributions (https://iceberg.apache.org/contribute/#guidelines-for-ai-assisted-contributions). All changes were reviewed and tested by the author.
