### PR TITLE
feat: preserve field ids when creating table metadata

### DIFF
--- a/src/iceberg/table_metadata.cc
+++ b/src/iceberg/table_metadata.cc
@@ -24,6 +24,7 @@
 #include <chrono>
 #include <cstdint>
 #include <format>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <ranges>
@@ -120,6 +121,30 @@ Result<std::shared_ptr<SortOrder>> FreshSortOrder(int32_t order_id,
                              field.direction(), field.null_order());
   }
   return SortOrder::Make(order_id, std::move(sort_fields));
+}
+
+Status ValidatePreservedFieldIds(const Schema& schema) {
+  std::unordered_set<int32_t> field_ids;
+  std::function<Status(const Type&)> validate_type = [&](const Type& type) -> Status {
+    if (!type.is_nested()) {
+      return {};
+    }
+
+    const auto& nested = internal::checked_cast<const NestedType&>(type);
+    for (const auto& field : nested.fields()) {
+      if (field.field_id() <= Schema::kInitialColumnId) {
+        return InvalidSchema("Invalid field id {} for '{}'", field.field_id(),
+                             field.name());
+      }
+      if (!field_ids.insert(field.field_id()).second) {
+        return InvalidSchema("Duplicate field id found: {}", field.field_id());
+      }
+      ICEBERG_RETURN_UNEXPECTED(validate_type(*field.type()));
+    }
+    return {};
+  };
+
+  return validate_type(schema);
 }
 
 std::vector<std::unique_ptr<TableUpdate>> ChangesForCreate(
@@ -231,6 +256,46 @@ Result<std::unique_ptr<TableMetadata>> TableMetadata::Make(
       ->AssignUUID()
       .SetLocation(location)
       .SetCurrentSchema(std::move(fresh_schema), last_column_id)
+      .SetDefaultPartitionSpec(std::move(fresh_spec))
+      .SetDefaultSortOrder(std::move(fresh_order))
+      .SetProperties(properties)
+      .Build();
+}
+
+Result<std::unique_ptr<TableMetadata>> TableMetadata::MakeWithFieldIds(
+    const iceberg::Schema& schema, const iceberg::PartitionSpec& spec,
+    const iceberg::SortOrder& sort_order, const std::string& location,
+    const std::unordered_map<std::string, std::string>& properties, int format_version) {
+  for (const auto& [key, _] : properties) {
+    if (TableProperties::reserved_properties().contains(key)) {
+      return InvalidArgument(
+          "Table properties should not contain reserved properties, but got {}", key);
+    }
+  }
+
+  ICEBERG_RETURN_UNEXPECTED(ValidatePreservedFieldIds(schema));
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto preserved_schema,
+      Schema::Make(
+          std::vector<SchemaField>(schema.fields().begin(), schema.fields().end()),
+          Schema::kInitialSchemaId, schema.IdentifierFieldIds()));
+  ICEBERG_ASSIGN_OR_RAISE(auto last_column_id, preserved_schema->HighestFieldId());
+
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto fresh_spec,
+      FreshPartitionSpec(PartitionSpec::kInitialSpecId, spec, schema, *preserved_schema));
+  ICEBERG_ASSIGN_OR_RAISE(
+      auto fresh_order, FreshSortOrder(SortOrder::kInitialSortOrderId, sort_order, schema,
+                                       *preserved_schema));
+
+  ICEBERG_RETURN_UNEXPECTED(
+      MetricsConfig::VerifyReferencedColumns(properties, *preserved_schema));
+  ICEBERG_RETURN_UNEXPECTED(PropertyUtil::ValidateCommitProperties(properties));
+
+  return TableMetadataBuilder::BuildFromEmpty(format_version)
+      ->AssignUUID()
+      .SetLocation(location)
+      .SetCurrentSchema(std::move(preserved_schema), last_column_id)
       .SetDefaultPartitionSpec(std::move(fresh_spec))
       .SetDefaultSortOrder(std::move(fresh_order))
       .SetProperties(properties)

--- a/src/iceberg/table_metadata.h
+++ b/src/iceberg/table_metadata.h
@@ -138,6 +138,17 @@ struct ICEBERG_EXPORT TableMetadata {
       const std::unordered_map<std::string, std::string>& properties,
       int format_version = kDefaultTableFormatVersion);
 
+  /// \brief Create metadata for a new table while preserving schema field IDs.
+  ///
+  /// The supplied schema field IDs must be positive and unique across the complete
+  /// schema, including nested fields. Partition field IDs are assigned by the new
+  /// table rules and are not preserved.
+  static Result<std::unique_ptr<TableMetadata>> MakeWithFieldIds(
+      const iceberg::Schema& schema, const iceberg::PartitionSpec& spec,
+      const iceberg::SortOrder& sort_order, const std::string& location,
+      const std::unordered_map<std::string, std::string>& properties,
+      int format_version = kDefaultTableFormatVersion);
+
   /// \brief Get the current schema, return NotFoundError if not found
   /// \note The returned schema is guaranteed to be not null
   Result<std::shared_ptr<iceberg::Schema>> Schema() const;

--- a/src/iceberg/test/table_metadata_builder_test.cc
+++ b/src/iceberg/test/table_metadata_builder_test.cc
@@ -154,6 +154,52 @@ TEST(TableMetadataTest, MakeWithInvalidPartitionSpec) {
   EXPECT_THAT(res, HasErrorMessage("Cannot find source partition field"));
 }
 
+TEST(TableMetadataTest, MakeWithFieldIdsPreservesSchemaIds) {
+  auto id_field = SchemaField::MakeRequired(10, "id", int32());
+  auto value_field = SchemaField::MakeRequired(20, "value", string());
+  ICEBERG_UNWRAP_OR_FAIL(
+      auto schema, Schema::Make(std::vector<SchemaField>{id_field, value_field},
+                                Schema::kInitialSchemaId, std::vector<int32_t>{10}));
+  ICEBERG_UNWRAP_OR_FAIL(
+      auto spec, PartitionSpec::Make(7, std::vector<PartitionField>{PartitionField(
+                                            20, 1007, "value", Transform::Identity())}));
+  ICEBERG_UNWRAP_OR_FAIL(
+      auto order, SortOrder::Make(9, std::vector<SortField>{SortField(
+                                         10, Transform::Identity(),
+                                         SortDirection::kAscending, NullOrder::kLast)}));
+
+  ICEBERG_UNWRAP_OR_FAIL(
+      auto metadata,
+      TableMetadata::MakeWithFieldIds(*schema, *spec, *order, "s3://bucket/test", {}));
+  ASSERT_EQ(metadata->last_column_id, 20);
+  ASSERT_EQ(metadata->schemas.size(), 1);
+  auto fields = metadata->schemas[0]->fields() | std::ranges::to<std::vector>();
+  ASSERT_EQ(fields.size(), 2);
+  EXPECT_EQ(fields[0].field_id(), 10);
+  EXPECT_EQ(fields[1].field_id(), 20);
+  EXPECT_EQ(metadata->schemas[0]->IdentifierFieldIds(), std::vector<int32_t>{10});
+
+  ASSERT_EQ(metadata->partition_specs.size(), 1);
+  auto spec_fields = metadata->partition_specs[0]->fields();
+  ASSERT_EQ(spec_fields.size(), 1);
+  EXPECT_EQ(spec_fields[0].source_id(), 20);
+  EXPECT_EQ(spec_fields[0].field_id(), PartitionSpec::kLegacyPartitionDataIdStart);
+
+  ASSERT_EQ(metadata->sort_orders.size(), 1);
+  EXPECT_EQ(metadata->sort_orders[0]->fields()[0].source_id(), 10);
+}
+
+TEST(TableMetadataTest, MakeWithFieldIdsRejectsInvalidIds) {
+  auto invalid = SchemaField::MakeRequired(0, "id", int32());
+  auto schema = std::make_shared<Schema>(std::vector<SchemaField>{invalid});
+
+  auto result =
+      TableMetadata::MakeWithFieldIds(*schema, *PartitionSpec::Unpartitioned(),
+                                      *SortOrder::Unsorted(), "s3://bucket/test", {});
+  EXPECT_THAT(result, IsError(ErrorKind::kInvalidSchema));
+  EXPECT_THAT(result, HasErrorMessage("Invalid field id"));
+}
+
 TEST(TableMetadataTest, MakeWithInvalidSortOrder) {
   ICEBERG_UNWRAP_OR_FAIL(auto schema, CreateDisorderedSchema());
   ICEBERG_UNWRAP_OR_FAIL(


### PR DESCRIPTION
### Summary
- add `TableMetadata::MakeWithFieldIds` for preserving schema field IDs
- validate positive, globally unique field IDs, including nested fields
- keep partition field IDs assigned by new-table rules
- add coverage for preserved IDs and invalid IDs

### Tests
- `cmake --build build --target table_test --parallel 4`
- `build/src/iceberg/test/table_test --gtest_filter='TableMetadataTest.MakeWithFieldIds*'`
- all 18 CTest suites passed