### PR TITLE
ci: scope pull request checks to relevant paths

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -29,6 +29,9 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.github/**/*.yml'
+      - '.github/**/*.yaml'
 
 permissions:
   contents: read

--- a/.github/workflows/aws_test.yml
+++ b/.github/workflows/aws_test.yml
@@ -25,6 +25,12 @@ on:
       - '**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '.devcontainer/**'
+      - '*.md'
+      - '**/*.md'
+      - 'dev/**'
+      - 'mkdocs/**'
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/aws_test.yml
+++ b/.github/workflows/aws_test.yml
@@ -27,7 +27,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '.devcontainer/**'
-      - '*.md'
       - '**/*.md'
       - 'dev/**'
       - 'mkdocs/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
+    paths:
+      - '.github/**/*.yml'
+      - '.github/**/*.yaml'
   schedule:
     - cron: '16 4 * * 1'
 

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -28,7 +28,6 @@ on:
     paths-ignore:
       - '.devcontainer/**'
       - '.github/**'
-      - '*.md'
       - '**/*.md'
       - 'ci/**'
       - 'cmake_modules/**'

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -21,18 +21,19 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '.github/**'
-      - 'ci/**'
-      - 'cmake_modules/**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths-ignore:
+      - '.devcontainer/**'
       - '.github/**'
+      - '*.md'
+      - '**/*.md'
       - 'ci/**'
       - 'cmake_modules/**'
+      - 'dev/**'
+      - 'mkdocs/**'
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/sanitizer_test.yml
+++ b/.github/workflows/sanitizer_test.yml
@@ -25,6 +25,12 @@ on:
       - '**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '.devcontainer/**'
+      - '*.md'
+      - '**/*.md'
+      - 'dev/**'
+      - 'mkdocs/**'
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/sanitizer_test.yml
+++ b/.github/workflows/sanitizer_test.yml
@@ -27,7 +27,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '.devcontainer/**'
-      - '*.md'
       - '**/*.md'
       - 'dev/**'
       - 'mkdocs/**'

--- a/.github/workflows/sql_catalog_test.yml
+++ b/.github/workflows/sql_catalog_test.yml
@@ -25,6 +25,12 @@ on:
       - '**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '.devcontainer/**'
+      - '*.md'
+      - '**/*.md'
+      - 'dev/**'
+      - 'mkdocs/**'
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/sql_catalog_test.yml
+++ b/.github/workflows/sql_catalog_test.yml
@@ -27,7 +27,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '.devcontainer/**'
-      - '*.md'
       - '**/*.md'
       - 'dev/**'
       - 'mkdocs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,12 @@ on:
       - '**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '.devcontainer/**'
+      - '*.md'
+      - '**/*.md'
+      - 'dev/**'
+      - 'mkdocs/**'
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '.devcontainer/**'
-      - '*.md'
       - '**/*.md'
       - 'dev/**'
       - 'mkdocs/**'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,6 +25,9 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.github/**/*.yml'
+      - '.github/**/*.yaml'
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}


### PR DESCRIPTION
## What

- For pull requests, run ASF allowlist, Actions CodeQL, and zizmor only for YAML changes under `.github`.
- For pull requests, skip AWS, sanitizer, SQL catalog, general test, and C++ lint workflows for Markdown, documentation, devcontainer, and release-development-only changes.
- Keep license and pre-commit checks unfiltered.

## Why

These workflows currently run on pull requests even when every changed path is unrelated to what they validate. Directory and extension globs keep the filters applicable to future files without maintaining filename lists, and keeping filters off push triggers avoids duplicate maintenance.

## Impact

Documentation and development-only pull requests avoid unrelated CI work. Mixed changes still run the relevant workflows, GitHub YAML changes still run the Actions validators, and main, tag, and scheduled runs remain unfiltered.
