### PR TITLE
test: verify MergingSnapshotUpdate commit reports

### DIFF
--- a/src/iceberg/test/merging_snapshot_update_test.cc
+++ b/src/iceberg/test/merging_snapshot_update_test.cc
@@ -26,6 +26,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 #include <gmock/gmock.h>
@@ -37,6 +38,8 @@
 #include "iceberg/manifest/manifest_entry.h"
 #include "iceberg/manifest/manifest_reader.h"
 #include "iceberg/manifest/manifest_writer.h"
+#include "iceberg/metrics/commit_report.h"
+#include "iceberg/metrics/metrics_reporter.h"
 #include "iceberg/partition_spec.h"
 #include "iceberg/puffin_dv_io.h"
 #include "iceberg/row/partition_values.h"
@@ -58,6 +61,20 @@
 #include "iceberg/util/macros.h"
 
 namespace iceberg {
+
+namespace {
+
+class MergingSnapshotCapturingReporter final : public MetricsReporter {
+ public:
+  Status Report(const MetricsReport& report) override {
+    reports.push_back(report);
+    return {};
+  }
+
+  std::vector<MetricsReport> reports;
+};
+
+}  // namespace
 
 class RecordingPuffinDVIO final : public PuffinDVIO {
  public:
@@ -562,6 +579,29 @@ TEST_F(MergingSnapshotUpdateTest, CommitNewDataFile) {
   ICEBERG_UNWRAP_OR_FAIL(auto snapshot, table_->current_snapshot());
   EXPECT_EQ(snapshot->summary.at(SnapshotSummaryFields::kAddedDataFiles), "1");
   EXPECT_EQ(snapshot->summary.at(SnapshotSummaryFields::kAddedRecords), "100");
+}
+
+TEST_F(MergingSnapshotUpdateTest, CommitReportsCreatedSnapshot) {
+  auto reporter = std::make_shared<MergingSnapshotCapturingReporter>();
+  ICEBERG_UNWRAP_OR_FAIL(auto op, NewMergeAppend());
+  op->ReportWith(reporter);
+  EXPECT_THAT(op->AddFile(file_a_), IsOk());
+  EXPECT_THAT(op->Commit(), IsOk());
+
+  ASSERT_EQ(reporter->reports.size(), 1U);
+  ASSERT_TRUE(std::holds_alternative<CommitReport>(reporter->reports.front()));
+  const auto& report = std::get<CommitReport>(reporter->reports.front());
+
+  EXPECT_THAT(table_->Refresh(), IsOk());
+  ICEBERG_UNWRAP_OR_FAIL(auto snapshot, table_->current_snapshot());
+  EXPECT_EQ(report.table_name, table_->full_name());
+  EXPECT_EQ(report.operation, DataOperation::kAppend);
+  EXPECT_EQ(report.snapshot_id, snapshot->snapshot_id);
+  EXPECT_EQ(report.sequence_number, snapshot->sequence_number);
+  ASSERT_TRUE(report.commit_metrics.added_data_files.has_value());
+  EXPECT_EQ(report.commit_metrics.added_data_files->value, 1);
+  ASSERT_TRUE(report.commit_metrics.added_records.has_value());
+  EXPECT_EQ(report.commit_metrics.added_records->value, 100);
 }
 
 TEST_F(MergingSnapshotUpdateTest, CommitV3NewDataFileAssignsRowLineage) {

--- a/src/iceberg/update/merging_snapshot_update.h
+++ b/src/iceberg/update/merging_snapshot_update.h
@@ -60,12 +60,6 @@ namespace iceberg {
 ///   5. Write new delete manifests (cached for commit retry)
 ///   6. Merge data manifests (via data_merge_manager_)
 ///   7. Merge delete manifests (via delete_merge_manager_)
-///
-/// TODO(Guotao): Java MergingSnapshotProducer overrides updateEvent() to return a
-/// CreateSnapshotEvent(tableName, operation, snapshotId, sequenceNumber, summary)
-/// for commit listeners. The C++ update framework does not yet have an event
-/// notification mechanism, so this is intentionally not implemented here. Add it
-/// once an equivalent CreateSnapshotEvent / listener facility exists.
 class ICEBERG_EXPORT MergingSnapshotUpdate : public SnapshotUpdate {
  public:
   ~MergingSnapshotUpdate() override = default;


### PR DESCRIPTION
## What changed

- remove the stale `MergingSnapshotUpdate` event-reporting TODO
- add focused coverage proving a merge-based snapshot update emits one `CommitReport`
- verify the report carries the table name, operation, created snapshot ID, sequence number, and summary-derived file and record counts

## Why

The TODO predates commit metrics integration and still says C++ has no equivalent reporting mechanism. Snapshot updates now report successful commits through `MetricsReporter`, but `MergingSnapshotUpdate` did not have direct regression coverage for that behavior.

This keeps reporting centralized in `SnapshotUpdate` while testing the contract for merge-based updates.

## Validation

- `cmake --build build --target table_update_test -j2`
- `build/src/iceberg/test/table_update_test --gtest_filter='MergingSnapshotUpdateTest.*'` (79 tests passed)
- `clang-format --dry-run --Werror src/iceberg/test/merging_snapshot_update_test.cc src/iceberg/update/merging_snapshot_update.h`
- `git diff --check`
