### PR TITLE
fix: parse boolean properties case-insensitively

### DIFF
--- a/src/iceberg/arrow/s3/arrow_s3_file_io.cc
+++ b/src/iceberg/arrow/s3/arrow_s3_file_io.cc
@@ -58,10 +58,10 @@ Result<std::optional<bool>> ParseOptionalBool(
   if (value == nullptr) {
     return std::nullopt;
   }
-  if (*value == "true") {
+  if (StringUtils::EqualsIgnoreCase(*value, "true")) {
     return true;
   }
-  if (*value == "false") {
+  if (StringUtils::EqualsIgnoreCase(*value, "false")) {
     return false;
   }
   return InvalidArgument(R"("{}" must be "true" or "false")", key);

--- a/src/iceberg/test/arrow_s3_file_io_test.cc
+++ b/src/iceberg/test/arrow_s3_file_io_test.cc
@@ -269,25 +269,25 @@ TEST_F(ArrowS3FileIOTest, EndpointScheme) {
 TEST_F(ArrowS3FileIOTest, SslEnabled) {
   auto https =
       ConfigureS3Options({{std::string(S3Properties::kEndpoint), "http://localhost:9000"},
-                          {std::string(S3Properties::kSslEnabled), "true"}});
+                          {std::string(S3Properties::kSslEnabled), "TRUE"}});
   ASSERT_THAT(https, IsOk());
   EXPECT_EQ(https->scheme, "https");
 
   auto http = ConfigureS3Options(
       {{std::string(S3Properties::kEndpoint), "https://localhost:9000"},
-       {std::string(S3Properties::kSslEnabled), "false"}});
+       {std::string(S3Properties::kSslEnabled), "FaLsE"}});
   ASSERT_THAT(http, IsOk());
   EXPECT_EQ(http->scheme, "http");
 }
 
 TEST_F(ArrowS3FileIOTest, PathStyleAccess) {
   auto virtual_addressing =
-      ConfigureS3Options({{std::string(S3Properties::kPathStyleAccess), "false"}});
+      ConfigureS3Options({{std::string(S3Properties::kPathStyleAccess), "FALSE"}});
   ASSERT_THAT(virtual_addressing, IsOk());
   EXPECT_TRUE(virtual_addressing->force_virtual_addressing);
 
   auto path_style =
-      ConfigureS3Options({{std::string(S3Properties::kPathStyleAccess), "true"}});
+      ConfigureS3Options({{std::string(S3Properties::kPathStyleAccess), "TrUe"}});
   ASSERT_THAT(path_style, IsOk());
   EXPECT_FALSE(path_style->force_virtual_addressing);
 }

--- a/src/iceberg/test/config_test.cc
+++ b/src/iceberg/test/config_test.cc
@@ -126,4 +126,18 @@ TEST(ConfigTest, BasicOperations) {
   ASSERT_EQ(config.Get(TestConfig::kDoubleConfig), 3.14);
 }
 
+TEST(ConfigTest, ParseBooleanIgnoringCase) {
+  auto config = TestConfig::default_properties();
+
+  for (const auto& value : {"true", "TRUE", "TrUe"}) {
+    config.mutable_configs()[TestConfig::kBoolConfig.key()] = value;
+    EXPECT_TRUE(config.Get(TestConfig::kBoolConfig));
+  }
+
+  for (const auto& value : {"false", "FALSE", "not-a-boolean"}) {
+    config.mutable_configs()[TestConfig::kBoolConfig.key()] = value;
+    EXPECT_FALSE(config.Get(TestConfig::kBoolConfig));
+  }
+}
+
 }  // namespace iceberg

--- a/src/iceberg/util/config.h
+++ b/src/iceberg/util/config.h
@@ -54,7 +54,7 @@ U DefaultFromString(const std::string& val) {
   if constexpr (std::is_same_v<U, std::string>) {
     return val;
   } else if constexpr (std::is_same_v<U, bool>) {
-    return val == "true";
+    return StringUtils::EqualsIgnoreCase(val, "true");
   } else if constexpr ((std::is_signed_v<U> && std::is_integral_v<U>) ||
                        std::is_floating_point_v<U>) {
     ICEBERG_ASSIGN_OR_THROW(auto res, StringUtils::ParseNumber<U>(val));


### PR DESCRIPTION
## Summary

- parse boolean table and catalog properties case-insensitively, matching Java's `Boolean.parseBoolean`
- continue treating values other than a case-insensitive `true` as `false`
- add coverage for lowercase, uppercase, mixed-case, false, and unrecognized values

## Testing

- `util_test --gtest_filter=ConfigTest.ParseBooleanIgnoringCase`
- pre-commit hooks for the changed files
