### PR TITLE
feat(hive): add Iceberg-to-HMS schema and record conversion helpers

### DIFF
--- a/src/iceberg/catalog/hive/CMakeLists.txt
+++ b/src/iceberg/catalog/hive/CMakeLists.txt
@@ -54,8 +54,12 @@ if(NOT TARGET thrift::thrift)
                       "-DICEBERG_BUNDLE_THRIFT=OFF against a system Thrift install.")
 endif()
 
-set(ICEBERG_HIVE_SOURCES hive_catalog.cc hive_catalog_properties.cc hms_client.cc
-                         ${ICEBERG_HIVE_THRIFT_GEN_SOURCES})
+set(ICEBERG_HIVE_SOURCES
+    hive_catalog.cc
+    hive_catalog_properties.cc
+    hive_schema.cc
+    hms_client.cc
+    ${ICEBERG_HIVE_THRIFT_GEN_SOURCES})
 
 set(ICEBERG_HIVE_STATIC_BUILD_INTERFACE_LIBS)
 set(ICEBERG_HIVE_SHARED_BUILD_INTERFACE_LIBS)

--- a/src/iceberg/catalog/hive/CMakeLists.txt
+++ b/src/iceberg/catalog/hive/CMakeLists.txt
@@ -58,6 +58,7 @@ set(ICEBERG_HIVE_SOURCES
     hive_catalog.cc
     hive_catalog_properties.cc
     hive_schema.cc
+    hive_utils.cc
     hms_client.cc
     ${ICEBERG_HIVE_THRIFT_GEN_SOURCES})
 

--- a/src/iceberg/catalog/hive/hive_schema.cc
+++ b/src/iceberg/catalog/hive/hive_schema.cc
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/catalog/hive/hive_schema.h"
+
+#include <format>
+#include <string>
+#include <vector>
+
+#include "iceberg/schema.h"
+#include "iceberg/schema_field.h"
+#include "iceberg/type.h"
+#include "iceberg/util/checked_cast.h"
+#include "iceberg/util/macros.h"
+
+namespace iceberg::hive {
+
+namespace {
+
+// Hive doesn't have a precise counterpart to every Iceberg primitive
+// type; the closest equivalent is chosen for each case below. Mapping
+// matches iceberg-rust's `HiveSchemaBuilder::primitive`.
+Result<std::string> PrimitiveToHive(const Type& type) {
+  switch (type.type_id()) {
+    case TypeId::kBoolean:
+      return std::string("boolean");
+    case TypeId::kInt:
+      return std::string("int");
+    case TypeId::kLong:
+      return std::string("bigint");
+    case TypeId::kFloat:
+      return std::string("float");
+    case TypeId::kDouble:
+      return std::string("double");
+    case TypeId::kDate:
+      return std::string("date");
+    case TypeId::kTimestamp:
+      return std::string("timestamp");
+    case TypeId::kTimestampTz:
+      // Hive's TIMESTAMPLOCALTZ, the spelling iceberg-java emits on
+      // Hive 3+. Engines reading through HMS must see the tz-adjusted
+      // type, otherwise they read an Iceberg timestamptz column as a
+      // naive timestamp. See the header for why the Hive 2 fallback is
+      // not reproduced.
+      return std::string("timestamp with local time zone");
+    case TypeId::kTime:
+    case TypeId::kString:
+    case TypeId::kUuid:
+      return std::string("string");
+    case TypeId::kBinary:
+    case TypeId::kFixed:
+      return std::string("binary");
+    case TypeId::kDecimal: {
+      const auto& decimal = internal::checked_cast<const DecimalType&>(type);
+      return std::format("decimal({},{})", decimal.precision(), decimal.scale());
+    }
+    default:
+      return NotImplemented("Unhandled primitive Iceberg type id: {}",
+                            static_cast<int>(type.type_id()));
+  }
+}
+
+Result<std::string> StructToHive(const StructType& type) {
+  std::string out = "struct<";
+  bool first = true;
+  for (const auto& field : type.fields()) {
+    if (!first) {
+      out += ",";
+    }
+    ICEBERG_ASSIGN_OR_RAISE(auto field_type, TypeToHiveString(*field.type()));
+    out += std::string(field.name());
+    out += ":";
+    out += field_type;
+    first = false;
+  }
+  out += ">";
+  return out;
+}
+
+Result<std::string> ListToHive(const ListType& type) {
+  ICEBERG_ASSIGN_OR_RAISE(auto inner, TypeToHiveString(*type.element().type()));
+  return std::format("array<{}>", inner);
+}
+
+Result<std::string> MapToHive(const MapType& type) {
+  ICEBERG_ASSIGN_OR_RAISE(auto key_type, TypeToHiveString(*type.key().type()));
+  ICEBERG_ASSIGN_OR_RAISE(auto value_type, TypeToHiveString(*type.value().type()));
+  return std::format("map<{},{}>", key_type, value_type);
+}
+
+}  // namespace
+
+Result<std::string> TypeToHiveString(const Type& type) {
+  switch (type.type_id()) {
+    case TypeId::kStruct:
+      return StructToHive(internal::checked_cast<const StructType&>(type));
+    case TypeId::kList:
+      return ListToHive(internal::checked_cast<const ListType&>(type));
+    case TypeId::kMap:
+      return MapToHive(internal::checked_cast<const MapType&>(type));
+    default:
+      return PrimitiveToHive(type);
+  }
+}
+
+Result<std::vector<HiveColumn>> SchemaToHiveColumns(const Schema& schema) {
+  std::vector<HiveColumn> columns;
+  columns.reserve(schema.fields().size());
+  for (const auto& field : schema.fields()) {
+    ICEBERG_ASSIGN_OR_RAISE(auto type_string, TypeToHiveString(*field.type()));
+    columns.push_back(HiveColumn{.name = std::string(field.name()),
+                                 .type_string = std::move(type_string),
+                                 .comment = std::string(field.doc())});
+  }
+  return columns;
+}
+
+}  // namespace iceberg::hive

--- a/src/iceberg/catalog/hive/hive_schema.h
+++ b/src/iceberg/catalog/hive/hive_schema.h
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "iceberg/catalog/hive/iceberg_hive_export.h"
+#include "iceberg/result.h"
+#include "iceberg/type_fwd.h"
+
+/// \file iceberg/catalog/hive/hive_schema.h
+/// \brief Convert an Iceberg `Schema` (or any nested `Type`) into the
+///        Hive DDL representation that HMS expects on FieldSchema.type.
+///
+/// The conversion is the C++ port of iceberg-rust's `HiveSchemaBuilder`
+/// (`crates/catalog/hms/src/schema.rs`) and mirrors Java's
+/// `HiveSchemaUtil` for the subset of types Hive can represent.
+
+namespace iceberg::hive {
+
+/// \brief A column entry for Hive's HMS table schema.
+///
+/// HiveCatalog converts each top-level Iceberg `SchemaField` into one of
+/// these, then HmsClient further wraps them into Thrift `FieldSchema`
+/// records before passing to `create_table` / `alter_table`. Nested
+/// types are flattened into the `type_string` field via DDL syntax
+/// (e.g. `"struct<a:int,b:string>"`, `"array<int>"`, `"map<string,int>"`).
+struct ICEBERG_HIVE_EXPORT HiveColumn {
+  std::string name;
+  std::string type_string;
+  std::string comment;
+};
+
+/// \brief Render an Iceberg `Type` as a Hive DDL type string.
+///
+/// Supported primitive mappings (matching iceberg-rust):
+///   boolean -> boolean
+///   int     -> int
+///   long    -> bigint
+///   float   -> float
+///   double  -> double
+///   date                 -> date
+///   timestamp            -> timestamp
+///   timestamptz          -> timestamp with local time zone
+///   time / string / uuid -> string
+///   binary / fixed       -> binary
+///   decimal(p, s)        -> decimal(p,s)
+///   struct<...>          -> struct<f:t,...>
+///   list<T>              -> array<T>
+///   map<K, V>            -> map<K,V>
+///
+/// `timestamptz` follows iceberg-java, which emits Hive's
+/// `timestamp with local time zone` (TIMESTAMPLOCALTZ). Engines that
+/// read the table through HMS -- Hive, Spark, Trino -- take their
+/// column types from this DDL, so downgrading to a naive `timestamp`
+/// would silently misrepresent a tz-adjusted column to every one of
+/// them. iceberg-rust instead rejects zoned timestamps outright, which
+/// would make such tables uncreatable; that behaviour is not copied.
+///
+/// Java picks the spelling at runtime and falls back to plain
+/// `timestamp` below Hive 3, where TIMESTAMPLOCALTZ does not exist.
+/// That fallback is not reproduced: iceberg-cpp has no Hive-version
+/// probe, the vendored Metastore IDL is Hive 4.0.1, and Hive 2 has been
+/// end-of-life since 2019.
+ICEBERG_HIVE_EXPORT Result<std::string> TypeToHiveString(const Type& type);
+
+/// \brief Convert each top-level field in `schema` to a `HiveColumn`.
+///
+/// `optional` is intentionally not surfaced — HMS treats every column
+/// as nullable. Iceberg `doc` is copied into `comment` so DESCRIBE
+/// statements in Hive show the column documentation.
+ICEBERG_HIVE_EXPORT Result<std::vector<HiveColumn>> SchemaToHiveColumns(
+    const Schema& schema);
+
+}  // namespace iceberg::hive

--- a/src/iceberg/catalog/hive/hive_utils.cc
+++ b/src/iceberg/catalog/hive/hive_utils.cc
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/catalog/hive/hive_utils.h"
+
+#include <algorithm>
+#include <array>
+#include <format>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "iceberg/util/macros.h"
+#include "iceberg/util/string_util.h"
+
+namespace iceberg::hive {
+
+namespace {
+
+// Keys lifted into dedicated `Database` fields, so they must not be
+// duplicated into `parameters`.
+constexpr std::array<std::string_view, 4> kDatabaseReservedKeys = {
+    kCommentProperty, kLocationProperty, kHmsDbOwnerProperty, kHmsDbOwnerTypeProperty};
+
+// The table equivalent: `location` and `owner` have dedicated `Table`
+// fields, and `comment` is not part of the Iceberg-on-HMS contract.
+constexpr std::array<std::string_view, 3> kTableReservedKeys = {
+    kCommentProperty, kLocationProperty, kOwnerProperty};
+
+// HMS `PrincipalType` names accepted for a database owner.
+constexpr std::array<std::string_view, 3> kPrincipalTypes = {"USER", "GROUP", "ROLE"};
+
+bool IsDatabaseReservedKey(std::string_view key) {
+  return std::ranges::find(kDatabaseReservedKeys, key) != kDatabaseReservedKeys.end();
+}
+
+bool IsTableReservedKey(std::string_view key) {
+  return std::ranges::find(kTableReservedKeys, key) != kTableReservedKeys.end();
+}
+
+std::string GetOrEmpty(const std::unordered_map<std::string, std::string>& properties,
+                       std::string_view key) {
+  auto it = properties.find(std::string(key));
+  return it == properties.end() ? std::string() : it->second;
+}
+
+std::string TrimTrailingSlash(std::string_view path) {
+  while (path.size() > 1 && path.back() == '/') {
+    path.remove_suffix(1);
+  }
+  return std::string(path);
+}
+
+}  // namespace
+
+Status ValidateNamespace(const Namespace& ns) {
+  if (ns.levels.size() != 1) {
+    return InvalidArgument(
+        "Hive Metastore only supports single-level namespaces; got {} level(s).",
+        ns.levels.size());
+  }
+  if (ns.levels[0].empty()) {
+    return InvalidArgument("Hive namespace cannot have an empty name.");
+  }
+  return {};
+}
+
+Status ValidateOwnerSettings(
+    const std::unordered_map<std::string, std::string>& properties) {
+  auto owner_type = properties.find(std::string(kHmsDbOwnerTypeProperty));
+  if (owner_type == properties.end()) {
+    return {};
+  }
+  if (!properties.contains(std::string(kHmsDbOwnerProperty))) {
+    return InvalidArgument("Hive namespace property '{}' requires '{}' to also be set.",
+                           kHmsDbOwnerTypeProperty, kHmsDbOwnerProperty);
+  }
+  const bool known = std::ranges::any_of(kPrincipalTypes, [&](std::string_view name) {
+    return StringUtils::EqualsIgnoreCase(owner_type->second, name);
+  });
+  if (!known) {
+    return InvalidArgument(
+        "Hive namespace property '{}' has value '{}'; expected one of "
+        "USER, GROUP or ROLE.",
+        kHmsDbOwnerTypeProperty, owner_type->second);
+  }
+  return {};
+}
+
+Result<HiveDatabase> ConvertToHiveDatabase(
+    const Namespace& ns, const std::unordered_map<std::string, std::string>& properties) {
+  ICEBERG_RETURN_UNEXPECTED(ValidateNamespace(ns));
+  ICEBERG_RETURN_UNEXPECTED(ValidateOwnerSettings(properties));
+
+  HiveDatabase database;
+  database.name = ns.levels[0];
+  database.description = GetOrEmpty(properties, kCommentProperty);
+  database.location_uri = GetOrEmpty(properties, kLocationProperty);
+  database.owner_name = GetOrEmpty(properties, kHmsDbOwnerProperty);
+  database.owner_type = GetOrEmpty(properties, kHmsDbOwnerTypeProperty);
+
+  for (const auto& [key, value] : properties) {
+    if (!IsDatabaseReservedKey(key)) {
+      database.parameters.emplace(key, value);
+    }
+  }
+  return database;
+}
+
+HiveNamespace ConvertFromHiveDatabase(const HiveDatabase& database) {
+  HiveNamespace result;
+  result.ns.levels = {database.name};
+  result.properties = database.parameters;
+  if (!database.description.empty()) {
+    result.properties[std::string(kCommentProperty)] = database.description;
+  }
+  if (!database.location_uri.empty()) {
+    result.properties[std::string(kLocationProperty)] = database.location_uri;
+  }
+  if (!database.owner_name.empty()) {
+    result.properties[std::string(kHmsDbOwnerProperty)] = database.owner_name;
+  }
+  if (!database.owner_type.empty()) {
+    result.properties[std::string(kHmsDbOwnerTypeProperty)] = database.owner_type;
+  }
+  return result;
+}
+
+Result<HiveTable> ConvertToHiveTable(
+    const TableIdentifier& identifier, const std::vector<HiveColumn>& columns,
+    std::string_view metadata_location, std::string_view location,
+    const std::unordered_map<std::string, std::string>& table_properties) {
+  ICEBERG_RETURN_UNEXPECTED(ValidateNamespace(identifier.ns));
+  ICEBERG_RETURN_UNEXPECTED(identifier.Validate());
+
+  HiveTable table;
+  table.db_name = identifier.ns.levels[0];
+  table.table_name = identifier.name;
+  table.owner = GetOrEmpty(table_properties, kOwnerProperty);
+  table.table_type = "EXTERNAL_TABLE";
+  table.location = std::string(location);
+  table.columns = columns;
+  table.serde = std::string(kLazySimpleSerDe);
+  table.input_format = std::string(kFileInputFormat);
+  table.output_format = std::string(kFileOutputFormat);
+
+  // Mandatory Iceberg-on-HMS marker parameters.
+  table.parameters.emplace(std::string(kMetadataLocationKey), metadata_location);
+  table.parameters.emplace(std::string(kTableTypeKey), std::string(kTableTypeIceberg));
+  table.parameters.emplace(std::string(kExternalKey), std::string(kExternalTrue));
+
+  // Forward any user-supplied table properties that aren't reserved.
+  for (const auto& [key, value] : table_properties) {
+    if (!IsTableReservedKey(key) && !table.parameters.contains(key)) {
+      table.parameters.emplace(key, value);
+    }
+  }
+  return table;
+}
+
+Result<std::string> GetMetadataLocation(
+    const std::unordered_map<std::string, std::string>& table_parameters) {
+  auto it = table_parameters.find(std::string(kMetadataLocationKey));
+  if (it == table_parameters.end() || it->second.empty()) {
+    return NotFound("HMS table is missing '{}' parameter; not an Iceberg table.",
+                    kMetadataLocationKey);
+  }
+  return it->second;
+}
+
+Status ValidateIcebergTable(
+    const TableIdentifier& identifier,
+    const std::unordered_map<std::string, std::string>& table_parameters) {
+  auto it = table_parameters.find(std::string(kTableTypeKey));
+  if (it == table_parameters.end() || it->second.empty()) {
+    return NoSuchTable(
+        "HMS table {} has no '{}' parameter; refusing to treat it as an Iceberg table.",
+        identifier.ToString(), kTableTypeKey);
+  }
+  if (!StringUtils::EqualsIgnoreCase(it->second, kTableTypeIceberg)) {
+    return NoSuchTable("HMS table {} has '{}={}'; expected '{}' (case-insensitive).",
+                       identifier.ToString(), kTableTypeKey, it->second,
+                       kTableTypeIceberg);
+  }
+  return {};
+}
+
+std::string GetDefaultTableLocation(std::string_view warehouse, const Namespace& ns,
+                                    std::string_view table_name) {
+  std::string base = TrimTrailingSlash(warehouse);
+  std::string ns_part;
+  for (std::size_t i = 0; i < ns.levels.size(); ++i) {
+    if (i > 0) {
+      ns_part += ".";
+    }
+    ns_part += ns.levels[i];
+  }
+  return std::format("{}/{}.db/{}", base, ns_part, table_name);
+}
+
+}  // namespace iceberg::hive

--- a/src/iceberg/catalog/hive/hive_utils.h
+++ b/src/iceberg/catalog/hive/hive_utils.h
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "iceberg/catalog/hive/hive_schema.h"
+#include "iceberg/catalog/hive/iceberg_hive_export.h"
+#include "iceberg/result.h"
+#include "iceberg/table_identifier.h"
+
+/// \file iceberg/catalog/hive/hive_utils.h
+/// \brief Conversion helpers between Iceberg's catalog model
+///        (Namespace, TableIdentifier, Schema) and the Hive Metastore
+///        record shape that HmsClient expects on the wire.
+///
+/// These helpers deliberately produce plain C++ structs rather than
+/// Thrift `Database` / `Table` instances so that the public iceberg_hive
+/// API stays free of Thrift includes. HmsClient is the only translation
+/// unit that converts these structs into Thrift requests.
+
+namespace iceberg::hive {
+
+/// \brief Iceberg table parameter keys recognised by both
+///        iceberg-java's HiveCatalog and iceberg-rust's HmsCatalog.
+inline constexpr std::string_view kMetadataLocationKey = "metadata_location";
+inline constexpr std::string_view kTableTypeKey = "table_type";
+inline constexpr std::string_view kTableTypeIceberg = "ICEBERG";
+inline constexpr std::string_view kExternalKey = "EXTERNAL";
+inline constexpr std::string_view kExternalTrue = "TRUE";
+
+/// \brief Iceberg namespace / table property keys used during conversion.
+inline constexpr std::string_view kCommentProperty = "comment";
+inline constexpr std::string_view kLocationProperty = "location";
+
+/// \brief HMS table owner property key.
+inline constexpr std::string_view kOwnerProperty = "owner";
+
+/// \brief HMS *database* owner property keys.
+///
+/// Both iceberg-java's `HiveCatalog` and iceberg-rust's `HmsCatalog`
+/// namespace these, so a bare `owner` set on a namespace stays an
+/// ordinary Hive parameter and only the qualified key reaches the
+/// `Database.ownerName` / `Database.ownerType` fields.
+inline constexpr std::string_view kHmsDbOwnerProperty = "hive.metastore.database.owner";
+inline constexpr std::string_view kHmsDbOwnerTypeProperty =
+    "hive.metastore.database.owner-type";
+
+/// \brief Hive storage descriptor values written into table parameters.
+///        These match what Spark/Trino expect to find on Iceberg-backed
+///        Hive tables, so cross-engine reads keep working.
+inline constexpr std::string_view kLazySimpleSerDe =
+    "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe";
+inline constexpr std::string_view kFileInputFormat =
+    "org.apache.hadoop.mapred.FileInputFormat";
+inline constexpr std::string_view kFileOutputFormat =
+    "org.apache.hadoop.mapred.FileOutputFormat";
+
+/// \brief Plain mirror of the Hive Metastore `Database` record fields
+///        that iceberg_hive needs to construct or read.
+struct ICEBERG_HIVE_EXPORT HiveDatabase {
+  std::string name;
+  std::string description;
+  std::string location_uri;
+  std::unordered_map<std::string, std::string> parameters;
+  std::string owner_name;
+  std::string owner_type;  // "USER", "GROUP" or "ROLE"; empty means HMS-default
+};
+
+/// \brief Plain mirror of the Hive Metastore `Table` record fields
+///        that iceberg_hive cares about. HmsClient maps it to Thrift.
+struct ICEBERG_HIVE_EXPORT HiveTable {
+  std::string db_name;
+  std::string table_name;
+  std::string owner;
+  std::string table_type;  // "EXTERNAL_TABLE" for Iceberg tables
+  std::string location;
+  std::vector<HiveColumn> columns;
+  std::unordered_map<std::string, std::string> parameters;
+  std::string serde;
+  std::string input_format;
+  std::string output_format;
+};
+
+/// \brief Result of converting a `HiveDatabase` back to Iceberg's model.
+struct ICEBERG_HIVE_EXPORT HiveNamespace {
+  Namespace ns;
+  std::unordered_map<std::string, std::string> properties;
+};
+
+/// \brief Build the `HiveDatabase` that represents `ns` together with
+///        `properties`. Reserved Iceberg property keys (`comment`,
+///        `location`, `hive.metastore.database.owner`,
+///        `hive.metastore.database.owner-type`) are lifted into dedicated
+///        Hive fields; everything else becomes an entry in
+///        `parameters`.
+///
+/// Returns `kInvalidArgument` when the namespace has more than one
+/// level (HMS only supports flat namespaces) or when the owner
+/// settings are inconsistent (see `ValidateOwnerSettings`).
+ICEBERG_HIVE_EXPORT Result<HiveDatabase> ConvertToHiveDatabase(
+    const Namespace& ns, const std::unordered_map<std::string, std::string>& properties);
+
+/// \brief Inverse of `ConvertToHiveDatabase`: split a `HiveDatabase`
+///        into the Iceberg namespace plus the property map a caller
+///        of `GetNamespaceProperties` would see.
+ICEBERG_HIVE_EXPORT HiveNamespace ConvertFromHiveDatabase(const HiveDatabase& database);
+
+/// \brief Assemble the `HiveTable` describing an Iceberg table backed
+///        by a metadata file at `metadata_location`. Sets the standard
+///        Iceberg table parameters (`table_type=ICEBERG`,
+///        `EXTERNAL=TRUE`, `metadata_location`) plus a `LazySimpleSerDe`
+///        storage descriptor so Spark / Trino can read the table.
+///
+/// `location` is the table's filesystem root (typically
+/// `<warehouse>/<ns>.db/<table>`); see `GetDefaultTableLocation`.
+ICEBERG_HIVE_EXPORT Result<HiveTable> ConvertToHiveTable(
+    const TableIdentifier& identifier, const std::vector<HiveColumn>& columns,
+    std::string_view metadata_location, std::string_view location,
+    const std::unordered_map<std::string, std::string>& table_properties);
+
+/// \brief Extract the `metadata_location` parameter from a HMS Table
+///        parameter map. Returns `kNotFound` if absent (the table is
+///        not an Iceberg table).
+ICEBERG_HIVE_EXPORT Result<std::string> GetMetadataLocation(
+    const std::unordered_map<std::string, std::string>& table_parameters);
+
+/// \brief Validate that a HMS Table parameter map represents an Iceberg
+///        table by checking `table_type == "ICEBERG"` (case-insensitive).
+///        Returns `kNoSuchTable` when the parameter is absent or holds
+///        any other value, matching the guard Java's
+///        `BaseMetastoreTableOperations.refresh()` applies before reading
+///        `metadata_location`.
+ICEBERG_HIVE_EXPORT Status ValidateIcebergTable(
+    const TableIdentifier& identifier,
+    const std::unordered_map<std::string, std::string>& table_parameters);
+
+/// \brief Compute a default table location under `warehouse`. The
+///        layout matches what iceberg-java and iceberg-rust pick:
+///        `<warehouse>/<ns_with_dots>.db/<table_name>`.
+ICEBERG_HIVE_EXPORT std::string GetDefaultTableLocation(std::string_view warehouse,
+                                                        const Namespace& ns,
+                                                        std::string_view table_name);
+
+/// \brief Enforce that `ns` is a single-level namespace (HMS only
+///        supports flat databases).
+ICEBERG_HIVE_EXPORT Status ValidateNamespace(const Namespace& ns);
+
+/// \brief Enforce the owner invariants shared with iceberg-java and
+///        iceberg-rust: `hive.metastore.database.owner-type` requires
+///        `hive.metastore.database.owner`, and its value must be one of
+///        HMS's `PrincipalType` names -- USER, GROUP or ROLE, compared
+///        case-insensitively.
+ICEBERG_HIVE_EXPORT Status
+ValidateOwnerSettings(const std::unordered_map<std::string, std::string>& properties);
+
+}  // namespace iceberg::hive

--- a/src/iceberg/test/CMakeLists.txt
+++ b/src/iceberg/test/CMakeLists.txt
@@ -354,5 +354,5 @@ if(ICEBERG_BUILD_HIVE)
     add_test(NAME ${test_name} COMMAND ${test_name})
   endfunction()
 
-  add_hive_iceberg_test(hive_catalog_test SOURCES hms_client_test.cc)
+  add_hive_iceberg_test(hive_catalog_test SOURCES hive_schema_test.cc hms_client_test.cc)
 endif()

--- a/src/iceberg/test/CMakeLists.txt
+++ b/src/iceberg/test/CMakeLists.txt
@@ -354,5 +354,9 @@ if(ICEBERG_BUILD_HIVE)
     add_test(NAME ${test_name} COMMAND ${test_name})
   endfunction()
 
-  add_hive_iceberg_test(hive_catalog_test SOURCES hive_schema_test.cc hms_client_test.cc)
+  add_hive_iceberg_test(hive_catalog_test
+                        SOURCES
+                        hive_schema_test.cc
+                        hive_utils_test.cc
+                        hms_client_test.cc)
 endif()

--- a/src/iceberg/test/hive_schema_test.cc
+++ b/src/iceberg/test/hive_schema_test.cc
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/catalog/hive/hive_schema.h"
+
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "iceberg/schema.h"
+#include "iceberg/schema_field.h"
+#include "iceberg/type.h"
+
+namespace iceberg::hive {
+
+namespace {
+
+// Convenience: convert a primitive Iceberg type to its Hive DDL string,
+// asserting success.
+std::string ToHive(const std::shared_ptr<Type>& type) {
+  auto result = TypeToHiveString(*type);
+  EXPECT_TRUE(result.has_value())
+      << "TypeToHiveString failed: " << (result ? "" : result.error().message);
+  return result.value_or("");
+}
+
+}  // namespace
+
+TEST(TypeToHiveStringTest, PrimitivesMapToHiveScalarTypes) {
+  EXPECT_EQ(ToHive(boolean()), "boolean");
+  EXPECT_EQ(ToHive(int32()), "int");
+  EXPECT_EQ(ToHive(int64()), "bigint");
+  EXPECT_EQ(ToHive(float32()), "float");
+  EXPECT_EQ(ToHive(float64()), "double");
+  EXPECT_EQ(ToHive(date()), "date");
+  EXPECT_EQ(ToHive(timestamp()), "timestamp");
+}
+
+TEST(TypeToHiveStringTest, TimeStringUuidAllMapToString) {
+  EXPECT_EQ(ToHive(time()), "string");
+  EXPECT_EQ(ToHive(string()), "string");
+  EXPECT_EQ(ToHive(uuid()), "string");
+}
+
+TEST(TypeToHiveStringTest, BinaryAndFixedMapToBinary) {
+  EXPECT_EQ(ToHive(binary()), "binary");
+  EXPECT_EQ(ToHive(fixed(16)), "binary");
+}
+
+TEST(TypeToHiveStringTest, DecimalIncludesPrecisionAndScale) {
+  EXPECT_EQ(ToHive(decimal(10, 2)), "decimal(10,2)");
+  EXPECT_EQ(ToHive(decimal(38, 9)), "decimal(38,9)");
+}
+
+TEST(TypeToHiveStringTest, TimestampTzMapsToTimestampWithLocalTimeZone) {
+  // Hive's TIMESTAMPLOCALTZ, matching what iceberg-java emits on Hive 3+.
+  // A plain `timestamp` here would make every engine reading through HMS
+  // see a tz-adjusted column as naive.
+  EXPECT_EQ(ToHive(timestamp_tz()), "timestamp with local time zone");
+}
+
+TEST(TypeToHiveStringTest, StructFlattensFieldList) {
+  StructType struct_type(
+      {SchemaField(1, "a", int32(), true), SchemaField(2, "b", string(), true)});
+  auto result = TypeToHiveString(struct_type);
+  ASSERT_TRUE(result.has_value()) << result.error().message;
+  EXPECT_EQ(*result, "struct<a:int,b:string>");
+}
+
+TEST(TypeToHiveStringTest, ListWrapsElement) {
+  ListType list_type(1, int32(), true);
+  auto result = TypeToHiveString(list_type);
+  ASSERT_TRUE(result.has_value()) << result.error().message;
+  EXPECT_EQ(*result, "array<int>");
+}
+
+TEST(TypeToHiveStringTest, MapEmitsKeyAndValue) {
+  MapType map_type(SchemaField(1, "key", string(), false),
+                   SchemaField(2, "value", int32(), true));
+  auto result = TypeToHiveString(map_type);
+  ASSERT_TRUE(result.has_value()) << result.error().message;
+  EXPECT_EQ(*result, "map<string,int>");
+}
+
+TEST(TypeToHiveStringTest, NestedMapInsideMap) {
+  // map<string, map<string, int>>
+  auto inner_map = std::make_shared<MapType>(SchemaField(3, "key", string(), false),
+                                             SchemaField(4, "value", int32(), true));
+  MapType outer_map(SchemaField(1, "key", string(), false),
+                    SchemaField(2, "value", inner_map, true));
+  auto result = TypeToHiveString(outer_map);
+  ASSERT_TRUE(result.has_value()) << result.error().message;
+  EXPECT_EQ(*result, "map<string,map<string,int>>");
+}
+
+TEST(TypeToHiveStringTest, StructInsideListEmitsArrayOfStruct) {
+  auto struct_type = std::make_shared<StructType>(std::vector<SchemaField>{
+      SchemaField(2, "name", string(), true), SchemaField(3, "age", int32(), true)});
+  ListType list_type(SchemaField(1, "element", struct_type, true));
+  auto result = TypeToHiveString(list_type);
+  ASSERT_TRUE(result.has_value()) << result.error().message;
+  EXPECT_EQ(*result, "array<struct<name:string,age:int>>");
+}
+
+TEST(TypeToHiveStringTest, NestedTimestampTzKeepsTheMultiWordTypeName) {
+  // The Hive type name contains spaces, and it stays spelled out inside a
+  // nested type. Java composes struct fields the same way -- via Hive's
+  // own TypeInfo round-trip -- so Hive's type parser accepts this form.
+  StructType struct_type(
+      {SchemaField(1, "a", int32(), true), SchemaField(2, "b", timestamp_tz(), true)});
+  auto result = TypeToHiveString(struct_type);
+  ASSERT_TRUE(result.has_value()) << result.error().message;
+  EXPECT_EQ(*result, "struct<a:int,b:timestamp with local time zone>");
+}
+
+TEST(SchemaToHiveColumnsTest, FlatSchemaProducesOneColumnPerField) {
+  Schema schema(
+      {SchemaField(1, "id", int64(), true), SchemaField(2, "name", string(), true)},
+      /*schema_id=*/100);
+
+  auto columns = SchemaToHiveColumns(schema);
+  ASSERT_TRUE(columns.has_value()) << columns.error().message;
+  ASSERT_EQ(columns->size(), 2);
+
+  EXPECT_EQ((*columns)[0].name, "id");
+  EXPECT_EQ((*columns)[0].type_string, "bigint");
+  EXPECT_TRUE((*columns)[0].comment.empty());
+
+  EXPECT_EQ((*columns)[1].name, "name");
+  EXPECT_EQ((*columns)[1].type_string, "string");
+}
+
+TEST(SchemaToHiveColumnsTest, NestedFieldRendersAsFlattenedTypeString) {
+  auto address = std::make_shared<StructType>(std::vector<SchemaField>{
+      SchemaField(10, "street", string(), true), SchemaField(11, "zip", int32(), true)});
+  Schema schema(
+      {SchemaField(1, "id", int64(), true), SchemaField(2, "address", address, true)},
+      /*schema_id=*/200);
+
+  auto columns = SchemaToHiveColumns(schema);
+  ASSERT_TRUE(columns.has_value()) << columns.error().message;
+  ASSERT_EQ(columns->size(), 2);
+  EXPECT_EQ((*columns)[1].name, "address");
+  EXPECT_EQ((*columns)[1].type_string, "struct<street:string,zip:int>");
+}
+
+TEST(SchemaToHiveColumnsTest, FieldDocBecomesColumnComment) {
+  SchemaField id_field(1, "id", int64(), true, "Synthetic primary key.");
+  Schema schema({std::move(id_field)}, /*schema_id=*/1);
+
+  auto columns = SchemaToHiveColumns(schema);
+  ASSERT_TRUE(columns.has_value()) << columns.error().message;
+  ASSERT_EQ(columns->size(), 1);
+  EXPECT_EQ((*columns)[0].comment, "Synthetic primary key.");
+}
+
+TEST(SchemaToHiveColumnsTest, TimestampTzColumnIsTzAdjustedInTheDdl) {
+  // Distinguishing the two timestamp types is the whole point: a schema
+  // carrying both must not collapse them onto the same Hive type.
+  Schema schema({SchemaField(1, "ts", timestamp_tz(), true),
+                 SchemaField(2, "naive", timestamp(), true)},
+                /*schema_id=*/1);
+  auto columns = SchemaToHiveColumns(schema);
+  ASSERT_TRUE(columns.has_value()) << columns.error().message;
+  ASSERT_EQ(columns->size(), 2);
+  EXPECT_EQ((*columns)[0].name, "ts");
+  EXPECT_EQ((*columns)[0].type_string, "timestamp with local time zone");
+  EXPECT_EQ((*columns)[1].name, "naive");
+  EXPECT_EQ((*columns)[1].type_string, "timestamp");
+}
+
+}  // namespace iceberg::hive

--- a/src/iceberg/test/hive_utils_test.cc
+++ b/src/iceberg/test/hive_utils_test.cc
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "iceberg/catalog/hive/hive_utils.h"
+
+#include <gtest/gtest.h>
+
+namespace iceberg::hive {
+
+TEST(ValidateNamespaceTest, SingleLevelAccepted) {
+  EXPECT_TRUE(ValidateNamespace(Namespace{{"warehouse"}}).has_value());
+}
+
+TEST(ValidateNamespaceTest, MultiLevelRejected) {
+  auto status = ValidateNamespace(Namespace{{"a", "b"}});
+  ASSERT_FALSE(status.has_value());
+  EXPECT_EQ(status.error().kind, ErrorKind::kInvalidArgument);
+}
+
+TEST(ValidateNamespaceTest, EmptyLevelRejected) {
+  auto status = ValidateNamespace(Namespace{{""}});
+  ASSERT_FALSE(status.has_value());
+  EXPECT_EQ(status.error().kind, ErrorKind::kInvalidArgument);
+}
+
+TEST(ValidateOwnerSettingsTest, OwnerTypeRequiresOwner) {
+  auto status = ValidateOwnerSettings({{"hive.metastore.database.owner-type", "USER"}});
+  ASSERT_FALSE(status.has_value());
+  EXPECT_EQ(status.error().kind, ErrorKind::kInvalidArgument);
+}
+
+TEST(ValidateOwnerSettingsTest, OwnerOrOwnerPlusTypeAreOk) {
+  EXPECT_TRUE(
+      ValidateOwnerSettings({{"hive.metastore.database.owner", "alice"}}).has_value());
+  EXPECT_TRUE(ValidateOwnerSettings({{"hive.metastore.database.owner", "alice"},
+                                     {"hive.metastore.database.owner-type", "role"}})
+                  .has_value());
+  EXPECT_TRUE(ValidateOwnerSettings({}).has_value());
+}
+
+TEST(ValidateOwnerSettingsTest, UnknownOwnerTypeRejected) {
+  auto status = ValidateOwnerSettings({{"hive.metastore.database.owner", "alice"},
+                                       {"hive.metastore.database.owner-type", "ADMIN"}});
+  ASSERT_FALSE(status.has_value());
+  EXPECT_EQ(status.error().kind, ErrorKind::kInvalidArgument);
+}
+
+TEST(ValidateOwnerSettingsTest, BareOwnerKeysAreOrdinaryProperties) {
+  // Only the `hive.metastore.database.*` keys drive Database.ownerName /
+  // ownerType, matching iceberg-java and iceberg-rust. A bare `owner-type`
+  // is just a namespace property and needs no matching `owner`.
+  EXPECT_TRUE(ValidateOwnerSettings({{"owner-type", "nonsense"}}).has_value());
+}
+
+TEST(ConvertToHiveDatabaseTest, LiftsReservedKeysIntoDedicatedFields) {
+  auto db = ConvertToHiveDatabase(Namespace{{"warehouse"}},
+                                  {{"comment", "primary db"},
+                                   {"location", "s3://bucket/wh/"},
+                                   {"hive.metastore.database.owner", "alice"},
+                                   {"hive.metastore.database.owner-"
+                                    "type",
+                                    "USER"},
+                                   {"custom-prop", "value"}});
+  ASSERT_TRUE(db.has_value()) << db.error().message;
+  EXPECT_EQ(db->name, "warehouse");
+  EXPECT_EQ(db->description, "primary db");
+  EXPECT_EQ(db->location_uri, "s3://bucket/wh/");
+  EXPECT_EQ(db->owner_name, "alice");
+  EXPECT_EQ(db->owner_type, "USER");
+  ASSERT_EQ(db->parameters.size(), 1);
+  EXPECT_EQ(db->parameters.at("custom-prop"), "value");
+}
+
+TEST(ConvertToHiveDatabaseTest, RejectsHierarchicalNamespace) {
+  auto db = ConvertToHiveDatabase(Namespace{{"a", "b"}}, {});
+  ASSERT_FALSE(db.has_value());
+  EXPECT_EQ(db.error().kind, ErrorKind::kInvalidArgument);
+}
+
+TEST(ConvertFromHiveDatabaseTest, RoundTripWithCustomProperties) {
+  auto original = ConvertToHiveDatabase(Namespace{{"warehouse"}},
+                                        {{"comment", "primary"},
+                                         {"hive.metastore.database.owner", "alice"},
+                                         {"team", "data"}});
+  ASSERT_TRUE(original.has_value()) << original.error().message;
+
+  const auto round_tripped = ConvertFromHiveDatabase(*original);
+  EXPECT_EQ(round_tripped.ns.levels, std::vector<std::string>{"warehouse"});
+  EXPECT_EQ(round_tripped.properties.at("comment"), "primary");
+  EXPECT_EQ(round_tripped.properties.at("hive.metastore.database.owner"), "alice");
+  EXPECT_EQ(round_tripped.properties.at("team"), "data");
+  EXPECT_FALSE(round_tripped.properties.contains("hive.metastore.database.owner-type"));
+}
+
+TEST(ConvertToHiveTableTest, SetsIcebergMarkerParametersAndStorageDescriptor) {
+  TableIdentifier ident{.ns = Namespace{{"warehouse"}}, .name = "orders"};
+  const std::vector<HiveColumn> columns = {{.name = "id", .type_string = "bigint"},
+                                           {.name = "amount", .type_string = "double"}};
+  auto table = ConvertToHiveTable(ident, columns,
+                                  /*metadata_location=*/
+                                  "s3://bucket/wh/warehouse.db/"
+                                  "orders/metadata/v1.metadata.json",
+                                  /*location=*/"s3://bucket/wh/warehouse.db/orders",
+                                  /*table_properties=*/{{"format-version", "2"}});
+  ASSERT_TRUE(table.has_value()) << table.error().message;
+  EXPECT_EQ(table->db_name, "warehouse");
+  EXPECT_EQ(table->table_name, "orders");
+  EXPECT_EQ(table->table_type, "EXTERNAL_TABLE");
+  EXPECT_EQ(table->location, "s3://bucket/wh/warehouse.db/orders");
+  EXPECT_EQ(table->columns.size(), 2);
+  EXPECT_EQ(table->columns[0].name, "id");
+  EXPECT_EQ(table->columns[0].type_string, "bigint");
+
+  EXPECT_EQ(table->parameters.at("metadata_location"),
+            "s3://bucket/wh/warehouse.db/orders/metadata/v1.metadata.json");
+  EXPECT_EQ(table->parameters.at("table_type"), "ICEBERG");
+  EXPECT_EQ(table->parameters.at("EXTERNAL"), "TRUE");
+  EXPECT_EQ(table->parameters.at("format-version"), "2");
+
+  EXPECT_EQ(table->serde, "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe");
+  EXPECT_EQ(table->input_format, "org.apache.hadoop.mapred.FileInputFormat");
+  EXPECT_EQ(table->output_format, "org.apache.hadoop.mapred.FileOutputFormat");
+}
+
+TEST(ConvertToHiveTableTest, ReservedTablePropertiesAreFiltered) {
+  TableIdentifier ident{.ns = Namespace{{"warehouse"}}, .name = "orders"};
+  auto table = ConvertToHiveTable(ident, /*columns=*/{}, /*metadata_location=*/"loc",
+                                  /*location=*/"root",
+                                  {{"comment", "ignore me"}, {"owner", "bob"}});
+  ASSERT_TRUE(table.has_value()) << table.error().message;
+  EXPECT_EQ(table->owner, "bob");
+  EXPECT_FALSE(table->parameters.contains("comment"));
+  EXPECT_FALSE(table->parameters.contains("owner"));
+}
+
+TEST(GetMetadataLocationTest, ExtractsKnownKey) {
+  auto loc = GetMetadataLocation({{"metadata_location", "s3://m.json"}});
+  ASSERT_TRUE(loc.has_value()) << loc.error().message;
+  EXPECT_EQ(*loc, "s3://m.json");
+}
+
+TEST(GetMetadataLocationTest, AbsenceMapsToNotFound) {
+  auto loc = GetMetadataLocation({{"EXTERNAL", "TRUE"}});
+  ASSERT_FALSE(loc.has_value());
+  EXPECT_EQ(loc.error().kind, ErrorKind::kNotFound);
+}
+
+TEST(ValidateIcebergTableTest, AcceptsCaseInsensitiveIcebergMarker) {
+  const TableIdentifier id{.ns = Namespace{{"sales"}}, .name = "orders"};
+  EXPECT_TRUE(ValidateIcebergTable(id, {{"table_type", "ICEBERG"}}).has_value());
+  EXPECT_TRUE(ValidateIcebergTable(id, {{"table_type", "iceberg"}}).has_value());
+  EXPECT_TRUE(ValidateIcebergTable(id, {{"table_type", "Iceberg"}}).has_value());
+}
+
+TEST(ValidateIcebergTableTest, RejectsMissingMarker) {
+  const TableIdentifier id{.ns = Namespace{{"sales"}}, .name = "orders"};
+  auto status = ValidateIcebergTable(id, {{"EXTERNAL", "TRUE"}});
+  ASSERT_FALSE(status.has_value());
+  EXPECT_EQ(status.error().kind, ErrorKind::kNoSuchTable);
+}
+
+TEST(ValidateIcebergTableTest, RejectsForeignTableType) {
+  const TableIdentifier id{.ns = Namespace{{"sales"}}, .name = "orders"};
+  auto status =
+      ValidateIcebergTable(id, {{"table_type", "MANAGED_TABLE"}, {"EXTERNAL", "TRUE"}});
+  ASSERT_FALSE(status.has_value());
+  EXPECT_EQ(status.error().kind, ErrorKind::kNoSuchTable);
+}
+
+TEST(GetDefaultTableLocationTest, TrimsTrailingSlashAndAppendsDbAndTable) {
+  EXPECT_EQ(
+      GetDefaultTableLocation("s3://bucket/wh/", Namespace{{"warehouse"}}, "orders"),
+      "s3://bucket/wh/warehouse.db/orders");
+  EXPECT_EQ(GetDefaultTableLocation("hdfs://nn/data", Namespace{{"sales"}}, "orders"),
+            "hdfs://nn/data/sales.db/orders");
+}
+
+}  // namespace iceberg::hive


### PR DESCRIPTION
Next step of the HiveCatalog split (follows #796): two conversion layers between Iceberg's catalog model and the HMS record shape. No Thrift, no I/O, fully unit tested.

- **`hive_schema`** — renders an Iceberg `Schema` as the Hive DDL column list HMS stores, nested types included.
- **`hive_utils`** — `Namespace` / `TableIdentifier` ↔ HMS `Database` / `Table`, the Iceberg-on-HMS parameter keys (`metadata_location`, `table_type`, `EXTERNAL`), and the LazySimpleSerDe descriptor Spark and Trino expect. Plain structs rather than Thrift objects, so `HmsClient` stays the only translation unit that includes the generated bindings.

Where the two reference implementations disagree:

- `timestamptz` → `timestamp with local time zone`, following iceberg-java; iceberg-rust rejects zoned timestamps outright, which would make such tables uncreatable. Java's sub-Hive-3 fallback is not reproduced — no Hive-version probe here, and the vendored IDL is Hive 4.0.1.
- A database owner is carried by `hive.metastore.database.owner` / `hive.metastore.database.owner-type`, the keys both references use; a bare `owner` is the *table* owner key.

Iceberg v3 types that neither reference maps to a real Hive type return `kNotImplemented` rather than guessing a spelling. Nothing calls any of this yet — `HiveCatalog` remains a stub; `HmsClient`'s Thrift wrappers and the catalog CRUD paths come next.

33 new unit tests; `hive_catalog_test` goes from 17 to 50 cases.