### PR TITLE
fix: compare transform function parameters

### DIFF
--- a/src/iceberg/test/transform_test.cc
+++ b/src/iceberg/test/transform_test.cc
@@ -34,6 +34,7 @@
 #include "iceberg/schema_field.h"
 #include "iceberg/test/matchers.h"
 #include "iceberg/test/temporal_test_helper.h"
+#include "iceberg/transform_function.h"
 #include "iceberg/type.h"
 #include "iceberg/util/checked_cast.h"
 #include "iceberg/util/formatter.h"  // IWYU pragma: keep
@@ -72,6 +73,13 @@ TEST(TransformFunctionTest, CreateBucketTransform) {
   const auto transformPtr = transform->Bind(iceberg::string());
   ASSERT_TRUE(transformPtr);
   EXPECT_EQ(transformPtr.value()->transform_type(), TransformType::kBucket);
+
+  BucketTransform same_bucket(string(), bucket_count);
+  BucketTransform different_bucket(string(), 16);
+  BucketTransform different_source(int32(), bucket_count);
+  EXPECT_EQ(*transformPtr.value(), same_bucket);
+  EXPECT_NE(*transformPtr.value(), different_bucket);
+  EXPECT_NE(*transformPtr.value(), different_source);
 }
 
 TEST(TransformFunctionTest, CreateTruncateTransform) {
@@ -81,7 +89,15 @@ TEST(TransformFunctionTest, CreateTruncateTransform) {
   EXPECT_EQ("truncate[16]", std::format("{}", *transform));
 
   auto transformPtr = transform->Bind(iceberg::string());
+  ASSERT_TRUE(transformPtr);
   EXPECT_EQ(transformPtr.value()->transform_type(), TransformType::kTruncate);
+
+  TruncateTransform same_truncate(string(), width);
+  TruncateTransform different_truncate(string(), 32);
+  TruncateTransform different_source(int32(), width);
+  EXPECT_EQ(*transformPtr.value(), same_truncate);
+  EXPECT_NE(*transformPtr.value(), different_truncate);
+  EXPECT_NE(*transformPtr.value(), different_source);
 }
 
 TEST(TransformFunctionTest, CreateYearTransform) {

--- a/src/iceberg/transform.h
+++ b/src/iceberg/transform.h
@@ -275,10 +275,11 @@ class ICEBERG_EXPORT TransformFunction {
     return lhs.Equals(rhs);
   }
 
- private:
-  /// \brief Compare two partition specs for equality.
+ protected:
+  /// \brief Compare the common properties of two transform functions for equality.
   [[nodiscard]] virtual bool Equals(const TransformFunction& other) const;
 
+ private:
   TransformType transform_type_;
   std::shared_ptr<Type> source_type_;
 };

--- a/src/iceberg/transform_function.cc
+++ b/src/iceberg/transform_function.cc
@@ -68,6 +68,12 @@ Result<Literal> BucketTransform::Transform(const Literal& literal) {
 
 std::shared_ptr<Type> BucketTransform::ResultType() const { return int32(); }
 
+bool BucketTransform::Equals(const TransformFunction& other) const {
+  const auto* other_bucket = dynamic_cast<const BucketTransform*>(&other);
+  return other_bucket != nullptr && TransformFunction::Equals(other) &&
+         num_buckets_ == other_bucket->num_buckets_;
+}
+
 Result<std::unique_ptr<TransformFunction>> BucketTransform::Make(
     std::shared_ptr<Type> const& source_type, int32_t num_buckets) {
   if (!source_type) {
@@ -109,6 +115,12 @@ Result<Literal> TruncateTransform::Transform(const Literal& literal) {
 }
 
 std::shared_ptr<Type> TruncateTransform::ResultType() const { return source_type(); }
+
+bool TruncateTransform::Equals(const TransformFunction& other) const {
+  const auto* other_truncate = dynamic_cast<const TruncateTransform*>(&other);
+  return other_truncate != nullptr && TransformFunction::Equals(other) &&
+         width_ == other_truncate->width_;
+}
 
 Result<std::unique_ptr<TransformFunction>> TruncateTransform::Make(
     std::shared_ptr<Type> const& source_type, int32_t width) {

--- a/src/iceberg/transform_function.h
+++ b/src/iceberg/transform_function.h
@@ -70,6 +70,8 @@ class ICEBERG_EXPORT BucketTransform : public TransformFunction {
       std::shared_ptr<Type> const& source_type, int32_t num_buckets);
 
  private:
+  [[nodiscard]] bool Equals(const TransformFunction& other) const override;
+
   int32_t num_buckets_;
 };
 
@@ -97,6 +99,8 @@ class ICEBERG_EXPORT TruncateTransform : public TransformFunction {
       std::shared_ptr<Type> const& source_type, int32_t width);
 
  private:
+  [[nodiscard]] bool Equals(const TransformFunction& other) const override;
+
   int32_t width_;
 };
 


### PR DESCRIPTION
## Summary
- include bucket counts in BucketTransform equality
- include truncate widths in TruncateTransform equality
- cover parameter and source-type differences in transform tests

## Testing
- build/src/iceberg/test/schema_test
- pre-commit hooks