### PR TITLE
test(io): stop probing the EC2 metadata service in S3 tests

### DIFF
--- a/src/iceberg/test/arrow_s3_file_io_test.cc
+++ b/src/iceberg/test/arrow_s3_file_io_test.cc
@@ -104,6 +104,15 @@ class ArrowS3FileIOTest : public ::testing::Test {
  protected:
 #if ICEBERG_S3_ENABLED
   static void SetUpTestSuite() {
+    // Off EC2 every S3 client build waits for this to time out. Not overwritten,
+    // so a run that does want those credentials can still ask.
+#  ifdef _WIN32
+    if (std::getenv("AWS_EC2_METADATA_DISABLED") == nullptr) {
+      _putenv_s("AWS_EC2_METADATA_DISABLED", "true");
+    }
+#  else
+    ::setenv("AWS_EC2_METADATA_DISABLED", "true", /*overwrite=*/0);
+#  endif
     auto io = MakeS3FileIO({});
     ASSERT_THAT(io, IsOk());
   }


### PR DESCRIPTION
Off EC2, every S3 client build in the test suite waits several seconds for the instance metadata probe to time out before falling back. No test in this binary wants those credentials, and the wait dominated the run: `file_io_test` goes from ~54s to 0.3s locally, in CI included.

 Set without overwriting, so a run that does want instance credentials can still export `AWS_EC2_METADATA_DISABLED=false