### PR TITLE
fix: detect system Thrift in CONFIG mode

### DIFF
--- a/cmake_modules/FindThriftAlt.cmake
+++ b/cmake_modules/FindThriftAlt.cmake
@@ -86,9 +86,10 @@ endif()
 include(FindPackageHandleStandardArgs)
 if(TARGET thrift::thrift)
   # CONFIG mode already produced the target; satisfy REQUIRED_VARS with it.
+  set(ThriftAlt_TARGET thrift::thrift)
   find_package_handle_standard_args(
     ThriftAlt
-    REQUIRED_VARS thrift::thrift
+    REQUIRED_VARS ThriftAlt_TARGET
     VERSION_VAR ThriftAlt_VERSION)
 else()
   find_package_handle_standard_args(


### PR DESCRIPTION
## What
`REQUIRED_VARS` dereferences its entries as variable names, so passing the target `thrift::thrift` resolves to nothing and the module reports Thrift as missing. Instead we need to pass a variable holding the target.

## Why
The current behavior breaks `-DICEBERG_BUNDLE_THRIFT=OFF` against any Thrift shipping a CMake config, which is 0.13 and later. `resolve_thrift_dependency()` calls `find_package(ThriftAlt MODULE REQUIRED)`, so the false negative aborts configure, and it is the path `iceberg_hive` recommends when the target is missing. It has gone unnoticed because Arrow's bundled Thrift defines the target first and the module returns early.

## Validation
- Against a config-mode Thrift install, before: `Could NOT find ThriftAlt (missing: thrift::thrift)` and configure aborts. After: `Found ThriftAlt: thrift::thrift` and configure completes.