### PR TITLE
feat: add Nimble to FileFormatType

### DIFF
--- a/src/iceberg/file_format.h
+++ b/src/iceberg/file_format.h
@@ -37,6 +37,7 @@ enum class ICEBERG_EXPORT FileFormatType {
   kAvro,
   kOrc,
   kPuffin,
+  kNimble,
 };
 
 /// \brief Convert a FileFormatType to a string
@@ -50,6 +51,8 @@ ICEBERG_EXPORT inline std::string_view ToString(FileFormatType format_type) {
       return "orc";
     case FileFormatType::kPuffin:
       return "puffin";
+    case FileFormatType::kNimble:
+      return "nimble";
   }
   std::unreachable();
 }
@@ -62,6 +65,7 @@ ICEBERG_EXPORT inline Result<FileFormatType> FileFormatTypeFromString(
   if (lower == "avro") return FileFormatType::kAvro;
   if (lower == "orc") return FileFormatType::kOrc;
   if (lower == "puffin") return FileFormatType::kPuffin;
+  if (lower == "nimble") return FileFormatType::kNimble;
   return InvalidArgument("Invalid file format type: {}", str);
 }
 


### PR DESCRIPTION
Working on integrating Nimble https://github.com/facebookincubator/nimble to iceberg. This requires extending the FileFormatType enum.

Add `kNimble` to the `FileFormatType` enum along with its `ToString` and `FileFormatTypeFromString` mappings, so tables whose data files are written in the Nimble columnar format can be represented and round-tripped through manifest and REST JSON deserialization.