### PR TITLE
chore(ci): Update ASF allowlist check action dependency to track versioned releases

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -44,4 +44,4 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
-    - uses: apache/infrastructure-actions/allowlist-check@4e9c961f587f72b170874b6f5cd4ac15f7f26eb8
+    - uses: apache/infrastructure-actions/allowlist-check@61dcea11f19e2bbe1263f14d72235e8da17d3ad0  # allowlist-check/v1.0.0


### PR DESCRIPTION
Updates GH Actions CI to track versioned tags for the ASF allowlist check. The ASF allowlist check recently started publishing tagged releases, so there is no longer a need to track `main` branch.

Related ASF action change: https://github.com/apache/infrastructure-actions/pull/1032

Follows the same change as https://github.com/apache/iceberg-rust/pull/2914