### PR TITLE
build: keep CMake and Meson definitions in sync

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,16 @@ env:
   ICEBERG_HOME: /tmp/iceberg
 
 jobs:
+  build-definition-parity:
+    name: Build definition parity
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout iceberg-cpp
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check build definition parity
+        run: python3 dev/test_build_definition_parity.py
   ubuntu:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: AMD64 Ubuntu 26.04 (${{ matrix.cmake_build_type }})

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -443,8 +443,16 @@ function(resolve_croaring_dependency)
     endif()
 
     set(CROARING_VENDORED TRUE)
-    set_target_properties(roaring PROPERTIES OUTPUT_NAME "iceberg_vendored_croaring"
-                                             POSITION_INDEPENDENT_CODE ON)
+    # CRoaring 4.3.11 exposes its header-only helper targets in roaring's install
+    # interface. Iceberg installs roaring in its own export without those helper
+    # targets, so downstream find_package(iceberg) would otherwise reject the
+    # package. Preserve the build dependencies without leaking them to consumers.
+    set_target_properties(roaring
+                          PROPERTIES OUTPUT_NAME "iceberg_vendored_croaring"
+                                     POSITION_INDEPENDENT_CODE ON
+                                     INTERFACE_LINK_LIBRARIES
+                                     "$<BUILD_INTERFACE:roaring-headers>;$<BUILD_INTERFACE:roaring-headers-cpp>"
+    )
     install(TARGETS roaring
             EXPORT iceberg_targets
             RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -422,7 +422,7 @@ function(resolve_croaring_dependency)
     set(CROARING_URL "$ENV{ICEBERG_CROARING_URL}")
   else()
     set(CROARING_URL
-        "https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v4.4.3.tar.gz")
+        "https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v4.3.11.tar.gz")
   endif()
 
   fetchcontent_declare(croaring
@@ -532,7 +532,7 @@ function(resolve_nlohmann_json_dependency)
     set(NLOHMANN_JSON_URL "$ENV{ICEBERG_NLOHMANN_JSON_URL}")
   else()
     set(NLOHMANN_JSON_URL
-        "https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz")
+        "https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz")
   endif()
 
   fetchcontent_declare(nlohmann_json
@@ -828,7 +828,7 @@ function(resolve_gtest_dependency)
 
   fetchcontent_declare(googletest
                        GIT_REPOSITORY https://github.com/google/googletest.git
-                       GIT_TAG b514bdc898e2951020cbdca1304b75f5950d1f59 # release-1.15.2
+                       GIT_TAG 52eb8108c5bdec04579160ae17225d66034bd723 # release-1.17.0
                        FIND_PACKAGE_ARGS
                        NAMES
                        GTest)

--- a/dev/test_build_definition_parity.py
+++ b/dev/test_build_definition_parity.py
@@ -84,6 +84,11 @@ class BuildDefinitionParityTest(unittest.TestCase):
         }
         self.assertEqual({}, mismatches)
 
+    def test_croaring_build_only_targets_are_not_exported(self) -> None:
+        toolchain = read("cmake_modules/IcebergThirdpartyToolchain.cmake")
+        self.assertIn("$<BUILD_INTERFACE:roaring-headers>", toolchain)
+        self.assertIn("$<BUILD_INTERFACE:roaring-headers-cpp>", toolchain)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/dev/test_build_definition_parity.py
+++ b/dev/test_build_definition_parity.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def extract(pattern: str, relative_path: str) -> str:
+    match = re.search(pattern, read(relative_path))
+    if match is None:
+        raise AssertionError(f"Could not find {pattern!r} in {relative_path}")
+    return match.group(1)
+
+
+class BuildDefinitionParityTest(unittest.TestCase):
+    def test_public_headers_are_installed_by_both_build_systems(self) -> None:
+        self.assertIn("puffin_dv_io.h", read("src/iceberg/meson.build"))
+        self.assertIn(
+            "token_refresh_scheduler.h",
+            read("src/iceberg/catalog/rest/auth/meson.build"),
+        )
+        self.assertIn(
+            "iceberg_install_all_headers(iceberg/catalog)",
+            read("src/iceberg/catalog/CMakeLists.txt"),
+        )
+
+    def test_core_tests_are_run_by_both_build_systems(self) -> None:
+        self.assertIn(
+            "snapshot_summary_builder_test.cc",
+            read("src/iceberg/test/meson.build"),
+        )
+
+    def test_fallback_dependency_versions_match(self) -> None:
+        versions = {
+            "CRoaring": (
+                extract(
+                    r"CRoaring/.+?/v([0-9.]+)\.tar\.gz",
+                    "cmake_modules/IcebergThirdpartyToolchain.cmake",
+                ),
+                extract(r"directory = CRoaring-([0-9.]+)", "subprojects/croaring.wrap"),
+            ),
+            "nlohmann/json": (
+                extract(
+                    r"nlohmann/json/releases/download/v([0-9.]+)",
+                    "cmake_modules/IcebergThirdpartyToolchain.cmake",
+                ),
+                extract(
+                    r"directory = nlohmann_json-([0-9.]+)",
+                    "subprojects/nlohmann_json.wrap",
+                ),
+            ),
+            "GoogleTest": (
+                extract(
+                    r"# release-([0-9.]+)",
+                    "cmake_modules/IcebergThirdpartyToolchain.cmake",
+                ),
+                extract(r"directory = googletest-([0-9.]+)", "subprojects/gtest.wrap"),
+            ),
+        }
+        mismatches = {
+            name: pair for name, pair in versions.items() if pair[0] != pair[1]
+        }
+        self.assertEqual({}, mismatches)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/iceberg/catalog/CMakeLists.txt
+++ b/src/iceberg/catalog/CMakeLists.txt
@@ -28,3 +28,5 @@ endif()
 if(ICEBERG_BUILD_SQL_CATALOG)
   add_subdirectory(sql)
 endif()
+
+iceberg_install_all_headers(iceberg/catalog)

--- a/src/iceberg/catalog/rest/auth/meson.build
+++ b/src/iceberg/catalog/rest/auth/meson.build
@@ -22,6 +22,7 @@ install_headers(
         'auth_properties.h',
         'auth_session.h',
         'oauth2_util.h',
+        'token_refresh_scheduler.h',
     ],
     subdir: 'iceberg/catalog/rest/auth',
 )

--- a/src/iceberg/meson.build
+++ b/src/iceberg/meson.build
@@ -334,6 +334,7 @@ install_headers(
         'name_mapping.h',
         'partition_field.h',
         'partition_spec.h',
+        'puffin_dv_io.h',
         'resolving_file_io.h',
         'result.h',
         'schema_field.h',

--- a/src/iceberg/test/meson.build
+++ b/src/iceberg/test/meson.build
@@ -53,6 +53,7 @@ iceberg_tests = {
             'metrics_config_test.cc',
             'metrics_reporter_test.cc',
             'metrics_test.cc',
+            'snapshot_summary_builder_test.cc',
             'snapshot_test.cc',
             'snapshot_util_test.cc',
             'table_metadata_builder_test.cc',


### PR DESCRIPTION
## Summary

- install the missing public headers in Meson and the top-level catalog headers in CMake
- include `snapshot_summary_builder_test.cc` in Meson's `table_test`
- align the CRoaring, nlohmann/json, and GoogleTest fallback versions across CMake and Meson
- add a dependency-free parity regression and run it in CI

Closes #894.

## Validation

- `python3 dev/test_build_definition_parity.py`
- `pre-commit run --files .github/workflows/test.yml cmake_modules/IcebergThirdpartyToolchain.cmake src/iceberg/catalog/CMakeLists.txt src/iceberg/catalog/rest/auth/meson.build src/iceberg/meson.build src/iceberg/test/meson.build dev/test_build_definition_parity.py`
- CMake configure with bundle/REST disabled, followed by `cmake --build build-cmake-parity --target table_test --parallel 2`
- `ctest --test-dir build-cmake-parity -R '^table_test$' --output-on-failure`
- Meson configure with REST/tests enabled, followed by `meson compile -C build-meson-parity table_test -j 2`
- `meson test -C build-meson-parity table_test --print-errorlogs`
- inspected both generated install manifests for the corrected public headers

## AI assistance disclosure

AI-assisted tooling was used for initial regression-test scaffolding and mechanical build-definition edits. I reviewed the change end-to-end, verified the dependency choices and generated manifests, and ran the validations listed above. I am not aware of remaining uncertainty in the affected build paths.
