### PR TITLE
fix: correct mismatched class and struct declarations

### DIFF
--- a/src/iceberg/expression/projections.h
+++ b/src/iceberg/expression/projections.h
@@ -43,7 +43,7 @@ class ICEBERG_EXPORT ProjectionEvaluator {
   Result<std::shared_ptr<Expression>> Project(const std::shared_ptr<Expression>& expr);
 
  private:
-  friend class Projections;
+  friend struct Projections;
 
   /// \brief Create a ProjectionEvaluator.
   ///

--- a/src/iceberg/table_metadata.h
+++ b/src/iceberg/table_metadata.h
@@ -489,7 +489,7 @@ class ICEBERG_EXPORT TableMetadataBuilder : public ErrorCollector {
   explicit TableMetadataBuilder(const TableMetadata* base);
 
   /// Internal state members
-  struct Impl;
+  class Impl;
   std::unique_ptr<Impl> impl_;
 };
 


### PR DESCRIPTION
Keep Projections and TableMetadataBuilder::Impl declarations consistent with their definitions to avoid mismatched-tag diagnostics and potential link failures under the Microsoft C++ ABI.

Found while supporting Meson bundle build, which was an obvious warning.
