### PR TITLE
docs: clarify contribution conventions for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,17 @@ When assessing potential vulnerabilities or calibrating automated security
 findings, use [`SECURITY-THREAT-MODEL.md`](SECURITY-THREAT-MODEL.md) as the
 authoritative detailed description of this repository's security boundaries,
 trust assumptions, and non-boundaries.
+
+## Build System Consistency
+
+Keep CMake and Meson build definitions in sync. When adding, removing, or
+renaming source files, headers, tests, or build targets, or changing dependencies
+or build options, update the corresponding CMake (`CMakeLists.txt` and CMake
+modules) and Meson (`meson.build` and `meson.options`) definitions in the same
+change.
+
+## PR & Commit Conventions
+
+- Use Conventional Commits for commit messages.
+- Commit messages describe the what and why, not implementation details.
+- Run `pre-commit` for every PR and fix any reported issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,5 +40,4 @@ change.
 ## PR & Commit Conventions
 
 - Use Conventional Commits for commit messages.
-- Commit messages describe the what and why, not implementation details.
 - Run `pre-commit` for every PR and fix any reported issues.


### PR DESCRIPTION
use Conventional Commits for commit messages and run pre-commit for every PR, fixing any reported issues before review.