### PR TITLE
refactor: protect merging snapshot update hooks

### DIFF
--- a/src/iceberg/test/merging_snapshot_update_test.cc
+++ b/src/iceberg/test/merging_snapshot_update_test.cc
@@ -139,6 +139,10 @@ class TestMergeAppend : public MergingSnapshotUpdate {
   std::string operation() override { return "append"; }
 
   // Expose protected API for test access
+  using MergingSnapshotUpdate::Apply;
+  using MergingSnapshotUpdate::CleanUncommitted;
+  using MergingSnapshotUpdate::Summary;
+
   Status AddFile(std::shared_ptr<DataFile> file) { return AddDataFile(std::move(file)); }
   Status AddDelete(std::shared_ptr<DataFile> file) {
     return AddDeleteFile(std::move(file));
@@ -284,6 +288,8 @@ class TestOverwriteUpdate : public MergingSnapshotUpdate {
 
   std::string operation() override { return DataOperation::kOverwrite; }
   int64_t GeneratedSnapshotId() { return SnapshotId(); }
+
+  using MergingSnapshotUpdate::Apply;
 
   Status AddDelete(std::shared_ptr<DataFile> file) {
     return AddDeleteFile(std::move(file));

--- a/src/iceberg/update/merging_snapshot_update.h
+++ b/src/iceberg/update/merging_snapshot_update.h
@@ -64,6 +64,7 @@ class ICEBERG_EXPORT MergingSnapshotUpdate : public SnapshotUpdate {
  public:
   ~MergingSnapshotUpdate() override = default;
 
+ protected:
   // SnapshotUpdate overrides
   Result<std::vector<ManifestFile>> Apply(
       const TableMetadata& metadata_to_update,
@@ -73,7 +74,6 @@ class ICEBERG_EXPORT MergingSnapshotUpdate : public SnapshotUpdate {
 
   std::unordered_map<std::string, std::string> Summary() override;
 
- protected:
   /// \brief Constructor; reads merge configuration from table properties.
   explicit MergingSnapshotUpdate(std::string table_name,
                                  std::shared_ptr<TransactionContext> ctx);


### PR DESCRIPTION
## Summary

- move `MergingSnapshotUpdate`'s `Apply`, `CleanUncommitted`, and `Summary` overrides from public to protected
- keep the destructor public
- explicitly re-expose the protected hooks only in test subclasses that need white-box access

## Why

These methods implement internal extension hooks that are already protected in `SnapshotUpdate`. Declaring the overrides public unnecessarily widens the `MergingSnapshotUpdate` API. Keeping them protected aligns the derived class with the base-class contract while preserving access for subclasses and virtual dispatch from `SnapshotUpdate`.

External code that directly called these internal hooks through a concrete merging update will need to use the public snapshot-update workflow instead. The virtual function layout and runtime behavior are unchanged.

## Validation

- `clang-format --dry-run --Werror src/iceberg/update/merging_snapshot_update.h src/iceberg/test/merging_snapshot_update_test.cc`
- `cmake --build build --target table_update_test -j2`
- `build/src/iceberg/test/table_update_test --gtest_filter='MergingSnapshotUpdateTest.*:MergingSnapshotUpdateV1Test.*'` (79 tests passed)
- `git diff --check upstream/main...HEAD`
