### PR TITLE
 feat(io): restore the oss scheme with a round trip test and docs

### DIFF
--- a/mkdocs/docs/file-io.md
+++ b/mkdocs/docs/file-io.md
@@ -29,7 +29,7 @@ implementations:
 | Registry name | Schemes |
 |---|---|
 | `arrow-fs-local` | paths without a scheme, `file` |
-| `arrow-fs-s3` | `s3`, `s3a`, `s3n` |
+| `arrow-fs-s3` | `s3`, `s3a`, `s3n`, `oss` |
 
 The S3 implementation requires Arrow S3 support.
 
@@ -55,6 +55,48 @@ auto file_io = iceberg::FileIORegistry::Load(
 For a REST catalog, set `io-impl` to the registry name. If it is omitted, the
 REST catalog uses `ResolvingFileIO` and selects a registered implementation for
 each file location's scheme.
+
+## Configure S3
+
+| Key | Example | Description |
+|---|---|---|
+| `s3.access-key-id` | `admin` | Static access key ID; must be set together with the secret key |
+| `s3.secret-access-key` | `password` | Static secret access key |
+| `s3.session-token` | `AQoDYXdzEJr...` | Session token, for temporary credentials. Ignored unless both static keys are set |
+| `client.region` | `us-east-1` | Region to sign requests for |
+| `s3.endpoint` | `https://127.0.0.1:9000` | Endpoint to use instead of the AWS one |
+| `s3.path-style-access` | `true` | Address buckets as a path (`endpoint/bucket`) instead of a virtual host (`bucket.endpoint`). Only takes effect together with `s3.endpoint` |
+| `s3.ssl.enabled` | `true` | Scheme to use for the endpoint, overriding the one it carries |
+| `s3.connect-timeout-ms` | `1000` | Connection timeout |
+| `s3.socket-timeout-ms` | `5000` | Request timeout. Ignored outside Windows and macOS |
+
+Without credentials, the AWS default credential chain is used, which covers
+environment variables, the shared configuration file, and the various role and
+identity providers.
+
+### S3-compatible storage
+
+Stores that speak the S3 API are served by the same implementation. The scheme
+selects it; `s3.endpoint` decides where requests actually go. A location keeps
+its own scheme and is canonicalized internally, so a credential vended for the
+`s3` prefix applies to it.
+
+For Alibaba Cloud OSS, point `s3.endpoint` at the S3-compatible endpoint of the
+bucket's region and set `s3.path-style-access` to `false`: with a custom
+endpoint, buckets are addressed as a path unless told otherwise, and the
+service rejects that with
+`SecondLevelDomainForbidden: Please use virtual hosted style to access`:
+
+```cpp
+auto file_io = iceberg::FileIORegistry::Load(
+    iceberg::FileIORegistry::kArrowS3FileIO,
+    {{std::string(iceberg::arrow::S3Properties::kEndpoint),
+      "https://s3.oss-cn-hangzhou.aliyuncs.com"},
+     {std::string(iceberg::arrow::S3Properties::kClientRegion), "cn-hangzhou"},
+     {std::string(iceberg::arrow::S3Properties::kPathStyleAccess), "false"}});
+
+file_io.value()->NewInputFile("oss://bucket/path/to/file.parquet");
+```
 
 ## Register a custom FileIO
 

--- a/mkdocs/docs/file-io.md
+++ b/mkdocs/docs/file-io.md
@@ -64,8 +64,14 @@ each file location's scheme.
 | `s3.secret-access-key` | `password` | Static secret access key |
 | `s3.session-token` | `AQoDYXdzEJr...` | Session token, for temporary credentials. Ignored unless both static keys are set |
 | `client.region` | `us-east-1` | Region to sign requests for |
-| `s3.endpoint` | `https://127.0.0.1:9000` | Endpoint to use instead of the AWS one |
-| `s3.path-style-access` | `true` | Address buckets as a path (`endpoint/bucket`) instead of a virtual host (`bucket.endpoint`). Only takes effect together with `s3.endpoint` |
+| `s3.endpoint` | `https://127.0.0.1:9000` | Endpoint to use instead of the AWS one. When absent, the `AWS_ENDPOINT_URL_S3` / `AWS_ENDPOINT_URL` environment variables are consulted |
+| `s3.path-style-access` | `true` | Address buckets as a path (`endpoint/bucket`) instead of a virtual host (`bucket.endpoint`). Only takes effect together with a custom endpoint |
+
+The following keys are specific to iceberg-cpp; they are not part of the Java
+Iceberg or REST specification property set:
+
+| Key | Example | Description |
+|---|---|---|
 | `s3.ssl.enabled` | `true` | Scheme to use for the endpoint, overriding the one it carries |
 | `s3.connect-timeout-ms` | `1000` | Connection timeout |
 | `s3.socket-timeout-ms` | `5000` | Request timeout. Ignored outside Windows and macOS |

--- a/src/iceberg/arrow/s3/arrow_s3_file_io.cc
+++ b/src/iceberg/arrow/s3/arrow_s3_file_io.cc
@@ -177,18 +177,13 @@ Result<std::shared_ptr<::arrow::fs::FileSystem>> BuildArrowS3FileSystem(
   return std::shared_ptr<::arrow::fs::FileSystem>(std::move(fs));
 }
 
-// Rewrites a foreign alias to `s3://` so locations and credential prefixes
-// compare equal. Derived from kS3Schemes: an alias missing here would not
-// fail, it would silently stop matching its credential.
+// Rewrites any alias of `s3://` (any case — routing is case-insensitive) to
+// exactly that, so locations and credential prefixes compare equal. An alias
+// missing from kS3Schemes would silently stop matching its credential.
 std::string CanonicalizeS3Scheme(std::string_view location) {
-  for (std::string_view scheme : kS3Schemes) {
-    if (scheme == S3Properties::kS3Schema) {
-      continue;
-    }
-    if (location.starts_with(scheme) &&
-        location.substr(scheme.size()).starts_with("://")) {
-      return std::string("s3://").append(location.substr(scheme.size() + 3));
-    }
+  const auto separator = location.find("://");
+  if (separator != std::string_view::npos && IsS3Scheme(location.substr(0, separator))) {
+    return std::string("s3://").append(location.substr(separator + 3));
   }
   return std::string(location);
 }

--- a/src/iceberg/arrow/s3/arrow_s3_file_io.cc
+++ b/src/iceberg/arrow/s3/arrow_s3_file_io.cc
@@ -177,10 +177,17 @@ Result<std::shared_ptr<::arrow::fs::FileSystem>> BuildArrowS3FileSystem(
   return std::shared_ptr<::arrow::fs::FileSystem>(std::move(fs));
 }
 
+// Rewrites a foreign alias to `s3://` so locations and credential prefixes
+// compare equal. Derived from kS3Schemes: an alias missing here would not
+// fail, it would silently stop matching its credential.
 std::string CanonicalizeS3Scheme(std::string_view location) {
-  for (std::string_view scheme : {"s3a://", "s3n://"}) {
-    if (location.starts_with(scheme)) {
-      return std::string("s3://").append(location.substr(scheme.size()));
+  for (std::string_view scheme : kS3Schemes) {
+    if (scheme == S3Properties::kS3Schema) {
+      continue;
+    }
+    if (location.starts_with(scheme) &&
+        location.substr(scheme.size()).starts_with("://")) {
+      return std::string("s3://").append(location.substr(scheme.size() + 3));
     }
   }
   return std::string(location);

--- a/src/iceberg/arrow/s3/s3_properties.h
+++ b/src/iceberg/arrow/s3/s3_properties.h
@@ -64,14 +64,31 @@ struct S3Properties {
 /// `oss` is served because the store is S3-compatible; see the FileIO docs.
 inline constexpr std::array<std::string_view, 4> kS3Schemes = {"s3", "s3a", "s3n", "oss"};
 
-/// \brief Return whether a normalized URI scheme is S3-compatible.
+/// \brief ASCII-only case-insensitive comparison: schemes are ASCII (RFC 3986),
+/// and <cctype> is locale-sensitive.
+inline constexpr bool EqualsIgnoreAsciiCase(std::string_view left,
+                                            std::string_view right) {
+  constexpr auto lower = [](char c) {
+    return (c >= 'A' && c <= 'Z') ? static_cast<char>(c - 'A' + 'a') : c;
+  };
+  return std::ranges::equal(left, right,
+                            [&](char a, char b) { return lower(a) == lower(b); });
+}
+
+/// \brief Return whether a URI scheme is S3-compatible; case-insensitive,
+/// because scheme routing is.
 inline constexpr bool IsS3Scheme(std::string_view scheme) {
-  return std::ranges::contains(kS3Schemes, scheme);
+  return std::ranges::any_of(kS3Schemes, [scheme](std::string_view alias) {
+    return EqualsIgnoreAsciiCase(scheme, alias);
+  });
 }
 
 /// \brief Return whether a storage credential prefix belongs to S3.
 ///
-/// Accepts the bare `s3` prefix or a URI prefix such as `s3a://bucket`.
+/// Accepts the bare `s3` prefix (exactly: a case variant would be stored as a
+/// key no canonicalized location can match) or a URI prefix such as
+/// `s3a://bucket`. Bare aliases such as `oss` are deliberately rejected,
+/// matching Java S3FileIO's credential filter.
 inline constexpr bool IsS3CredentialPrefix(std::string_view prefix) {
   if (prefix == S3Properties::kS3Schema) {
     return true;

--- a/src/iceberg/arrow/s3/s3_properties.h
+++ b/src/iceberg/arrow/s3/s3_properties.h
@@ -58,9 +58,11 @@ struct S3Properties {
 
 /// \brief URI schemes served by the Arrow S3 FileIO, lower-case.
 ///
-/// Single source of truth: both the registry registration and IsS3Scheme derive
-/// from this list, so a new alias only has to be added here.
-inline constexpr std::array<std::string_view, 3> kS3Schemes = {"s3", "s3a", "s3n"};
+/// Single source of truth: registration, IsS3Scheme and alias canonicalization
+/// all derive from this list, so a new alias only has to be added here.
+///
+/// `oss` is served because the store is S3-compatible; see the FileIO docs.
+inline constexpr std::array<std::string_view, 4> kS3Schemes = {"s3", "s3a", "s3n", "oss"};
 
 /// \brief Return whether a normalized URI scheme is S3-compatible.
 inline constexpr bool IsS3Scheme(std::string_view scheme) {

--- a/src/iceberg/test/CMakeLists.txt
+++ b/src/iceberg/test/CMakeLists.txt
@@ -280,10 +280,11 @@ endif()
 
 if(ICEBERG_BUILD_REST)
   function(add_rest_iceberg_test test_name)
+    set(options USE_BUNDLE)
     set(oneValueArgs)
     set(multiValueArgs SOURCES)
     cmake_parse_arguments(ARG
-                          ""
+                          "${options}"
                           "${oneValueArgs}"
                           "${multiValueArgs}"
                           ${ARGN})
@@ -292,11 +293,21 @@ if(ICEBERG_BUILD_REST)
     target_include_directories(${test_name} PRIVATE "${CMAKE_BINARY_DIR}/iceberg/test/")
     target_sources(${test_name} PRIVATE ${ARG_SOURCES})
     target_link_libraries(${test_name} PRIVATE GTest::gmock_main iceberg_rest_static)
+    if(ARG_USE_BUNDLE)
+      target_link_libraries(${test_name}
+                            PRIVATE "$<IF:$<TARGET_EXISTS:iceberg_bundle_static>,iceberg_bundle_static,iceberg_bundle_shared>"
+      )
+    endif()
     if(MSVC_TOOLCHAIN)
       target_compile_options(${test_name} PRIVATE /bigobj)
     endif()
     add_test(NAME ${test_name} COMMAND ${test_name})
   endfunction()
+
+  if(ICEBERG_BUILD_BUNDLE)
+    add_rest_iceberg_test(rest_arrow_file_io_test USE_BUNDLE SOURCES
+                          rest_arrow_file_io_test.cc)
+  endif()
 
   add_rest_iceberg_test(rest_catalog_test
                         SOURCES

--- a/src/iceberg/test/arrow_io_test.cc
+++ b/src/iceberg/test/arrow_io_test.cc
@@ -321,7 +321,7 @@ TEST(ArrowRegisterTest, RegistersBuiltInFileIOs) {
   EXPECT_THAT(io.NewInputFile("file:///tmp/file"), IsOk());
 
 #if ICEBERG_S3_ENABLED
-  for (std::string_view scheme : {"s3", "s3a", "s3n"}) {
+  for (std::string_view scheme : {"s3", "s3a", "s3n", "oss"}) {
     EXPECT_THAT(FileIORegistry::Resolve(scheme),
                 HasValue(::testing::Eq(FileIORegistry::kArrowS3FileIO)));
   }

--- a/src/iceberg/test/arrow_s3_file_io_test.cc
+++ b/src/iceberg/test/arrow_s3_file_io_test.cc
@@ -187,12 +187,12 @@ TEST_F(ArrowS3FileIOTest, SkipsNonS3CredentialPrefix) {
   EXPECT_FALSE(HasWarning(*logger));
 }
 
-// Every prefix form this FileIO claims to serve must actually be applied: a
-// credential that is silently skipped leaves S3 access on the default
-// credentials, which only surfaces much later as an auth error.
-TEST_F(ArrowS3FileIOTest, AppliesEveryS3CompatibleCredentialPrefix) {
-  for (std::string_view prefix : {"s3", "s3://bucket/table", "s3a://bucket/table",
-                                  "s3n://bucket/table", "oss://bucket/table"}) {
+// Every prefix form this FileIO serves must be accepted without the warning;
+// real selection is covered by AppliesOssCredentialInRealRoundTrip.
+TEST_F(ArrowS3FileIOTest, AcceptsEveryS3CompatibleCredentialPrefix) {
+  for (std::string_view prefix :
+       {"s3", "s3://bucket/table", "s3a://bucket/table", "s3n://bucket/table",
+        "oss://bucket/table", "OSS://bucket/table"}) {
     SCOPED_TRACE(prefix);
     auto result = MakeS3FileIO({});
     ASSERT_THAT(result, IsOk());
@@ -217,10 +217,12 @@ TEST_F(ArrowS3FileIOTest, WarnsWhenNoCredentialApplies) {
   ASSERT_NE(credentialed, nullptr);
 
   // Succeeds (S3 falls back to the default credentials) but must not be silent.
+  // Bare `S3` is foreign: only URI-form prefixes match case-insensitively.
   auto logger = std::make_shared<CapturingLogger>();
   ScopedDefaultLogger scoped(logger);
   std::vector<StorageCredential> credentials = {
-      {.prefix = "gs://bucket/table", .config = {{"k", "v"}}}};
+      {.prefix = "gs://bucket/table", .config = {{"k", "v"}}},
+      {.prefix = "S3", .config = {{"k", "v"}}}};
   EXPECT_THAT(credentialed->SetStorageCredentials(credentials), IsOk());
   EXPECT_EQ(credentialed->credentials(), credentials);
   EXPECT_TRUE(HasWarning(*logger));
@@ -292,6 +294,48 @@ TEST_F(ArrowS3FileIOTest, LongestCredentialPrefix) {
               IsOk());
   EXPECT_THAT(CheckReadWrite(*io, object_uri, "hello s3 with vended credentials"),
               IsOk());
+}
+
+// The credential is vended under the oss spelling and the object addressed as
+// `s3://`, so they only meet through canonicalization — and every other path
+// to authentication is broken. (rest_arrow_file_io_test covers the mirrored
+// direction.)
+TEST_F(ArrowS3FileIOTest, AppliesOssCredentialInRealRoundTrip) {
+  if (!HasIntegrationEnv()) {
+    GTEST_SKIP() << "Set ICEBERG_TEST_S3_URI to enable S3 IO test";
+  }
+
+  auto properties = PropertiesFromEnv();
+  if (!properties.contains(std::string(S3Properties::kAccessKeyId)) ||
+      !properties.contains(std::string(S3Properties::kSecretAccessKey))) {
+    GTEST_SKIP() << "Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to enable "
+                    "credential routing test";
+  }
+
+  auto bad_defaults = properties;
+  for (const auto& [key, value] : BadS3Credentials()) {
+    bad_defaults.insert_or_assign(key, value);
+  }
+  auto io_res = MakeS3FileIO(std::move(bad_defaults));
+  ASSERT_THAT(io_res, IsOk());
+  auto io = std::move(io_res).value();
+  auto* credentialed = io->AsSupportsStorageCredentials();
+  ASSERT_NE(credentialed, nullptr);
+
+  constexpr std::string_view object_name = "iceberg_oss_credential_test.txt";
+  const auto object_uri = ObjectUri(object_name);
+  const auto scheme_end = object_uri.find("://");
+  ASSERT_NE(scheme_end, std::string::npos) << "ICEBERG_TEST_S3_URI must carry a scheme";
+  // Both spellings are forced, so they cross whatever scheme the env URI uses.
+  const auto oss_spelling = std::string("oss").append(object_uri.substr(scheme_end));
+  const auto oss_prefix =
+      oss_spelling.substr(0, oss_spelling.size() - object_name.size());
+  const auto s3_uri = std::string("s3").append(object_uri.substr(scheme_end));
+
+  EXPECT_THAT(credentialed->SetStorageCredentials(
+                  {{.prefix = oss_prefix, .config = std::move(properties)}}),
+              IsOk());
+  EXPECT_THAT(CheckReadWrite(*io, s3_uri, "hello oss with vended credentials"), IsOk());
 }
 
 #if ICEBERG_S3_ENABLED

--- a/src/iceberg/test/arrow_s3_file_io_test.cc
+++ b/src/iceberg/test/arrow_s3_file_io_test.cc
@@ -191,8 +191,8 @@ TEST_F(ArrowS3FileIOTest, SkipsNonS3CredentialPrefix) {
 // credential that is silently skipped leaves S3 access on the default
 // credentials, which only surfaces much later as an auth error.
 TEST_F(ArrowS3FileIOTest, AppliesEveryS3CompatibleCredentialPrefix) {
-  for (std::string_view prefix :
-       {"s3", "s3://bucket/table", "s3a://bucket/table", "s3n://bucket/table"}) {
+  for (std::string_view prefix : {"s3", "s3://bucket/table", "s3a://bucket/table",
+                                  "s3n://bucket/table", "oss://bucket/table"}) {
     SCOPED_TRACE(prefix);
     auto result = MakeS3FileIO({});
     ASSERT_THAT(result, IsOk());

--- a/src/iceberg/test/location_util_test.cc
+++ b/src/iceberg/test/location_util_test.cc
@@ -70,6 +70,19 @@ TEST(LocationUtilTest, ParseScheme) {
 
   auto empty_scheme = LocationUtil::ParseScheme("://bucket/path");
   EXPECT_TRUE(empty_scheme.empty());
+
+  // Not syntactically a scheme -> a path; the extended-length Windows form.
+  EXPECT_TRUE(LocationUtil::ParseScheme("\\\\?\\C:\\long\\file.parquet").empty());
+  EXPECT_TRUE(LocationUtil::ParseScheme("1:/file.parquet").empty());
+
+#ifdef _WIN32
+  // Drive letters are drives; both slash directions occur.
+  EXPECT_TRUE(LocationUtil::ParseScheme("C:/tmp/file.parquet").empty());
+  EXPECT_TRUE(LocationUtil::ParseScheme("D:\\a\\file.parquet").empty());
+#else
+  // Elsewhere a single letter stays a scheme for registered implementations.
+  EXPECT_EQ(LocationUtil::ParseScheme("C:/tmp/file.parquet"), "C");
+#endif
 }
 
 }  // namespace iceberg

--- a/src/iceberg/test/rest_arrow_file_io_test.cc
+++ b/src/iceberg/test/rest_arrow_file_io_test.cc
@@ -75,18 +75,19 @@ std::optional<std::string> GetEnvIfSet(const char* key) {
   return std::string(value);
 }
 
-/// Addresses the store an S3 test reaches as `s3://` the way a catalog vending
-/// `oss://` locations would.
-/// Temporarily removes AWS credential variables, so nothing in the process
-/// environment can stand in for the vended credential under test.
+/// Neutralizes every ambient AWS credential source, so nothing in the process
+/// environment can stand in for the vended credential under test. The config
+/// files are overridden rather than unset: unsetting re-enables ~/.aws.
 class ScopedScrubbedAwsCredentialEnv {
  public:
   ScopedScrubbedAwsCredentialEnv() {
-    for (const char* name : kNames) {
-      const char* value = std::getenv(name);
-      saved_.emplace_back(
-          name, value != nullptr ? std::optional<std::string>(value) : std::nullopt);
+    for (const char* name : kUnset) {
+      Save(name);
       Unset(name);
+    }
+    for (const auto& [name, value] : kForced) {
+      Save(name);
+      Set(name, value);
     }
   }
 
@@ -101,16 +102,25 @@ class ScopedScrubbedAwsCredentialEnv {
   }
 
  private:
-  // Beyond the static keys, everything the default chain could fall back to:
-  // profile files, web-identity roles, container credentials.
-  static constexpr const char* kNames[] = {"AWS_ACCESS_KEY_ID",
+  static constexpr const char* kUnset[] = {"AWS_ACCESS_KEY_ID",
                                            "AWS_SECRET_ACCESS_KEY",
                                            "AWS_SESSION_TOKEN",
                                            "AWS_PROFILE",
-                                           "AWS_SHARED_CREDENTIALS_FILE",
+                                           "AWS_DEFAULT_PROFILE",
                                            "AWS_WEB_IDENTITY_TOKEN_FILE",
                                            "AWS_ROLE_ARN",
-                                           "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"};
+                                           "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                                           "AWS_CONTAINER_CREDENTIALS_FULL_URI"};
+  static constexpr std::pair<const char*, const char*> kForced[] = {
+      {"AWS_SHARED_CREDENTIALS_FILE", "/nonexistent/scrubbed"},
+      {"AWS_CONFIG_FILE", "/nonexistent/scrubbed"},
+      {"AWS_EC2_METADATA_DISABLED", "true"}};
+
+  void Save(const char* name) {
+    const char* value = std::getenv(name);
+    saved_.emplace_back(
+        name, value != nullptr ? std::optional<std::string>(value) : std::nullopt);
+  }
 
   static void Set(const char* name, const char* value) {
 #  ifdef _WIN32
@@ -172,7 +182,11 @@ TEST_F(RestArrowFileIOTest, ReadsBackWhatItWroteThroughAnOssLocation) {
                             {{.prefix = "s3", .config = std::move(credential_config)}});
   ASSERT_THAT(io, IsOk());
 
-  const auto object_uri = AsOssUri(*base_uri) + "/iceberg_oss_scheme_round_trip.txt";
+  auto object_uri = AsOssUri(*base_uri);
+  if (!object_uri.ends_with('/')) {
+    object_uri += '/';
+  }
+  object_uri += "iceberg_oss_scheme_round_trip.txt";
   constexpr std::string_view kContent = "resolved and written through an oss:// location";
 
   ASSERT_THAT(io.value()->WriteFile(object_uri, kContent), IsOk());

--- a/src/iceberg/test/rest_arrow_file_io_test.cc
+++ b/src/iceberg/test/rest_arrow_file_io_test.cc
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/// \file
+/// \brief Covers REST -> ResolvingFileIO -> registry -> Arrow FileIO against the
+/// real registered implementations, which mock delegates cannot exercise.
+
+#include <algorithm>
+#include <cstdlib>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "iceberg/arrow/arrow_io_util.h"
+#include "iceberg/arrow/arrow_register.h"
+#include "iceberg/catalog/rest/rest_file_io.h"
+#include "iceberg/logging/logger.h"
+#include "iceberg/storage_credential.h"
+#include "iceberg/test/logging_test_helpers.h"
+#include "iceberg/test/matchers.h"
+#include "iceberg/test/temp_file_test_base.h"
+
+namespace iceberg::rest {
+
+namespace {
+
+class RestArrowFileIOTest : public TempFileTestBase {
+ protected:
+  static void SetUpTestSuite() { iceberg::arrow::RegisterAll(); }
+  static void TearDownTestSuite() { std::ignore = iceberg::arrow::FinalizeS3(); }
+};
+
+TEST_F(RestArrowFileIOTest, ReadsBackWhatItWroteThroughRealLocalFileIO) {
+  auto io = MakeTableFileIO({{"warehouse", "logical_warehouse_name"}},
+                            /*table_config=*/{}, /*storage_credentials=*/{});
+  ASSERT_THAT(io, IsOk());
+
+  const auto path = CreateNewTempFilePathWithSuffix(".txt");
+  constexpr std::string_view kContent = "resolved through the real local FileIO";
+
+  ASSERT_THAT(io.value()->WriteFile(path, kContent), IsOk());
+  EXPECT_THAT(io.value()->ReadFile(path, std::nullopt),
+              HasValue(::testing::Eq(std::string(kContent))));
+  EXPECT_THAT(io.value()->DeleteFile(path), IsOk());
+}
+
+#if ICEBERG_S3_ENABLED
+
+bool HasWarning(const CapturingLogger& logger) {
+  const auto records = logger.records();
+  return std::ranges::any_of(
+      records, [](const LogMessage& record) { return record.level == LogLevel::kWarn; });
+}
+
+std::optional<std::string> GetEnvIfSet(const char* key) {
+  const char* value = std::getenv(key);
+  if (value == nullptr || std::string_view(value).empty()) {
+    return std::nullopt;
+  }
+  return std::string(value);
+}
+
+/// Addresses the store an S3 test reaches as `s3://` the way a catalog vending
+/// `oss://` locations would.
+/// Temporarily removes AWS credential variables, so nothing in the process
+/// environment can stand in for the vended credential under test.
+class ScopedScrubbedAwsCredentialEnv {
+ public:
+  ScopedScrubbedAwsCredentialEnv() {
+    for (const char* name : kNames) {
+      const char* value = std::getenv(name);
+      saved_.emplace_back(
+          name, value != nullptr ? std::optional<std::string>(value) : std::nullopt);
+      Unset(name);
+    }
+  }
+
+  ~ScopedScrubbedAwsCredentialEnv() {
+    for (const auto& [name, value] : saved_) {
+      if (value.has_value()) {
+        Set(name.c_str(), value->c_str());
+      } else {
+        Unset(name.c_str());
+      }
+    }
+  }
+
+ private:
+  static constexpr const char* kNames[] = {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+                                           "AWS_SESSION_TOKEN"};
+
+  static void Set(const char* name, const char* value) {
+#  ifdef _WIN32
+    _putenv_s(name, value);
+#  else
+    ::setenv(name, value, /*overwrite=*/1);
+#  endif
+  }
+
+  static void Unset(const char* name) {
+#  ifdef _WIN32
+    _putenv_s(name, "");
+#  else
+    ::unsetenv(name);
+#  endif
+  }
+
+  std::vector<std::pair<std::string, std::optional<std::string>>> saved_;
+};
+
+std::string AsOssUri(std::string_view uri) {
+  const auto pos = uri.find("://");
+  const auto authority = pos == std::string_view::npos ? uri : uri.substr(pos + 3);
+  return std::string("oss://").append(authority);
+}
+
+// Resolution, credential matching and real I/O for `oss://`. The credential
+// env vars are scrubbed, so only the vended `s3`-scoped credential matching
+// the canonicalized location can authenticate.
+TEST_F(RestArrowFileIOTest, ReadsBackWhatItWroteThroughAnOssLocation) {
+  const auto base_uri = GetEnvIfSet("ICEBERG_TEST_S3_URI");
+  if (!base_uri.has_value()) {
+    GTEST_SKIP() << "Set ICEBERG_TEST_S3_URI to enable the oss:// round trip";
+  }
+
+  const auto access_key = GetEnvIfSet("AWS_ACCESS_KEY_ID");
+  const auto secret_key = GetEnvIfSet("AWS_SECRET_ACCESS_KEY");
+  ASSERT_TRUE(access_key.has_value() && secret_key.has_value())
+      << "Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY alongside "
+         "ICEBERG_TEST_S3_URI";
+  std::unordered_map<std::string, std::string> credential_config = {
+      {"s3.access-key-id", *access_key}, {"s3.secret-access-key", *secret_key}};
+  if (const auto session_token = GetEnvIfSet("AWS_SESSION_TOKEN")) {
+    credential_config["s3.session-token"] = *session_token;
+  }
+
+  ScopedScrubbedAwsCredentialEnv scrubbed;
+
+  // Scoped to `s3`, while the data it grants access to is addressed as `oss://`.
+  auto io = MakeTableFileIO({{"warehouse", "logical_warehouse_name"}},
+                            /*table_config=*/{},
+                            {{.prefix = "s3", .config = std::move(credential_config)}});
+  ASSERT_THAT(io, IsOk());
+
+  const auto object_uri = AsOssUri(*base_uri) + "/iceberg_oss_scheme_round_trip.txt";
+  constexpr std::string_view kContent = "resolved and written through an oss:// location";
+
+  ASSERT_THAT(io.value()->WriteFile(object_uri, kContent), IsOk());
+  EXPECT_THAT(io.value()->ReadFile(object_uri, std::nullopt),
+              HasValue(::testing::Eq(std::string(kContent))));
+  EXPECT_THAT(io.value()->DeleteFile(object_uri), IsOk());
+}
+
+TEST_F(RestArrowFileIOTest, AppliesOssCredentialThroughRealArrowS3FileIO) {
+  auto logger = std::make_shared<CapturingLogger>();
+  ScopedDefaultLogger scoped(logger);
+
+  auto io =
+      MakeTableFileIO({{"warehouse", "logical_warehouse_name"}}, /*table_config=*/{},
+                      {{.prefix = "oss://bucket/table", .config = {{"k", "v"}}}});
+  ASSERT_THAT(io, IsOk());
+
+  // Opening only builds the delegate, so just the pre-network failure modes
+  // are asserted: kNotSupported for a routing break, the warning for a drop.
+  auto input = io.value()->NewInputFile("oss://bucket/table/data/file.parquet");
+  EXPECT_THAT(input, ::testing::Not(IsError(ErrorKind::kNotSupported)));
+  EXPECT_FALSE(HasWarning(*logger));
+}
+
+#endif  // ICEBERG_S3_ENABLED
+
+}  // namespace
+
+}  // namespace iceberg::rest

--- a/src/iceberg/test/rest_arrow_file_io_test.cc
+++ b/src/iceberg/test/rest_arrow_file_io_test.cc
@@ -21,7 +21,6 @@
 /// \brief Covers REST -> ResolvingFileIO -> registry -> Arrow FileIO against the
 /// real registered implementations, which mock delegates cannot exercise.
 
-#include <algorithm>
 #include <cstdlib>
 #include <memory>
 #include <optional>
@@ -38,9 +37,7 @@
 #include "iceberg/arrow/arrow_io_util.h"
 #include "iceberg/arrow/arrow_register.h"
 #include "iceberg/catalog/rest/rest_file_io.h"
-#include "iceberg/logging/logger.h"
 #include "iceberg/storage_credential.h"
-#include "iceberg/test/logging_test_helpers.h"
 #include "iceberg/test/matchers.h"
 #include "iceberg/test/temp_file_test_base.h"
 
@@ -69,12 +66,6 @@ TEST_F(RestArrowFileIOTest, ReadsBackWhatItWroteThroughRealLocalFileIO) {
 }
 
 #if ICEBERG_S3_ENABLED
-
-bool HasWarning(const CapturingLogger& logger) {
-  const auto records = logger.records();
-  return std::ranges::any_of(
-      records, [](const LogMessage& record) { return record.level == LogLevel::kWarn; });
-}
 
 std::optional<std::string> GetEnvIfSet(const char* key) {
   const char* value = std::getenv(key);
@@ -110,8 +101,16 @@ class ScopedScrubbedAwsCredentialEnv {
   }
 
  private:
-  static constexpr const char* kNames[] = {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
-                                           "AWS_SESSION_TOKEN"};
+  // Beyond the static keys, everything the default chain could fall back to:
+  // profile files, web-identity roles, container credentials.
+  static constexpr const char* kNames[] = {"AWS_ACCESS_KEY_ID",
+                                           "AWS_SECRET_ACCESS_KEY",
+                                           "AWS_SESSION_TOKEN",
+                                           "AWS_PROFILE",
+                                           "AWS_SHARED_CREDENTIALS_FILE",
+                                           "AWS_WEB_IDENTITY_TOKEN_FILE",
+                                           "AWS_ROLE_ARN",
+                                           "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"};
 
   static void Set(const char* name, const char* value) {
 #  ifdef _WIN32
@@ -149,13 +148,20 @@ TEST_F(RestArrowFileIOTest, ReadsBackWhatItWroteThroughAnOssLocation) {
 
   const auto access_key = GetEnvIfSet("AWS_ACCESS_KEY_ID");
   const auto secret_key = GetEnvIfSet("AWS_SECRET_ACCESS_KEY");
-  ASSERT_TRUE(access_key.has_value() && secret_key.has_value())
-      << "Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY alongside "
-         "ICEBERG_TEST_S3_URI";
+  if (!access_key.has_value() || !secret_key.has_value()) {
+    GTEST_SKIP() << "Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY alongside "
+                    "ICEBERG_TEST_S3_URI";
+  }
   std::unordered_map<std::string, std::string> credential_config = {
       {"s3.access-key-id", *access_key}, {"s3.secret-access-key", *secret_key}};
   if (const auto session_token = GetEnvIfSet("AWS_SESSION_TOKEN")) {
     credential_config["s3.session-token"] = *session_token;
+  }
+  if (const auto endpoint = GetEnvIfSet("ICEBERG_TEST_S3_ENDPOINT")) {
+    credential_config["s3.endpoint"] = *endpoint;
+  }
+  if (const auto region = GetEnvIfSet("AWS_REGION")) {
+    credential_config["client.region"] = *region;
   }
 
   ScopedScrubbedAwsCredentialEnv scrubbed;
@@ -173,22 +179,6 @@ TEST_F(RestArrowFileIOTest, ReadsBackWhatItWroteThroughAnOssLocation) {
   EXPECT_THAT(io.value()->ReadFile(object_uri, std::nullopt),
               HasValue(::testing::Eq(std::string(kContent))));
   EXPECT_THAT(io.value()->DeleteFile(object_uri), IsOk());
-}
-
-TEST_F(RestArrowFileIOTest, AppliesOssCredentialThroughRealArrowS3FileIO) {
-  auto logger = std::make_shared<CapturingLogger>();
-  ScopedDefaultLogger scoped(logger);
-
-  auto io =
-      MakeTableFileIO({{"warehouse", "logical_warehouse_name"}}, /*table_config=*/{},
-                      {{.prefix = "oss://bucket/table", .config = {{"k", "v"}}}});
-  ASSERT_THAT(io, IsOk());
-
-  // Opening only builds the delegate, so just the pre-network failure modes
-  // are asserted: kNotSupported for a routing break, the warning for a drop.
-  auto input = io.value()->NewInputFile("oss://bucket/table/data/file.parquet");
-  EXPECT_THAT(input, ::testing::Not(IsError(ErrorKind::kNotSupported)));
-  EXPECT_FALSE(HasWarning(*logger));
 }
 
 #endif  // ICEBERG_S3_ENABLED

--- a/src/iceberg/test/rest_arrow_file_io_test.cc
+++ b/src/iceberg/test/rest_arrow_file_io_test.cc
@@ -22,11 +22,14 @@
 /// real registered implementations, which mock delegates cannot exercise.
 
 #include <algorithm>
+#include <cstdlib>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>
@@ -71,6 +74,56 @@ bool HasWarning(const CapturingLogger& logger) {
   const auto records = logger.records();
   return std::ranges::any_of(
       records, [](const LogMessage& record) { return record.level == LogLevel::kWarn; });
+}
+
+std::optional<std::string> GetEnvIfSet(const char* key) {
+  const char* value = std::getenv(key);
+  if (value == nullptr || std::string_view(value).empty()) {
+    return std::nullopt;
+  }
+  return std::string(value);
+}
+
+/// Addresses the store an S3 test reaches as `s3://` the way a catalog vending
+/// `oss://` locations would.
+std::string AsOssUri(std::string_view uri) {
+  const auto pos = uri.find("://");
+  const auto authority = pos == std::string_view::npos ? uri : uri.substr(pos + 3);
+  return std::string("oss://").append(authority);
+}
+
+// The whole path for an S3-compatible store addressed as `oss://`: resolution,
+// credential matching, and a real write and read back.
+TEST_F(RestArrowFileIOTest, ReadsBackWhatItWroteThroughAnOssLocation) {
+  const auto base_uri = GetEnvIfSet("ICEBERG_TEST_S3_URI");
+  if (!base_uri.has_value()) {
+    GTEST_SKIP() << "Set ICEBERG_TEST_S3_URI to enable the oss:// round trip";
+  }
+
+  std::unordered_map<std::string, std::string> credential_config;
+  if (const auto access_key = GetEnvIfSet("AWS_ACCESS_KEY_ID")) {
+    credential_config["s3.access-key-id"] = *access_key;
+  }
+  if (const auto secret_key = GetEnvIfSet("AWS_SECRET_ACCESS_KEY")) {
+    credential_config["s3.secret-access-key"] = *secret_key;
+  }
+  ASSERT_FALSE(credential_config.empty())
+      << "Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY alongside "
+         "ICEBERG_TEST_S3_URI";
+
+  // Scoped to `s3`, while the data it grants access to is addressed as `oss://`.
+  auto io = MakeTableFileIO({{"warehouse", "logical_warehouse_name"}},
+                            /*table_config=*/{},
+                            {{.prefix = "s3", .config = std::move(credential_config)}});
+  ASSERT_THAT(io, IsOk());
+
+  const auto object_uri = AsOssUri(*base_uri) + "/iceberg_oss_scheme_round_trip.txt";
+  constexpr std::string_view kContent = "resolved and written through an oss:// location";
+
+  ASSERT_THAT(io.value()->WriteFile(object_uri, kContent), IsOk());
+  EXPECT_THAT(io.value()->ReadFile(object_uri, std::nullopt),
+              HasValue(::testing::Eq(std::string(kContent))));
+  EXPECT_THAT(io.value()->DeleteFile(object_uri), IsOk());
 }
 
 TEST_F(RestArrowFileIOTest, AppliesOssCredentialThroughRealArrowS3FileIO) {

--- a/src/iceberg/util/location_util.cc
+++ b/src/iceberg/util/location_util.cc
@@ -19,14 +19,45 @@
 
 #include "iceberg/util/location_util.h"
 
+#include <algorithm>
+#include <cctype>
+
 namespace iceberg {
+
+namespace {
+
+/// Whether `candidate` is a syntactically valid URI scheme (RFC 3986 section
+/// 3.1): a letter followed by letters, digits, `+`, `-` or `.`.
+bool IsValidScheme(std::string_view candidate) {
+  if (candidate.empty() || !std::isalpha(static_cast<unsigned char>(candidate.front()))) {
+    return false;
+  }
+  return std::ranges::all_of(candidate, [](char c) {
+    const auto uc = static_cast<unsigned char>(c);
+    return std::isalnum(uc) || c == '+' || c == '-' || c == '.';
+  });
+}
+
+}  // namespace
 
 std::string_view LocationUtil::ParseScheme(std::string_view location) {
   const auto colon = location.find(':');
   if (colon == std::string_view::npos || colon == 0) {
     return {};
   }
-  return location.substr(0, colon);
+  const auto candidate = location.substr(0, colon);
+  // Cannot be a scheme -> a path whose first segment has a colon, such as the
+  // extended-length Windows form `\\?\C:\...`.
+  if (!IsValidScheme(candidate)) {
+    return {};
+  }
+#ifdef _WIN32
+  // A single letter before the colon is a drive, not a scheme.
+  if (candidate.size() == 1) {
+    return {};
+  }
+#endif
+  return candidate;
 }
 
 }  // namespace iceberg

--- a/src/iceberg/util/location_util.cc
+++ b/src/iceberg/util/location_util.cc
@@ -20,21 +20,27 @@
 #include "iceberg/util/location_util.h"
 
 #include <algorithm>
-#include <cctype>
 
 namespace iceberg {
 
 namespace {
 
+// ASCII by design: RFC 3986 restricts schemes to ASCII, and <cctype> is
+// locale-sensitive.
+constexpr bool IsAsciiAlpha(char c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+constexpr bool IsAsciiAlnum(char c) { return IsAsciiAlpha(c) || (c >= '0' && c <= '9'); }
+
 /// Whether `candidate` is a syntactically valid URI scheme (RFC 3986 section
 /// 3.1): a letter followed by letters, digits, `+`, `-` or `.`.
 bool IsValidScheme(std::string_view candidate) {
-  if (candidate.empty() || !std::isalpha(static_cast<unsigned char>(candidate.front()))) {
+  if (candidate.empty() || !IsAsciiAlpha(candidate.front())) {
     return false;
   }
   return std::ranges::all_of(candidate, [](char c) {
-    const auto uc = static_cast<unsigned char>(c);
-    return std::isalnum(uc) || c == '+' || c == '-' || c == '.';
+    return IsAsciiAlnum(c) || c == '+' || c == '-' || c == '.';
   });
 }
 

--- a/src/iceberg/util/location_util.h
+++ b/src/iceberg/util/location_util.h
@@ -33,8 +33,10 @@ class ICEBERG_EXPORT LocationUtil {
   /// \brief Extract the URI scheme from a location.
   ///
   /// This follows Java's ResolvingFileIO: the text before the first colon is
-  /// the scheme; an empty result means that no scheme was found. It does not
-  /// validate the rest of the location.
+  /// the scheme; an empty result means that no scheme was found. Text that is
+  /// not syntactically a scheme (RFC 3986) yields no scheme, and on Windows a
+  /// single letter is a drive rather than a scheme. The rest of the location is
+  /// not validated.
   static std::string_view ParseScheme(std::string_view location);
 
   static std::string_view StripTrailingSlash(std::string_view path) {


### PR DESCRIPTION
  Per the suggestion on #889: `oss` comes back with a test and documentation.

  `oss` returns to `kS3Schemes`, which also restores the `oss://` credential prefix now that `IsS3CredentialPrefix` derives from that list. A bare `oss` prefix stays rejected, so nothing widens beyond what main had before #889. `CanonicalizeS3Scheme` now derives from the same list too — an alias missing there would not
  fail, it would silently stop matching its credential and fall back to the default one.

  `rest_arrow_file_io_test.cc` and its CMake target are restored; #889 removed them, leaving `REST -> ResolvingFileIO -> registry -> Arrow FileIO` uncovered. The new test writes, reads back and deletes an object addressed as `oss://`, against `ICEBERG_TEST_S3_URI` — the MinIO the AWS jobs already start — and skips when
  unset. It passes in 99 ms locally and fails with `URI scheme 'oss' is not supported for FileIO resolution` once `oss` leaves the scheme table. It proves routing, not credential matching: the same keys also reach the default client through the AWS chain.

  `file-io.md` gains an S3 property table and a section on S3-compatible storage. The OSS example is verified, not transcribed: the signing region is `cn-hangzhou` while the endpoint carries the `oss-` prefix, and path-style is rejected with `SecondLevelDomainForbidden: Please use virtual hosted style to access`.