### PR TITLE
fix: compare all snapshot fields

### DIFF
--- a/src/iceberg/snapshot.cc
+++ b/src/iceberg/snapshot.cc
@@ -172,6 +172,7 @@ bool Snapshot::Equals(const Snapshot& other) const {
   return snapshot_id == other.snapshot_id &&
          parent_snapshot_id == other.parent_snapshot_id &&
          sequence_number == other.sequence_number && timestamp_ms == other.timestamp_ms &&
+         manifest_list == other.manifest_list && summary == other.summary &&
          schema_id == other.schema_id && first_row_id == other.first_row_id &&
          added_rows == other.added_rows;
 }

--- a/src/iceberg/test/snapshot_test.cc
+++ b/src/iceberg/test/snapshot_test.cc
@@ -116,8 +116,16 @@ TEST_F(SnapshotTest, EqualityComparison) {
   Snapshot snapshot3(67890, {}, 1, TimePointMsFromUnixMs(1615569200000),
                      "s3://example/manifest_list.avro", summary3, {});
 
+  Snapshot snapshot4(12345, {}, 1, TimePointMsFromUnixMs(1615569200000),
+                     "s3://example/other_manifest_list.avro", summary1, {});
+
+  Snapshot snapshot5(12345, {}, 1, TimePointMsFromUnixMs(1615569200000),
+                     "s3://example/manifest_list.avro", summary3, {});
+
   EXPECT_EQ(snapshot1, snapshot2);
   EXPECT_NE(snapshot1, snapshot3);
+  EXPECT_NE(snapshot1, snapshot4);
+  EXPECT_NE(snapshot1, snapshot5);
 }
 
 }  // namespace iceberg


### PR DESCRIPTION
`Snapshot::Equals` compares IDs, sequence metadata, schema, and row-lineage fields, but it currently ignores the manifest list and summary. As a result, snapshots that point to different manifests or describe different operations can compare equal. This also weakens equality-based REST update round-trip checks.

Include `manifest_list` and `summary` in snapshot equality and add regression coverage for both fields.

Tested with:
- `table_test --gtest_filter=SnapshotTest.EqualityComparison`
- full CTest suite (17 test binaries)