### PR TITLE
fix: reject malformed commit property integers

### DIFF
--- a/src/iceberg/test/table_metadata_builder_test.cc
+++ b/src/iceberg/test/table_metadata_builder_test.cc
@@ -200,6 +200,22 @@ TEST(TableMetadataTest, InvalidProperties) {
                     "Table property {} must have non negative integer value, but got {}",
                     TableProperties::kCommitNumRetries.key(), -1)));
   }
+
+  {
+    // Commit properties must contain only an integer, not a valid integer prefix.
+    ICEBERG_UNWRAP_OR_FAIL(auto schema, CreateDisorderedSchema());
+    for (const auto& value : {"4x", "1.5"}) {
+      std::unordered_map<std::string, std::string> invalid_commit_properties = {
+          {TableProperties::kCommitNumRetries.key(), value}};
+
+      auto res = TableMetadata::Make(*schema, *spec, *order, "s3://bucket/test",
+                                     invalid_commit_properties);
+      EXPECT_THAT(res, IsError(ErrorKind::kValidationFailed));
+      EXPECT_THAT(res, HasErrorMessage(std::format(
+                           "Table property {} must have integer value, but got {}",
+                           TableProperties::kCommitNumRetries.key(), value)));
+    }
+  }
 }
 
 // test construction of TableMetadataBuilder

--- a/src/iceberg/util/property_util.cc
+++ b/src/iceberg/util/property_util.cc
@@ -30,14 +30,17 @@ Status PropertyUtil::ValidateCommitProperties(
   for (const auto& property : TableProperties::commit_properties()) {
     if (auto it = properties.find(property); it != properties.end()) {
       int32_t parsed;
-      auto [ptr, ec] = std::from_chars(it->second.data(),
-                                       it->second.data() + it->second.size(), parsed);
+      const auto* end = it->second.data() + it->second.size();
+      auto [ptr, ec] = std::from_chars(it->second.data(), end, parsed);
       if (ec == std::errc::invalid_argument) {
         return ValidationFailed("Table property {} must have integer value, but got {}",
                                 property, it->second);
       } else if (ec == std::errc::result_out_of_range) {
         return ValidationFailed("Table property {} value out of range {}", property,
                                 it->second);
+      } else if (ptr != end) {
+        return ValidationFailed("Table property {} must have integer value, but got {}",
+                                property, it->second);
       }
       if (parsed < 0) {
         return ValidationFailed(

--- a/src/iceberg/util/property_util.cc
+++ b/src/iceberg/util/property_util.cc
@@ -19,9 +19,10 @@
 
 #include "iceberg/util/property_util.h"
 
-#include <charconv>
+#include <cstdint>
 
 #include "iceberg/table_properties.h"
+#include "iceberg/util/string_util.h"
 
 namespace iceberg {
 
@@ -29,19 +30,12 @@ Status PropertyUtil::ValidateCommitProperties(
     const std::unordered_map<std::string, std::string>& properties) {
   for (const auto& property : TableProperties::commit_properties()) {
     if (auto it = properties.find(property); it != properties.end()) {
-      int32_t parsed;
-      const auto* end = it->second.data() + it->second.size();
-      auto [ptr, ec] = std::from_chars(it->second.data(), end, parsed);
-      if (ec == std::errc::invalid_argument) {
-        return ValidationFailed("Table property {} must have integer value, but got {}",
-                                property, it->second);
-      } else if (ec == std::errc::result_out_of_range) {
-        return ValidationFailed("Table property {} value out of range {}", property,
-                                it->second);
-      } else if (ptr != end) {
+      auto parsed_result = StringUtils::ParseNumber<int32_t>(it->second);
+      if (!parsed_result) {
         return ValidationFailed("Table property {} must have integer value, but got {}",
                                 property, it->second);
       }
+      const auto parsed = *parsed_result;
       if (parsed < 0) {
         return ValidationFailed(
             "Table property {} must have non negative integer value, but got {}",


### PR DESCRIPTION
## Summary

- require commit property integers to parse completely, matching Java's `Integer.parseInt`
- reject values with alphanumeric or decimal suffixes instead of accepting their numeric prefix
- preserve the existing validation errors for invalid and out-of-range values

## Testing

- `ctest --test-dir build -R ^table_test$ --output-on-failure`
- full CTest suite (17 test binaries)
