### PR TITLE
feat(meson): align library modules with CMake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Meson - ${{ matrix.title }}
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       max-parallel: 15
       fail-fast: false
@@ -221,9 +221,22 @@ jobs:
             meson-setup-args: -Drest_integration_test=enabled
           - title: AMD64 Windows 2025
             runs-on: windows-2025
-            meson-setup-args: --vsenv
+            meson-setup-args: --vsenv --buildtype=release --cmake-prefix-path=C:/vcpkg/installed/x64-windows-static-md
           - title: AArch64 macOS 26
             runs-on: macos-26
+          - title: AMD64 Ubuntu 26.04, all catalogs and library variants
+            runs-on: ubuntu-26.04
+            CC: gcc-14
+            CXX: g++-14
+            sql-clients: true
+            benchmarks: true
+            meson-setup-args: --default-library=both --buildtype=release -Db_ndebug=true --force-fallback-for=arrow,avro -Dhive=enabled -Dsql_catalog=enabled -Dsql_sqlite=enabled -Dsql_postgresql=enabled -Dsql_mysql=enabled -Dbenchmarks=enabled
+          - title: AMD64 Ubuntu 26.04, bundle disabled
+            runs-on: ubuntu-26.04
+            CC: gcc-14
+            CXX: g++-14
+            bundle: disabled
+            meson-setup-args: -Dbundle=disabled
     steps:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -244,13 +257,32 @@ jobs:
         run: |
           echo "CC=sccache ${{ matrix.CC }}" >> $GITHUB_ENV
           echo "CXX=sccache ${{ matrix.CXX }}" >> $GITHUB_ENV
+      - name: Install SQL client development packages
+        if: ${{ matrix.sql-clients }}
+        run: |
+          # Match the PostgreSQL packages preinstalled from PGDG on the runner.
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          sudo apt-get install -y libsqlite3-dev libpq-dev "postgresql-server-dev-$(pg_config --version | awk '{print $2}' | cut -d. -f1)" default-libmysqlclient-dev libcurl4-openssl-dev libgpg-error-dev libunistring-dev libsasl2-dev libdb-dev
+          echo "LIBRARY_PATH=$(pg_config --pkglibdir)" >> "$GITHUB_ENV"
+          # Complete the system packages' static link interfaces.
+          sudo sed -i '/^Requires.private:/s/$/ libsasl2/' "$(pkg-config --variable=pcfiledir libcurl)/libcurl.pc"
+          sudo sed -i '/^Libs.private:/s/$/ -ldb -lsqlite3 -lpq -lmysqlclient/' "$(pkg-config --variable=pcfiledir libsasl2)/libsasl2.pc"
+          sudo sed -i 's/-lpgcommon /-lpgcommon_shlib /' "$(pkg-config --variable=pcfiledir libpq)/libpq.pc"
+      - name: Install OpenSSL static dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libjitterentropy3-dev
+      - name: Install Zlib and pkgconf
+        if: runner.os == 'Windows'
+        run: |
+          vcpkg install zlib:x64-windows-static-md pkgconf:x64-windows-static-md
+          "PKG_CONFIG=C:/vcpkg/installed/x64-windows-static-md/tools/pkgconf/pkgconf.exe" >> $env:GITHUB_ENV
       - name: Set up sccache
         uses: ./.github/actions/setup-sccache
         with:
           key-prefix: sccache-meson-${{ matrix.runs-on }}
       - name: Build Iceberg
         run: |
-          meson setup builddir ${{ matrix.meson-setup-args || '' }}
+          meson setup builddir ${{ matrix.meson-setup-args || '' }} --prefix="${{ github.workspace }}/install" --libdir=lib
           meson compile -C builddir
       - name: Save sccache
         if: always()
@@ -261,3 +293,8 @@ jobs:
       - name: Test Iceberg
         run: |
           meson test -C builddir --timeout-multiplier 0 --print-errorlogs
+      - name: Test installed Meson libraries
+        run: python ci/scripts/test_meson_install.py builddir --bundle=${{ matrix.bundle || 'enabled' }}
+      - name: Test Meson benchmarks
+        if: ${{ matrix.benchmarks }}
+        run: meson test -C builddir --benchmark --print-errorlogs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,13 +224,13 @@ jobs:
             meson-setup-args: --vsenv --buildtype=release --cmake-prefix-path=C:/vcpkg/installed/x64-windows-static-md
           - title: AArch64 macOS 26
             runs-on: macos-26
-          - title: AMD64 Ubuntu 26.04, all catalogs and library variants
+          - title: AMD64 Ubuntu 26.04, all catalogs, S3 and library variants
             runs-on: ubuntu-26.04
             CC: gcc-14
             CXX: g++-14
             sql-clients: true
             benchmarks: true
-            meson-setup-args: --default-library=both --buildtype=release -Db_ndebug=true --force-fallback-for=arrow,avro -Dhive=enabled -Dsql_catalog=enabled -Dsql_sqlite=enabled -Dsql_postgresql=enabled -Dsql_mysql=enabled -Dbenchmarks=enabled
+            meson-setup-args: --default-library=both --buildtype=release -Db_ndebug=true --force-fallback-for=arrow,avro -Dhive=enabled -Dsql_catalog=enabled -Dsql_sqlite=enabled -Dsql_postgresql=enabled -Dsql_mysql=enabled -Dbenchmarks=enabled -Ds3=enabled -Dsigv4=enabled
           - title: AMD64 Ubuntu 26.04, bundle disabled
             runs-on: ubuntu-26.04
             CC: gcc-14

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ C++ implementation of [Apache Iceberg™](https://iceberg.apache.org/).
 **Required:**
 
 - C++23 compliant compiler (GCC 14+, Clang 18+, MSVC 2022+)
-- CMake 3.25+ or Meson 1.5+
+- CMake 3.25+ or Meson 1.8.3+
 - [Ninja](https://ninja-build.org/) (recommended build backend)
 
 **Optional:**
@@ -113,6 +113,24 @@ meson compile -C builddir
 meson test -C builddir --timeout-multiplier 0
 ```
 
+Meson builds `iceberg_bundle` by default, including Arrow filesystem, Avro,
+and Parquet support. Use `-Dbundle=disabled` to omit it.
+
+System dependencies are preferred. Arrow, Avro, CRoaring, and sqlpp23 source
+fallbacks use upstream CMake; use `--force-fallback-for=arrow,avro` to force
+Arrow and Avro source builds. S3 requires `-Ds3=enabled` and either a system
+Arrow with S3 support or an installed AWS SDK for the Arrow source build.
+
+Static libraries are the default. Installed libraries are available through
+pkg-config, for example `dependency('iceberg_bundle')`. With
+`--default-library=both`, use `dependency('iceberg_bundle_static', static: true)`
+or `dependency('iceberg_bundle_shared', static: false)` to select a variant;
+the same suffixes and `static` argument apply to other modules.
+
+Enable Hive with `-Dhive=enabled`. It reuses Thrift from the Arrow source fallback
+by default; use `-Dbundle_thrift=false` for system Thrift. SQL connectors require
+their native client development packages.
+
 Meson provides built-in equivalents for several CMake options:
 
 - `--default-library=<shared|static|both>` instead of `ICEBERG_BUILD_STATIC` / `ICEBERG_BUILD_SHARED`
@@ -123,7 +141,15 @@ Meson-specific options (configured via `-D<option>=<value>`):
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `bundle` | `enabled` | Build Arrow, Avro, and Parquet integrations |
 | `rest` | `enabled` | Build REST catalog client |
+| `hive` | `disabled` | Build Hive (HMS) catalog client |
+| `bundle_thrift` | `true` | Reuse Arrow's Thrift dependency for Hive |
+| `sql_catalog` | `disabled` | Build SQL catalog client |
+| `sql_sqlite` | `disabled` | Build the SQLite connector |
+| `sql_postgresql` | `disabled` | Build the PostgreSQL connector |
+| `sql_mysql` | `disabled` | Build the MySQL connector |
+| `s3` | `disabled` | Build S3 FileIO support |
 | `rest_integration_test` | `disabled` | Build integration test for REST catalog |
 | `spdlog` | `enabled` | Use spdlog as the default logging backend |
 | `tests` | `enabled` | Build tests |

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Arrow, Avro, CRoaring, and sqlpp23 source fallbacks use upstream CMake. Use
 
 Enable S3 with `-Ds3=enabled`. System Arrow must include S3 support; the Arrow
 source fallback bundles AWS SDK by default.
+On Linux, the bundled SDK uses system OpenSSL for s2n TLS support.
 Use `-Dbundle_awssdk=false` to use an installed AWS SDK in the Arrow source build.
 When S3 bundles AWS SDK, `-Dsigv4=enabled` reuses it for REST authentication;
 SigV4 without S3 requires an installed AWS SDK.

--- a/README.md
+++ b/README.md
@@ -116,10 +116,16 @@ meson test -C builddir --timeout-multiplier 0
 Meson builds `iceberg_bundle` by default, including Arrow filesystem, Avro,
 and Parquet support. Use `-Dbundle=disabled` to omit it.
 
-System dependencies are preferred. Arrow, Avro, CRoaring, and sqlpp23 source
-fallbacks use upstream CMake; use `--force-fallback-for=arrow,avro` to force
-Arrow and Avro source builds. S3 requires `-Ds3=enabled` and either a system
-Arrow with S3 support or an installed AWS SDK for the Arrow source build.
+System dependencies are preferred. System Arrow and Parquet are resolved through
+their CMake packages; separate Arrow component pkg-config files are not required.
+Arrow, Avro, CRoaring, and sqlpp23 source fallbacks use upstream CMake. Use
+`--force-fallback-for=arrow,avro` to force Arrow and Avro source builds.
+
+Enable S3 with `-Ds3=enabled`. System Arrow must include S3 support; the Arrow
+source fallback bundles AWS SDK by default.
+Use `-Dbundle_awssdk=false` to use an installed AWS SDK in the Arrow source build.
+When S3 bundles AWS SDK, `-Dsigv4=enabled` reuses it for REST authentication;
+SigV4 without S3 requires an installed AWS SDK.
 
 Static libraries are the default. Installed libraries are available through
 pkg-config, for example `dependency('iceberg_bundle')`. With
@@ -150,6 +156,7 @@ Meson-specific options (configured via `-D<option>=<value>`):
 | `sql_postgresql` | `disabled` | Build the PostgreSQL connector |
 | `sql_mysql` | `disabled` | Build the MySQL connector |
 | `s3` | `disabled` | Build S3 FileIO support |
+| `bundle_awssdk` | `true` | Bundle AWS SDK in the Arrow source build for S3 support |
 | `rest_integration_test` | `disabled` | Build integration test for REST catalog |
 | `spdlog` | `enabled` | Use spdlog as the default logging backend |
 | `tests` | `enabled` | Build tests |

--- a/ci/scripts/test_meson_install.py
+++ b/ci/scripts/test_meson_install.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Build and run a separate consumer against a Meson installation."""
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def run(*args, **kwargs):
+    subprocess.run(args, check=True, **kwargs)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("builddir", type=Path)
+    parser.add_argument("--bundle", choices=["enabled", "disabled"], default="enabled")
+    args = parser.parse_args()
+    options = {
+        item["name"]: item["value"]
+        for item in json.loads(
+            subprocess.check_output(
+                ["meson", "introspect", str(args.builddir), "--buildoptions"], text=True
+            )
+        )
+    }
+    prefix = Path(options["prefix"])
+    run("meson", "install", "-C", str(args.builddir), "--no-rebuild")
+    pkgdir = prefix / options["libdir"] / "pkgconfig"
+    bundle_pc = pkgdir / "iceberg_bundle.pc"
+    if args.bundle == "disabled":
+        if bundle_pc.exists():
+            raise RuntimeError("The disabled bundle must not be installed")
+    elif not bundle_pc.is_file():
+        raise RuntimeError("The bundle pkg-config file was not installed")
+    env = os.environ.copy()
+    additions = {
+        "PKG_CONFIG_PATH": [str(pkgdir)],
+        "LD_LIBRARY_PATH": [str(prefix / options["libdir"])],
+        "DYLD_LIBRARY_PATH": [str(prefix / options["libdir"])],
+        "PATH": [str(prefix / options["bindir"]), str(prefix / options["libdir"])],
+    }
+    for key, paths in additions.items():
+        env[key] = os.pathsep.join(paths + ([env[key]] if env.get(key) else []))
+    env["PKG_CONFIG_PATH"] = os.pathsep.join(
+        [env["PKG_CONFIG_PATH"], *options.get("pkg_config_path", [])]
+    )
+    source = Path(__file__).resolve().parents[1] / "test-install"
+    libraries = [options["default_library"]]
+    if libraries == ["both"]:
+        libraries = ["shared", "static"]
+    for library in libraries:
+        with tempfile.TemporaryDirectory(prefix="iceberg-consumer-") as tmp:
+            command = [
+                "meson",
+                "setup",
+                tmp,
+                str(source),
+                "--default-library=" + library,
+                "--buildtype=" + options["buildtype"],
+                "-Dbundle=" + args.bundle,
+            ]
+            for component in ("rest", "hive", "sql_catalog"):
+                command.append("-D" + component + "=" + options.get(component, "disabled"))
+            for connector in ("sqlite", "postgresql", "mysql"):
+                option = "sql_" + connector
+                command.append("-D" + option + "=" + str(options.get(option) == "enabled").lower())
+            if os.name == "nt":
+                command.append("--vsenv")
+            run(*command, env=env)
+            run("meson", "test", "-C", tmp, "--print-errorlogs", env=env)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/test-install/bundle_smoke.cc
+++ b/ci/test-install/bundle_smoke.cc
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+
+// Verify that the installed format dependency interfaces are usable by consumers.
+#include <arrow/api.h>
+#include <avro/Compiler.hh>
+#include <avro/GenericDatum.hh>
+#include <parquet/api/reader.h>
+
+#include "iceberg/arrow/arrow_io_util.h"
+#include "iceberg/arrow/arrow_register.h"
+#include "iceberg/avro/avro_register.h"
+#include "iceberg/file_reader.h"
+#include "iceberg/file_writer.h"
+#include "iceberg/parquet/parquet_register.h"
+#include "iceberg/schema.h"
+#include "iceberg/schema_field.h"
+#include "iceberg/type.h"
+
+// The borrowed buffers below remain alive until the writer is closed.
+void ReleaseBorrowedArray(ArrowArray* array) {
+  for (int64_t i = 0; i < array->n_children; ++i) {
+    if (array->children[i]->release) {
+      array->children[i]->release(array->children[i]);
+    }
+  }
+  array->release = nullptr;
+}
+
+iceberg::Status CheckBundle() {
+  auto avro_schema = avro::compileJsonSchemaFromString(R"("int")");
+  if (avro::GenericDatum(avro_schema).type() != avro::AVRO_INT) {
+    return iceberg::InvalidArgument("Avro schema type did not match");
+  }
+
+  iceberg::arrow::RegisterAll();
+  iceberg::avro::RegisterAll();
+  iceberg::parquet::RegisterAll();
+  std::shared_ptr<iceberg::FileIO> io = iceberg::arrow::MakeMockFileIO();
+  auto schema = std::make_shared<iceberg::Schema>(std::vector<iceberg::SchemaField>{
+      iceberg::SchemaField::MakeRequired(1, "id", iceberg::int32())});
+  for (auto format :
+       {iceberg::FileFormatType::kAvro, iceberg::FileFormatType::kParquet}) {
+    std::string path = "/roundtrip." + std::string(iceberg::ToString(format));
+    const int32_t values[] = {42};
+    const void* value_buffers[] = {nullptr, values};
+    ArrowArray child{.length = 1,
+                     .n_buffers = 2,
+                     .buffers = value_buffers,
+                     .release = ReleaseBorrowedArray};
+    ArrowArray* children[] = {&child};
+    const void* struct_buffers[] = {nullptr};
+    ArrowArray batch{.length = 1,
+                     .n_buffers = 1,
+                     .n_children = 1,
+                     .buffers = struct_buffers,
+                     .children = children,
+                     .release = ReleaseBorrowedArray};
+    auto writer = iceberg::WriterFactoryRegistry::Open(
+        format, {.path = path,
+                 .schema = schema,
+                 .io = io,
+                 .properties = iceberg::WriterProperties::FromMap(
+                     {{"write.parquet.compression-codec", "uncompressed"}})});
+    if (!writer) return std::unexpected(writer.error());
+    auto written = (*writer)->Write(&batch);
+    if (!written) return written;
+    auto closed = (*writer)->Close();
+    if (!closed) return closed;
+    for (bool skip_datum : {true, false}) {
+      iceberg::ReaderProperties properties;
+      properties.Set(iceberg::ReaderProperties::kAvroSkipDatum, skip_datum);
+      auto reader = iceberg::ReaderFactoryRegistry::Open(
+          format,
+          {.path = path, .io = io, .projection = schema, .properties = properties});
+      if (!reader) return std::unexpected(reader.error());
+      auto next = (*reader)->Next();
+      if (!next) return std::unexpected(next.error());
+      if (!next->has_value()) return iceberg::InvalidArgument("Expected one row");
+      auto& output = next->value();
+      bool valid = output.length == 1 && output.n_children == 1;
+      if (valid) {
+        const auto* column = output.children[0];
+        valid = column->n_buffers == 2 && column->buffers[1] &&
+                static_cast<const int32_t*>(column->buffers[1])[column->offset] == 42;
+      }
+      output.release(&output);
+      if (!valid) return iceberg::InvalidArgument("Round-trip value did not match");
+      closed = (*reader)->Close();
+      if (!closed) return closed;
+      if (format == iceberg::FileFormatType::kParquet) break;
+    }
+  }
+  return {};
+}
+
+int main() {
+  auto result = CheckBundle();
+  if (!result) {
+    std::cerr << result.error().message << '\n';
+    return 1;
+  }
+  return 0;
+}

--- a/ci/test-install/library_smoke.cc
+++ b/ci/test-install/library_smoke.cc
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <iostream>
+
+#include "iceberg/catalog/catalog_util.h"
+#include "iceberg/catalog/session_catalog.h"
+#include "iceberg/catalog/session_context.h"
+#include "iceberg/data/data_writer.h"
+#include "iceberg/schema_field.h"
+#include "iceberg/type.h"
+#include "iceberg/version.h"
+
+#ifdef INSTALL_TEST_REST
+#  include "iceberg/catalog/rest/auth/token_refresh_scheduler.h"
+#  include "iceberg/catalog/rest/endpoint.h"
+#  include "iceberg/catalog/rest/rest_catalog.h"
+#endif
+#ifdef INSTALL_TEST_HIVE
+#  include "iceberg/catalog/hive/hive_catalog.h"
+#  include "iceberg/catalog/hive/hms_client.h"
+#endif
+#ifdef INSTALL_TEST_SQL_CATALOG
+#  include "iceberg/catalog/sql/sql_catalog.h"
+#endif
+
+iceberg::Status CheckLibraries() {
+  if (std::string_view(ICEBERG_PROJECT_NAME) != "Iceberg") {
+    return iceberg::InvalidArgument("Unexpected project name in version.h");
+  }
+  const auto field = iceberg::SchemaField::MakeRequired(1, "id", iceberg::int32());
+  if (field.field_id() != 1) return iceberg::InvalidArgument("Invalid schema field");
+  // No format writers have been registered in this process.
+  if (iceberg::DataWriter::Make({})) {
+    return iceberg::InvalidArgument("Expected a missing writer error");
+  }
+#ifdef INSTALL_TEST_REST
+  auto endpoint = iceberg::rest::Endpoint::FromString("GET /v1/config");
+  if (!endpoint) return std::unexpected(endpoint.error());
+  if (endpoint->ToString() != "GET /v1/config") {
+    return iceberg::InvalidArgument("REST endpoint did not roundtrip");
+  }
+  iceberg::rest::auth::TokenRefreshScheduler scheduler;
+  scheduler.Shutdown();
+#endif
+#ifdef INSTALL_TEST_HIVE
+  auto endpoints = iceberg::hive::ParseHmsUris("thrift://localhost:9083");
+  if (!endpoints) return std::unexpected(endpoints.error());
+  if (endpoints->size() != 1 || endpoints->front().port != 9083) {
+    return iceberg::InvalidArgument("Invalid Hive endpoint");
+  }
+#endif
+#ifdef INSTALL_TEST_SQL_CATALOG
+  if (iceberg::sql::SqlCatalog::Make({}, nullptr, nullptr)) {
+    return iceberg::InvalidArgument("SQL catalog accepted a null store");
+  }
+#endif
+#ifdef INSTALL_TEST_SQL_SQLITE
+  auto store = iceberg::sql::MakeSqliteCatalogStore(
+      {.catalog_name = "installed", .uri = ":memory:"});
+  if (!store) return std::unexpected(store.error());
+  auto initialized = (*store)->Initialize();
+  if (!initialized) return initialized;
+  auto inserted = (*store)->InsertNamespaceProperty("ns", "key", std::string("value"));
+  if (!inserted) return inserted;
+  auto namespaces = (*store)->ListNamespaceNames();
+  if (!namespaces) return std::unexpected(namespaces.error());
+  if (namespaces->size() != 1 || namespaces->front() != "ns") {
+    return iceberg::InvalidArgument("SQLite namespace did not roundtrip");
+  }
+#endif
+#ifdef INSTALL_TEST_SQL_POSTGRESQL
+  if (iceberg::sql::MakePostgreSqlCatalogStore({.uri = "postgresql://"})) {
+    return iceberg::InvalidArgument("PostgreSQL connector accepted an invalid URI");
+  }
+#endif
+#ifdef INSTALL_TEST_SQL_MYSQL
+  if (iceberg::sql::MakeMySqlCatalogStore({.uri = "mysql://"})) {
+    return iceberg::InvalidArgument("MySQL connector accepted an invalid URI");
+  }
+#endif
+  return {};
+}
+
+int main() {
+  auto result = CheckLibraries();
+  if (!result) {
+    std::cerr << result.error().message << '\n';
+    return 1;
+  }
+  return 0;
+}

--- a/ci/test-install/meson.build
+++ b/ci/test-install/meson.build
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+project(
+    'iceberg-install-test',
+    'cpp',
+    default_options: ['cpp_std=c++23,c++latest'],
+)
+
+variant = get_option('default_library') == 'static' ? 'static' : 'shared'
+libs = [
+    dependency(
+        'iceberg_data_' + variant,
+        method: 'pkg-config',
+        static: variant == 'static',
+        allow_fallback: false,
+    ),
+]
+args = []
+foreach component : ['rest', 'hive', 'sql_catalog']
+    dep = dependency(
+        'iceberg_' + component + '_' + variant,
+        method: 'pkg-config',
+        required: get_option(component),
+        static: variant == 'static',
+        allow_fallback: false,
+    )
+    if dep.found()
+        libs += dep
+        args += '-DINSTALL_TEST_' + component.to_upper()
+    endif
+endforeach
+foreach connector : ['sqlite', 'postgresql', 'mysql']
+    if get_option('sql_' + connector)
+        args += '-DINSTALL_TEST_SQL_' + connector.to_upper()
+    endif
+endforeach
+smoke = executable(
+    'library_smoke',
+    'library_smoke.cc',
+    dependencies: libs,
+    cpp_args: args,
+)
+test('library_smoke', smoke)
+
+bundle = dependency(
+    'iceberg_bundle_' + variant,
+    method: 'pkg-config',
+    required: get_option('bundle'),
+    static: variant == 'static',
+    allow_fallback: false,
+)
+if bundle.found()
+    smoke = executable('bundle_smoke', 'bundle_smoke.cc', dependencies: bundle)
+    test('bundle_smoke', smoke)
+endif

--- a/ci/test-install/meson.options
+++ b/ci/test-install/meson.options
@@ -15,20 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-benchmark_dep = dependency(
-    'benchmark',
-    required: true,
-    static: true,
-    default_options: ['default_library=static'],
-)
-
-benchmark_smoke = executable(
-    'benchmark_smoke',
-    sources: files('benchmark_smoke.cc'),
-    dependencies: [
-        get_variable('iceberg_static_dep', iceberg_dep),
-        benchmark_dep,
-    ],
-)
-
-benchmark('benchmark_smoke', benchmark_smoke)
+option('bundle', type: 'feature', value: 'enabled')
+option('rest', type: 'feature', value: 'auto')
+option('hive', type: 'feature', value: 'auto')
+option('sql_catalog', type: 'feature', value: 'auto')
+option('sql_sqlite', type: 'boolean', value: false)
+option('sql_postgresql', type: 'boolean', value: false)
+option('sql_mysql', type: 'boolean', value: false)

--- a/cmake_modules/IcebergMesonSubproject.cmake
+++ b/cmake_modules/IcebergMesonSubproject.cmake
@@ -15,20 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
-benchmark_dep = dependency(
-    'benchmark',
-    required: true,
-    static: true,
-    default_options: ['default_library=static'],
-)
-
-benchmark_smoke = executable(
-    'benchmark_smoke',
-    sources: files('benchmark_smoke.cc'),
-    dependencies: [
-        get_variable('iceberg_static_dep', iceberg_dep),
-        benchmark_dep,
-    ],
-)
-
-benchmark('benchmark_smoke', benchmark_smoke)
+if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  return()
+endif()
+# Expose the instantiated location when Meson promotes nested subprojects.
+file(WRITE "${CMAKE_BINARY_DIR}/iceberg-meson-source-dir.txt" "${CMAKE_SOURCE_DIR}")
+add_custom_target(iceberg_meson_paths
+                  COMMAND "${CMAKE_COMMAND}" -E true
+                  BYPRODUCTS "${CMAKE_BINARY_DIR}/iceberg-meson-source-dir.txt")
+# Meson does not infer interface include paths from FILE_SET HEADERS.
+if(PROJECT_NAME STREQUAL "sqlpp23")
+  cmake_language(DEFER
+                 CALL
+                 target_include_directories
+                 sqlpp23
+                 INTERFACE
+                 "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+endif()

--- a/cmake_modules/IcebergThirdpartyToolchain.cmake
+++ b/cmake_modules/IcebergThirdpartyToolchain.cmake
@@ -337,11 +337,18 @@ function(resolve_avro_dependency)
     set(AVRO_VENDORED TRUE)
     set_target_properties(avrocpp_s PROPERTIES OUTPUT_NAME "iceberg_vendored_avrocpp")
     set_target_properties(avrocpp_s PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    if(APPLE AND ICEBERG_BUILD_SHARED)
+      # Avro's std::any values cross the shared bundle boundary. Keep their
+      # type information visible in Avro, the bundle, and installed consumers.
+      target_compile_definitions(avrocpp_s PUBLIC AVRO_DYN_LINK)
+    endif()
     install(TARGETS avrocpp_s
             EXPORT iceberg_targets
             RUNTIME DESTINATION "${ICEBERG_INSTALL_BINDIR}"
             ARCHIVE DESTINATION "${ICEBERG_INSTALL_LIBDIR}"
             LIBRARY DESTINATION "${ICEBERG_INSTALL_LIBDIR}")
+    install(DIRECTORY "${avro-cpp_SOURCE_DIR}/lang/c++/include/avro"
+            DESTINATION "${ICEBERG_INSTALL_INCLUDEDIR}")
 
     # TODO: add vendored ZLIB and Snappy support
     find_package(Snappy CONFIG)
@@ -467,6 +474,17 @@ endfunction()
 # utf8proc
 
 function(resolve_utf8proc_dependency)
+  # A system Arrow package may already provide this target through its own
+  # Findutf8proc module. Reuse it, and let find_dependency(Arrow) recreate it
+  # for installed consumers instead of defining the imported target twice.
+  if(ICEBERG_BUILD_BUNDLE
+     AND NOT ARROW_VENDORED
+     AND TARGET utf8proc::utf8proc)
+    set(UTF8PROC_VENDORED
+        FALSE
+        PARENT_SCOPE)
+    return()
+  endif()
   prepare_fetchcontent()
 
   # The vendored build needs no install rules; without this, CMake < 3.28 (where
@@ -867,7 +885,6 @@ endfunction()
 resolve_zlib_dependency()
 resolve_nanoarrow_dependency()
 resolve_croaring_dependency()
-resolve_utf8proc_dependency()
 resolve_nlohmann_json_dependency()
 if(ICEBERG_SPDLOG)
   resolve_spdlog_dependency()
@@ -885,6 +902,8 @@ if(ICEBERG_BUILD_BUNDLE)
   resolve_avro_dependency()
   resolve_zstd_dependency()
 endif()
+
+resolve_utf8proc_dependency()
 
 if(ICEBERG_BUILD_REST)
   resolve_cpr_dependency()

--- a/meson.build
+++ b/meson.build
@@ -17,11 +17,13 @@
 
 project(
     'iceberg',
+    'c',
     'cpp',
     version: '0.4.0',
     license: 'Apache-2.0',
-    meson_version: '>=1.3.0',
+    meson_version: '>=1.8.3',
     default_options: [
+        'default_library=static',
         'cpp_std=c++23,c++latest',
         'warning_level=2',
         # Don't build any tests for curl

--- a/meson.options
+++ b/meson.options
@@ -31,12 +31,61 @@
 # --includedir / --datadir arguments, respectively
 
 option(
+    'bundle',
+    type: 'feature',
+    description: 'Build Arrow, Avro, and Parquet integrations',
+    value: 'enabled',
+)
+
+option(
     'rest',
     type: 'feature',
     description: 'Build rest catalog client',
     value: 'enabled',
 )
 
+option(
+    'hive',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Build the Hive catalog',
+)
+option(
+    'sql_catalog',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Build the SQL catalog',
+)
+option(
+    'sql_sqlite',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Build the SQL SQLite connector',
+)
+option(
+    'sql_postgresql',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Build the SQL PostgreSQL connector',
+)
+option(
+    'sql_mysql',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Build the SQL MySQL connector',
+)
+option(
+    's3',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Build S3 FileIO support',
+)
+option(
+    'bundle_thrift',
+    type: 'boolean',
+    value: true,
+    description: 'Use Arrow\'s Thrift dependency for Hive',
+)
 option(
     'rest_integration_test',
     type: 'feature',

--- a/meson.options
+++ b/meson.options
@@ -81,6 +81,12 @@ option(
     description: 'Build S3 FileIO support',
 )
 option(
+    'bundle_awssdk',
+    type: 'boolean',
+    value: true,
+    description: 'Bundle AWS SDK in the Arrow source build for S3 support',
+)
+option(
     'bundle_thrift',
     type: 'boolean',
     value: true,

--- a/mkdocs/docs/getting-started.md
+++ b/mkdocs/docs/getting-started.md
@@ -24,7 +24,7 @@
 **Required:**
 
 - C++23 compliant compiler (GCC 14+, Clang 18+, MSVC 2022+)
-- CMake 3.25+ or Meson 1.5+
+- CMake 3.25+ or Meson 1.8.3+
 - [Ninja](https://ninja-build.org/) (recommended build backend)
 
 ## Quick Start
@@ -90,6 +90,24 @@ meson compile -C builddir
 meson test -C builddir --timeout-multiplier 0
 ```
 
+Meson builds `iceberg_bundle` by default, including Arrow filesystem, Avro,
+and Parquet support. Use `-Dbundle=disabled` to omit it.
+
+System dependencies are preferred. Arrow, Avro, CRoaring, and sqlpp23 source
+fallbacks use upstream CMake; use `--force-fallback-for=arrow,avro` to force
+Arrow and Avro source builds. S3 requires `-Ds3=enabled` and either a system
+Arrow with S3 support or an installed AWS SDK for the Arrow source build.
+
+Static libraries are the default. Installed libraries are available through
+pkg-config, for example `dependency('iceberg_bundle')`. With
+`--default-library=both`, use `dependency('iceberg_bundle_static', static: true)`
+or `dependency('iceberg_bundle_shared', static: false)` to select a variant;
+the same suffixes and `static` argument apply to other modules.
+
+Enable Hive with `-Dhive=enabled`. It reuses Thrift from the Arrow source fallback
+by default; use `-Dbundle_thrift=false` for system Thrift. SQL connectors require
+their native client development packages.
+
 Meson provides built-in equivalents for several CMake options:
 
 - `--default-library=<shared|static|both>` instead of `ICEBERG_BUILD_STATIC` / `ICEBERG_BUILD_SHARED`
@@ -98,7 +116,15 @@ Meson provides built-in equivalents for several CMake options:
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `bundle` | `enabled` | Build Arrow, Avro, and Parquet integrations |
 | `rest` | `enabled` | Build REST catalog client |
+| `hive` | `disabled` | Build Hive (HMS) catalog client |
+| `bundle_thrift` | `true` | Reuse Arrow's Thrift dependency for Hive |
+| `sql_catalog` | `disabled` | Build SQL catalog client |
+| `sql_sqlite` | `disabled` | Build the SQLite connector |
+| `sql_postgresql` | `disabled` | Build the PostgreSQL connector |
+| `sql_mysql` | `disabled` | Build the MySQL connector |
+| `s3` | `disabled` | Build S3 FileIO support |
 | `rest_integration_test` | `disabled` | Build integration test for REST catalog |
 | `tests` | `enabled` | Build tests |
 

--- a/mkdocs/docs/getting-started.md
+++ b/mkdocs/docs/getting-started.md
@@ -93,10 +93,16 @@ meson test -C builddir --timeout-multiplier 0
 Meson builds `iceberg_bundle` by default, including Arrow filesystem, Avro,
 and Parquet support. Use `-Dbundle=disabled` to omit it.
 
-System dependencies are preferred. Arrow, Avro, CRoaring, and sqlpp23 source
-fallbacks use upstream CMake; use `--force-fallback-for=arrow,avro` to force
-Arrow and Avro source builds. S3 requires `-Ds3=enabled` and either a system
-Arrow with S3 support or an installed AWS SDK for the Arrow source build.
+System dependencies are preferred. System Arrow and Parquet are resolved through
+their CMake packages; separate Arrow component pkg-config files are not required.
+Arrow, Avro, CRoaring, and sqlpp23 source fallbacks use upstream CMake. Use
+`--force-fallback-for=arrow,avro` to force Arrow and Avro source builds.
+
+Enable S3 with `-Ds3=enabled`. System Arrow must include S3 support; the Arrow
+source fallback bundles AWS SDK by default.
+Use `-Dbundle_awssdk=false` to use an installed AWS SDK in the Arrow source build.
+When S3 bundles AWS SDK, `-Dsigv4=enabled` reuses it for REST authentication;
+SigV4 without S3 requires an installed AWS SDK.
 
 Static libraries are the default. Installed libraries are available through
 pkg-config, for example `dependency('iceberg_bundle')`. With
@@ -125,6 +131,7 @@ Meson provides built-in equivalents for several CMake options:
 | `sql_postgresql` | `disabled` | Build the PostgreSQL connector |
 | `sql_mysql` | `disabled` | Build the MySQL connector |
 | `s3` | `disabled` | Build S3 FileIO support |
+| `bundle_awssdk` | `true` | Bundle AWS SDK in the Arrow source build for S3 support |
 | `rest_integration_test` | `disabled` | Build integration test for REST catalog |
 | `tests` | `enabled` | Build tests |
 

--- a/mkdocs/docs/getting-started.md
+++ b/mkdocs/docs/getting-started.md
@@ -100,6 +100,7 @@ Arrow, Avro, CRoaring, and sqlpp23 source fallbacks use upstream CMake. Use
 
 Enable S3 with `-Ds3=enabled`. System Arrow must include S3 support; the Arrow
 source fallback bundles AWS SDK by default.
+On Linux, the bundled SDK uses system OpenSSL for s2n TLS support.
 Use `-Dbundle_awssdk=false` to use an installed AWS SDK in the Arrow source build.
 When S3 bundles AWS SDK, `-Dsigv4=enabled` reuses it for REST authentication;
 SigV4 without S3 requires an installed AWS SDK.

--- a/mkdocs/docs/library.md
+++ b/mkdocs/docs/library.md
@@ -41,7 +41,8 @@ are supplied by the `iceberg_bundle` library.
 
 This library combines `iceberg_data` with the Arrow C++, Avro, Parquet, and
 Arrow filesystem integrations. It gives applications one link-time dependency.
-Please note that Meson build currently does not have this yet.
+It is enabled by default in both CMake and Meson. Use
+`ICEBERG_BUILD_BUNDLE=OFF` or `-Dbundle=disabled` to omit it.
 
 ### `iceberg_rest`, `iceberg_hive`, `iceberg_sql_catalog`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-meson==1.3.0
+meson==1.8.3
 ninja==1.13.0
 mkdocs==1.6.1
 mkdocs-material==9.7.7

--- a/src/iceberg/CMakeLists.txt
+++ b/src/iceberg/CMakeLists.txt
@@ -184,6 +184,7 @@ list(APPEND
      roaring::roaring)
 list(APPEND
      ICEBERG_STATIC_INSTALL_INTERFACE_LIBS
+     ZLIB::ZLIB
      "$<IF:$<BOOL:${NANOARROW_VENDORED}>,iceberg::nanoarrow_static,$<IF:$<TARGET_EXISTS:nanoarrow::nanoarrow_static>,nanoarrow::nanoarrow_static,nanoarrow::nanoarrow_shared>>"
      "$<IF:$<BOOL:${NLOHMANN_JSON_VENDORED}>,iceberg::nlohmann_json,$<IF:$<TARGET_EXISTS:nlohmann_json::nlohmann_json>,nlohmann_json::nlohmann_json,nlohmann_json::nlohmann_json>>"
      "$<IF:$<BOOL:${UTF8PROC_VENDORED}>,iceberg::utf8proc,utf8proc::utf8proc>"

--- a/src/iceberg/arrow/meson.build
+++ b/src/iceberg/arrow/meson.build
@@ -15,20 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-benchmark_dep = dependency(
-    'benchmark',
-    required: true,
-    static: true,
-    default_options: ['default_library=static'],
-)
+install_headers(['arrow_io_util.h', 'arrow_register.h'], subdir: 'iceberg/arrow')
 
-benchmark_smoke = executable(
-    'benchmark_smoke',
-    sources: files('benchmark_smoke.cc'),
-    dependencies: [
-        get_variable('iceberg_static_dep', iceberg_dep),
-        benchmark_dep,
-    ],
-)
-
-benchmark('benchmark_smoke', benchmark_smoke)
+subdir('s3')

--- a/src/iceberg/arrow/s3/meson.build
+++ b/src/iceberg/arrow/s3/meson.build
@@ -15,20 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-benchmark_dep = dependency(
-    'benchmark',
-    required: true,
-    static: true,
-    default_options: ['default_library=static'],
-)
-
-benchmark_smoke = executable(
-    'benchmark_smoke',
-    sources: files('benchmark_smoke.cc'),
-    dependencies: [
-        get_variable('iceberg_static_dep', iceberg_dep),
-        benchmark_dep,
-    ],
-)
-
-benchmark('benchmark_smoke', benchmark_smoke)
+install_headers(['s3_properties.h'], subdir: 'iceberg/arrow/s3')

--- a/src/iceberg/avro/meson.build
+++ b/src/iceberg/avro/meson.build
@@ -15,20 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-benchmark_dep = dependency(
-    'benchmark',
-    required: true,
-    static: true,
-    default_options: ['default_library=static'],
-)
-
-benchmark_smoke = executable(
-    'benchmark_smoke',
-    sources: files('benchmark_smoke.cc'),
-    dependencies: [
-        get_variable('iceberg_static_dep', iceberg_dep),
-        benchmark_dep,
+install_headers(
+    [
+        'avro_constants.h',
+        'avro_metrics.h',
+        'avro_reader.h',
+        'avro_register.h',
+        'avro_writer.h',
     ],
+    subdir: 'iceberg/avro',
 )
-
-benchmark('benchmark_smoke', benchmark_smoke)

--- a/src/iceberg/catalog/CMakeLists.txt
+++ b/src/iceberg/catalog/CMakeLists.txt
@@ -17,6 +17,8 @@
 
 add_subdirectory(memory)
 
+iceberg_install_all_headers(iceberg/catalog)
+
 if(ICEBERG_BUILD_REST)
   add_subdirectory(rest)
 endif()

--- a/src/iceberg/catalog/hive/meson.build
+++ b/src/iceberg/catalog/hive/meson.build
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Match ICEBERG_HIVE_SOURCES and ICEBERG_HIVE_THRIFT_GEN_SOURCES.
+if get_option('bundle_thrift')
+    if not bundle_enabled
+        error('bundle_thrift requires bundle=enabled')
+    endif
+    if arrow_dep.type_name() != 'internal'
+        error(
+            'bundle_thrift requires the Arrow source fallback; use --force-fallback-for=arrow or -Dbundle_thrift=false',
+        )
+    endif
+    hive_thrift_dep = arrow_thrift_dep
+else
+    hive_thrift_dep = dependency('thrift', required: true, allow_fallback: false)
+endif
+
+iceberg_hive_sources = files(
+    'gen-cpp/FacebookService.cpp',
+    'gen-cpp/ThriftHiveMetastore.cpp',
+    'gen-cpp/fb303_types.cpp',
+    'gen-cpp/hive_metastore_constants.cpp',
+    'gen-cpp/hive_metastore_types.cpp',
+    'hive_catalog.cc',
+    'hive_catalog_properties.cc',
+    'hms_client.cc',
+)
+iceberg_libraries += {
+    'iceberg_hive': {
+        'sources': iceberg_hive_sources,
+        'dependencies': [hive_thrift_dep],
+        'parent': 'iceberg',
+        'include_directories': [include_directories('gen-cpp')],
+        'compile_args': cpp.get_supported_arguments(
+            '-Wno-error=deprecated-declarations',
+        ),
+    },
+}
+install_headers(
+    [
+        'hive_catalog.h',
+        'hive_catalog_properties.h',
+        'hms_client.h',
+        'iceberg_hive_export.h',
+    ],
+    subdir: 'iceberg/catalog/hive',
+)

--- a/src/iceberg/catalog/meson.build
+++ b/src/iceberg/catalog/meson.build
@@ -25,3 +25,12 @@ install_headers(
 if get_option('rest').enabled()
     subdir('rest')
 endif
+
+if get_option('hive').enabled()
+    subdir('hive')
+endif
+
+sql_sqlite_enabled = false
+if get_option('sql_catalog').enabled()
+    subdir('sql')
+endif

--- a/src/iceberg/catalog/rest/auth/meson.build
+++ b/src/iceberg/catalog/rest/auth/meson.build
@@ -22,6 +22,7 @@ install_headers(
         'auth_properties.h',
         'auth_session.h',
         'oauth2_util.h',
+        'token_refresh_scheduler.h',
     ],
     subdir: 'iceberg/catalog/rest/auth',
 )

--- a/src/iceberg/catalog/rest/meson.build
+++ b/src/iceberg/catalog/rest/meson.build
@@ -34,16 +34,15 @@ iceberg_rest_sources = files(
     'rest_util.cc',
     'types.cc',
 )
-# cpr does not export symbols, so on Windows it must
-# be used as a static lib
-cpr_needs_static = (
-    get_option('default_library') == 'static' or
-    host_machine.system() == 'windows'
+# CMake vendors cpr statically, including when Iceberg builds shared libraries.
+cpr_dep = dependency(
+    'cpr',
+    static: true,
+    default_options: ['default_library=static'],
 )
-cpr_dep = dependency('cpr', static: cpr_needs_static)
 
 iceberg_rest_sources += files('auth/sigv4_manager.cc')
-iceberg_rest_build_deps = [iceberg_dep, cpr_dep]
+iceberg_rest_build_deps = [cpr_dep]
 iceberg_rest_compile_defs = []
 
 sigv4_opt = get_option('sigv4')
@@ -62,26 +61,14 @@ else
     iceberg_rest_compile_defs += '-DICEBERG_SIGV4_ENABLED=0'
 endif
 
-iceberg_rest_lib = library(
-    'iceberg_rest',
-    sources: iceberg_rest_sources,
-    dependencies: iceberg_rest_build_deps,
-    gnu_symbol_visibility: 'hidden',
-    cpp_shared_args: ['-DICEBERG_REST_EXPORTING'] + iceberg_rest_compile_defs,
-    cpp_static_args: ['-DICEBERG_REST_STATIC'] + iceberg_rest_compile_defs,
-)
-
-iceberg_rest_compile_args = iceberg_rest_compile_defs
-if get_option('default_library') == 'static'
-    iceberg_rest_compile_args += ['-DICEBERG_REST_STATIC']
-endif
-iceberg_rest_dep = declare_dependency(
-    link_with: [iceberg_rest_lib],
-    dependencies: iceberg_rest_build_deps,
-    compile_args: iceberg_rest_compile_args,
-)
-meson.override_dependency('iceberg-rest', iceberg_rest_dep)
-pkg.generate(iceberg_rest_lib)
+iceberg_libraries += {
+    'iceberg_rest': {
+        'sources': iceberg_rest_sources,
+        'dependencies': iceberg_rest_build_deps,
+        'parent': 'iceberg',
+        'compile_args': iceberg_rest_compile_defs,
+    },
+}
 
 install_headers(
     [

--- a/src/iceberg/catalog/rest/meson.build
+++ b/src/iceberg/catalog/rest/meson.build
@@ -48,12 +48,16 @@ iceberg_rest_compile_defs = []
 sigv4_opt = get_option('sigv4')
 # Use the CMake config, not pkg-config: aws-cpp-sdk-core.pc Cflags force
 # -std=c++11 -fno-exceptions, which would override the project's C++23 build.
-aws_sdk_core_dep = dependency(
-    'aws-cpp-sdk-core',
-    method: 'cmake',
-    modules: ['aws-cpp-sdk-core'],
-    required: sigv4_opt,
-)
+if not sigv4_opt.disabled() and arrow_aws_sdk_core_dep.found()
+    aws_sdk_core_dep = arrow_aws_sdk_core_dep
+else
+    aws_sdk_core_dep = dependency(
+        'aws-cpp-sdk-core',
+        method: 'cmake',
+        modules: ['aws-cpp-sdk-core'],
+        required: sigv4_opt,
+    )
+endif
 if aws_sdk_core_dep.found()
     iceberg_rest_build_deps += aws_sdk_core_dep
     iceberg_rest_compile_defs += '-DICEBERG_SIGV4_ENABLED=1'

--- a/src/iceberg/catalog/sql/meson.build
+++ b/src/iceberg/catalog/sql/meson.build
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Match ICEBERG_SQL_CATALOG_SOURCES and the optional built-in connectors.
+iceberg_sql_catalog_sources = files('connection_uri.cc', 'sql_catalog.cc')
+sql_deps = []
+sql_config = configuration_data()
+sql_connectors = {
+    'sqlite': ['sqlite3', 'SQLITE3', 'catalog_store_sqlite3.cc'],
+    'postgresql': ['libpq', 'POSTGRESQL', 'catalog_store_postgresql.cc'],
+    'mysql': ['mysqlclient', 'MYSQL', 'catalog_store_mysql.cc'],
+}
+foreach connector, spec : sql_connectors
+    opt = get_option('sql_' + connector)
+    native_dep = dependency(spec[0], required: opt, allow_fallback: false)
+    enabled = native_dep.found()
+    set_variable('sql_' + connector + '_enabled', enabled)
+    if enabled
+        sql_config.set('BUILD_' + spec[1] + '_CONNECTOR', true)
+        iceberg_sql_catalog_sources += files(spec[2])
+        sql_deps += native_dep
+    endif
+endforeach
+if sql_deps.length() > 0
+    # sqlpp23 is a build-only header dependency. Only the native database
+    # clients belong to the installed library's link interface.
+    sqlpp23_dep = dependency('sqlpp23', static: true, allow_fallback: false)
+    sql_deps += sqlpp23_dep
+endif
+configure_file(
+    input: 'config.h.in',
+    output: 'config.h',
+    format: 'cmake',
+    configuration: sql_config,
+)
+iceberg_libraries += {
+    'iceberg_sql_catalog': {
+        'sources': iceberg_sql_catalog_sources,
+        'dependencies': sql_deps,
+        'parent': 'iceberg',
+    },
+}
+install_headers(
+    ['catalog_store.h', 'iceberg_sql_catalog_export.h', 'sql_catalog.h'],
+    subdir: 'iceberg/catalog/sql',
+)

--- a/src/iceberg/meson.build
+++ b/src/iceberg/meson.build
@@ -54,7 +54,7 @@ conf_data.set(
     'ICEBERG_FULL_VERSION_STRING',
     'Apache Iceberg-CPP ' + version_string + ' (commit ' + git_commit_id + ')',
 )
-conf_data.set('PROJECT_NAME', meson.project_name())
+conf_data.set('PROJECT_NAME', 'Iceberg')
 configure_file(
     input: 'version.h.in',
     output: 'version.h',
@@ -65,7 +65,12 @@ configure_file(
 
 # Resolve spdlog before generating logging/config.h. The feature value controls
 # whether a missing dependency is allowed.
-spdlog_dep = dependency('spdlog', required: get_option('spdlog'))
+spdlog_dep = dependency(
+    'spdlog',
+    required: get_option('spdlog'),
+    static: true,
+    default_options: ['default_library=static'],
+)
 spdlog_enabled = spdlog_dep.found()
 
 subdir('logging')
@@ -227,28 +232,346 @@ iceberg_data_sources = files(
     'data/writer.cc',
 )
 
-# CRoaring does not export symbols, so on Windows it must
-# be used as a static lib
-croaring_needs_static = (
-    get_option('default_library') == 'static'
-    or host_machine.system() == 'windows'
-)
-croaring_dep = dependency('croaring', static: croaring_needs_static)
-nanoarrow_dep = dependency('nanoarrow')
-nlohmann_json_dep = dependency('nlohmann_json')
-# utf8proc's header declares its functions __declspec(dllimport) on Windows unless
-# UTF8PROC_STATIC is defined, and the wrap does not propagate that define to consumers.
-# Define it whenever utf8proc is linked statically, so the header's declarations match
-# how it is linked. Harmless on other platforms.
-utf8proc_needs_static = get_option('default_library') == 'static'
-utf8proc_dep = dependency('libutf8proc', static: utf8proc_needs_static)
-if utf8proc_needs_static
-    utf8proc_dep = declare_dependency(
-        compile_args: ['-DUTF8PROC_STATIC'],
-        dependencies: utf8proc_dep,
+# Use upstream CMake for dependencies that would otherwise need local Meson ports.
+system_format_static = get_option('default_library') != 'shared'
+system_format_variant = system_format_static ? 'static' : 'shared'
+cmake_lookup_args = host_machine.system() == 'windows' ? [
+    '-DZLIB_USE_STATIC_LIBS=ON',
+] : []
+sqlpp23_components = []
+foreach connector, component : {
+    'sqlite': 'SQLite3',
+    'postgresql': 'PostgreSQL',
+    'mysql': 'MySQL',
+}
+    if not get_option('sql_' + connector).disabled()
+        sqlpp23_components += component
+    endif
+endforeach
+cmake_deps = {
+    'croaring': {
+        'name': 'croaring',
+        'project': 'RoaringBitmap',
+        'target': 'roaring',
+        'version': '4.3.11',
+        'options': {
+            'ROARING_BUILD_STATIC': true,
+            'BUILD_SHARED_LIBS': false,
+            'ENABLE_ROARING_TESTS': false,
+            'ROARING_USE_CPM': false,
+        },
+    },
+    'arrow': {
+        'name': 'Arrow',
+        'project': 'IcebergArrow',
+        'target': 'arrow_static',
+        'version': '25.0.0',
+        'enabled': not get_option('bundle').disabled(),
+        'required': get_option('bundle'),
+        'lookup': {
+            'method': 'cmake',
+            'modules': ['Arrow::arrow_' + system_format_variant],
+            'version': '>=22.0.0',
+            'cmake_args': cmake_lookup_args,
+        },
+        'options': {
+            'ARROW_BUILD_SHARED': false,
+            'ARROW_BUILD_STATIC': true,
+            'ARROW_BUILD_TESTS': false,
+            'ARROW_BUILD_BENCHMARKS': false,
+            'ARROW_FILESYSTEM': true,
+            'ARROW_IPC': true,
+            'ARROW_JSON': true,
+            'ARROW_PARQUET': true,
+            'ARROW_WITH_ZLIB': true,
+            'ARROW_S3': get_option('s3').enabled(),
+            'ARROW_SIMD_LEVEL': 'NONE',
+            'ARROW_RUNTIME_SIMD_LEVEL': 'NONE',
+            'ARROW_POSITION_INDEPENDENT_CODE': true,
+            'ARROW_DEPENDENCY_SOURCE': 'BUNDLED',
+            'ARROW_MIMALLOC': false,
+            'ZLIB_SOURCE': 'SYSTEM',
+            'AWSSDK_SOURCE': 'SYSTEM',
+            'BUILD_WARNING_LEVEL': 'PRODUCTION',
+            'CMAKE_CXX_STANDARD': '20',
+        },
+    },
+    'avro': {
+        'name': 'avro-cpp',
+        'project': 'IcebergAvro',
+        'target': 'avrocpp_s',
+        'version': '1.13.0',
+        'enabled': not get_option('bundle').disabled(),
+        'required': get_option('bundle'),
+        'lookup': {
+            'method': 'cmake',
+            'modules': ['avro-cpp::avrocpp_' + system_format_variant],
+            'version': '>=1.13.0',
+            'cmake_args': cmake_lookup_args,
+        },
+        'options': {
+            'AVRO_USE_BOOST': false,
+            'AVRO_BUILD_TESTS': false,
+            'AVRO_BUILD_EXECUTABLES': false,
+            'AVRO_BUILD_SHARED': false,
+            'AVRO_BUILD_STATIC': true,
+            'CMAKE_CXX_VISIBILITY_PRESET': 'hidden',
+            'CMAKE_VISIBILITY_INLINES_HIDDEN': true,
+        },
+    },
+    'sqlpp23': {
+        'name': 'sqlpp23',
+        'project': 'sqlpp23',
+        'target': 'sqlpp23',
+        'version': '0.69',
+        'lookup_name': 'Sqlpp23',
+        'lookup': {
+            'method': 'cmake',
+            'modules': ['sqlpp23::core'],
+            'components': sqlpp23_components,
+        },
+        'enabled': get_option('sql_catalog').enabled() and (not get_option(
+            'sql_sqlite',
+        ).disabled() or not get_option(
+            'sql_postgresql',
+        ).disabled() or not get_option(
+            'sql_mysql',
+        ).disabled()),
+        'options': {'BUILD_WITH_MODULES': false},
+    },
+}
+# Keep the native CMake configuration consistent with Meson's build type.
+cmake_build_types = {
+    'debug': 'Debug',
+    'debugoptimized': 'RelWithDebInfo',
+    'release': 'Release',
+    'minsize': 'MinSizeRel',
+}
+cmake_build_type = cmake_build_types.get(get_option('buildtype'), 'Release')
+arrow_fallback_dep = disabler()
+avro_fallback_dep = disabler()
+arrow_system_lookup = cmake_deps['arrow']['lookup']
+avro_system_lookup = cmake_deps['avro']['lookup']
+arrow_system_static = system_format_static
+avro_system_static = system_format_static
+cmake = import('cmake')
+fs = import('fs')
+pkg = import('pkgconfig')
+foreach name, spec : cmake_deps
+    if not spec.get('enabled', true)
+        continue
+    endif
+    forced = get_option('wrap_mode') == 'forcefallback' or name in get_option(
+        'force_fallback_for',
+    ) or spec['name'] in get_option(
+        'force_fallback_for',
     )
-endif
-zlib_dep = dependency('zlib')
+    if not forced
+        variants = ['static']
+        if name in ['arrow', 'avro'] and not system_format_static
+            variants = ['shared', 'static']
+        endif
+        foreach variant : variants
+            lookup = spec.get('lookup', {})
+            if name == 'arrow'
+                lookup += {'modules': ['Arrow::arrow_' + variant]}
+            elif name == 'avro'
+                lookup += {'modules': ['avro-cpp::avrocpp_' + variant]}
+            endif
+            system_dep = dependency(
+                spec.get('lookup_name', spec['name']),
+                static: variant == 'static',
+                required: false,
+                allow_fallback: false,
+                kwargs: lookup,
+            )
+            if name == 'arrow'
+                arrow_system_lookup = lookup
+                arrow_system_static = variant == 'static'
+                if system_dep.found()
+                    system_parquet_dep = dependency(
+                        'Parquet',
+                        method: 'cmake',
+                        modules: ['Parquet::parquet_' + variant],
+                        static: arrow_system_static,
+                        cmake_args: cmake_lookup_args,
+                        required: false,
+                        allow_fallback: false,
+                    )
+                    if not system_parquet_dep.found()
+                        system_dep = disabler()
+                    endif
+                endif
+            elif name == 'avro'
+                avro_system_lookup = lookup
+                avro_system_static = variant == 'static'
+            endif
+            if system_dep.found()
+                break
+            endif
+        endforeach
+        if name == 'sqlpp23' and (system_dep.found() or get_option('wrap_mode') == 'nofallback')
+            meson.override_dependency('sqlpp23', system_dep, static: true)
+        endif
+        if system_dep.found() or get_option('wrap_mode') == 'nofallback'
+            continue
+        endif
+    endif
+    opts = cmake.subproject_options()
+    project_include = 'CMAKE_PROJECT_' + spec['project'] + '_INCLUDE'
+    opts.add_cmake_defines(
+        {
+            project_include: meson.project_source_root() / 'cmake_modules/IcebergMesonSubproject.cmake',
+        },
+    )
+    if host_machine.system() == 'windows'
+        opts.add_cmake_defines({'ZLIB_USE_STATIC_LIBS': true})
+    endif
+    opts.add_cmake_defines(
+        {
+            'BUILD_TESTING': false,
+            'CMAKE_POSITION_INDEPENDENT_CODE': true,
+            'CMAKE_BUILD_TYPE': cmake_build_type,
+            'CMAKE_INSTALL_LIBDIR': get_option('libdir'),
+            'CMAKE_INSTALL_INCLUDEDIR': get_option('includedir'),
+        } + spec['options'],
+    )
+    interface_args = []
+    if name == 'avro' and host_machine.system() == 'darwin'
+        # Keep std::any type information visible across the shared bundle boundary.
+        interface_args = ['-DAVRO_DYN_LINK']
+        opts.append_compile_args('cpp', interface_args)
+    elif name == 'sqlpp23'
+        opts.set_install(false)
+    endif
+    upstream = cmake.subproject(
+        name,
+        options: opts,
+        required: spec.get('required', true),
+    )
+    if not upstream.found()
+        continue
+    endif
+    cmake_program = find_program('cmake')
+    cmake_build_dir = fs.parent(
+        upstream.target('iceberg_meson_paths').full_path(),
+    ) / '__CMake_build'
+    source_dir = run_command(
+        cmake_program,
+        '-E',
+        'cat',
+        cmake_build_dir / 'iceberg-meson-source-dir.txt',
+        check: true,
+    ).stdout().strip()
+    dep = declare_dependency(
+        dependencies: upstream.dependency(spec['target']),
+        version: spec['version'],
+        compile_args: interface_args,
+    )
+    meson.override_dependency(spec['name'], dep, static: true)
+
+    if name == 'arrow'
+        arrow_fallback_dep = dep
+        # Meson's object-library conversion drops ExternalProject ordering.
+        # xsimd is header-only; let upstream CMake prepare it during setup.
+        run_command(
+            cmake_program,
+            '--build',
+            cmake_build_dir,
+            '--target',
+            'xsimd_ep',
+            check: true,
+        )
+        arrow_thrift_dep = upstream.dependency('thrift')
+        meson.override_dependency('arrow-filesystem', dep, static: true)
+        meson.override_dependency('arrow-json', dep, static: true)
+        meson.override_dependency(
+            'parquet',
+            upstream.dependency('parquet_static'),
+        )
+        pkg.generate(
+            upstream.target('arrow_static'),
+            libraries: upstream.dependency('arrow_static'),
+            filebase: 'arrow',
+            version: spec['version'],
+        )
+        pkg.generate(
+            upstream.target('parquet_static'),
+            libraries: upstream.dependency('parquet_static'),
+            filebase: 'parquet',
+            version: spec['version'],
+        )
+        thrift_version = ''
+        foreach line : fs.read(source_dir / 'cpp/thirdparty/versions.txt').split(
+            '\n',
+        )
+            if line.startswith('ARROW_THRIFT_BUILD_VERSION=')
+                thrift_version = line.split('=')[1].strip()
+            endif
+        endforeach
+        pkg.generate(
+            upstream.target('thrift'),
+            libraries: arrow_thrift_dep,
+            filebase: 'thrift',
+            version: thrift_version,
+        )
+        meson.add_install_script(
+            cmake_program,
+            '--install',
+            cmake_build_dir,
+            '--component',
+            'iceberg_dependency_headers',
+        )
+    elif name == 'avro'
+        avro_fallback_dep = dep
+        pkg.generate(
+            upstream.target('avrocpp_s'),
+            libraries: upstream.dependency('avrocpp_s'),
+            filebase: 'avro-cpp',
+            version: spec['version'],
+            extra_cflags: interface_args,
+        )
+        install_subdir(
+            source_dir / 'lang/c++/include/avro',
+            install_dir: get_option('includedir'),
+        )
+    elif name == 'croaring'
+        pkg.generate(
+            upstream.target('roaring'),
+            filebase: 'croaring',
+            version: spec['version'],
+        )
+        install_subdir(
+            source_dir / 'include/roaring',
+            install_dir: get_option('includedir'),
+        )
+        install_subdir(
+            source_dir / 'cpp/roaring',
+            install_dir: get_option('includedir'),
+        )
+    endif
+endforeach
+
+# Match CMake's static vendored dependencies in every Iceberg library mode.
+# Explicit fallback options avoid accidentally adding runtime DLL dependencies
+# when the top-level project builds shared libraries or both variants.
+croaring_dep = dependency('croaring', static: true, allow_fallback: false)
+nanoarrow_dep = dependency(
+    'nanoarrow',
+    static: true,
+    default_options: ['default_library=static'],
+)
+nlohmann_json_dep = dependency('nlohmann_json')
+utf8proc_dep = dependency(
+    'libutf8proc',
+    static: true,
+    default_options: ['default_library=static'],
+)
+utf8proc_dep = declare_dependency(
+    compile_args: ['-DUTF8PROC_STATIC'],
+    dependencies: utf8proc_dep,
+)
+zlib_dep = dependency('zlib', cmake_args: cmake_lookup_args)
 
 iceberg_deps = [
     nanoarrow_dep,
@@ -262,58 +585,11 @@ if spdlog_enabled
     iceberg_deps += spdlog_dep
 endif
 
-iceberg_lib = library(
-    'iceberg',
-    sources: iceberg_sources,
-    dependencies: iceberg_deps,
-    include_directories: iceberg_include_dir,
-    install: true,
-    gnu_symbol_visibility: 'inlineshidden',
-    cpp_shared_args: ['-DICEBERG_EXPORTING'],
-    cpp_static_args: ['-DICEBERG_STATIC'],
-)
-
-iceberg_interface_args = []
-if get_option('default_library') != 'shared'
-    iceberg_interface_args += ['-DICEBERG_STATIC']
-endif
-
-iceberg_dep = declare_dependency(
-    link_with: iceberg_lib,
-    dependencies: iceberg_deps,
-    include_directories: iceberg_include_dir,
-    compile_args: iceberg_interface_args,
-)
-meson.override_dependency('iceberg', iceberg_dep)
-
-iceberg_data_deps = [iceberg_dep]
-iceberg_data_lib = library(
-    'iceberg_data',
-    sources: iceberg_data_sources,
-    dependencies: iceberg_data_deps,
-    include_directories: iceberg_include_dir,
-    install: true,
-    gnu_symbol_visibility: 'inlineshidden',
-    cpp_shared_args: ['-DICEBERG_DATA_EXPORTING'],
-    cpp_static_args: ['-DICEBERG_DATA_STATIC'],
-)
-
-iceberg_data_interface_args = []
-if get_option('default_library') == 'static'
-    iceberg_data_interface_args += ['-DICEBERG_DATA_STATIC']
-endif
-
-iceberg_data_dep = declare_dependency(
-    link_with: iceberg_data_lib,
-    dependencies: iceberg_data_deps,
-    include_directories: iceberg_include_dir,
-    compile_args: iceberg_data_interface_args,
-)
-meson.override_dependency('iceberg-data', iceberg_data_dep)
-
-pkg = import('pkgconfig')
-pkg.generate(iceberg_lib)
-pkg.generate(iceberg_data_lib)
+# All project libraries use the same variant and installation rules below.
+iceberg_libraries = {
+    'iceberg': {'sources': iceberg_sources, 'dependencies': iceberg_deps},
+    'iceberg_data': {'sources': iceberg_data_sources, 'parent': 'iceberg'},
+}
 
 install_headers(
     [
@@ -328,6 +604,7 @@ install_headers(
         'file_reader.h',
         'file_writer.h',
         'geospatial.h',
+        'iceberg_bundle_export.h',
         'iceberg_data_export.h',
         'iceberg_export.h',
         'inheritable_metadata.h',
@@ -365,7 +642,6 @@ install_headers(
     subdir: 'iceberg',
 )
 
-subdir('catalog')
 subdir('data')
 subdir('deletes')
 subdir('encryption')
@@ -377,6 +653,272 @@ subdir('row')
 subdir('update')
 subdir('util')
 subdir('inspect')
+
+# Keep the bundle's sources and dependencies aligned with ICEBERG_BUILD_BUNDLE.
+# Source fallbacks use static format libraries, as CMake's vendored builds do.
+if get_option('sigv4').enabled() and not get_option('rest').enabled()
+    error('sigv4 requires rest=enabled')
+endif
+if get_option('s3').enabled() and get_option('bundle').disabled()
+    error('s3 requires bundle=enabled')
+endif
+s3_enabled = false
+bundle_enabled = false
+if not get_option('bundle').disabled()
+    # CMake package exports carry the full transitive static link interface.
+    if arrow_fallback_dep.found()
+        arrow_dep = arrow_fallback_dep
+    else
+        arrow_dep = dependency(
+            'Arrow',
+            static: arrow_system_static,
+            required: get_option('bundle'),
+            allow_fallback: false,
+            kwargs: arrow_system_lookup,
+        )
+    endif
+    arrow_filesystem_dep = dependency(
+        'arrow-filesystem',
+        static: arrow_fallback_dep.found() or arrow_system_static,
+        required: get_option('bundle'),
+        allow_fallback: false,
+    )
+    arrow_json_dep = dependency(
+        'arrow-json',
+        static: arrow_fallback_dep.found() or arrow_system_static,
+        required: get_option('bundle'),
+        allow_fallback: false,
+    )
+    if arrow_dep.type_name() == 'internal'
+        parquet_dep = dependency('parquet', allow_fallback: false)
+    else
+        parquet_dep = dependency(
+            'Parquet',
+            method: 'cmake',
+            modules: [
+                'Parquet::parquet_' + (arrow_system_static ? 'static' : 'shared'),
+            ],
+            static: arrow_system_static,
+            cmake_args: cmake_lookup_args,
+            required: get_option('bundle'),
+            allow_fallback: false,
+        )
+    endif
+    if avro_fallback_dep.found()
+        avro_dep = avro_fallback_dep
+    else
+        avro_dep = dependency(
+            'avro-cpp',
+            static: avro_system_static,
+            required: get_option('bundle'),
+            allow_fallback: false,
+            kwargs: avro_system_lookup,
+        )
+    endif
+    bundle_enabled = (
+        arrow_dep.found()
+        and arrow_filesystem_dep.found()
+        and arrow_json_dep.found()
+        and parquet_dep.found()
+        and avro_dep.found()
+    )
+endif
+
+if bundle_enabled
+    if not get_option('s3').disabled()
+        if arrow_dep.type_name() == 'internal'
+            s3_enabled = get_option('s3').enabled()
+        else
+            s3_enabled = cpp.has_header_symbol(
+                'arrow/util/config.h',
+                'ARROW_S3',
+                dependencies: arrow_dep,
+            )
+        endif
+        if get_option('s3').enabled() and not s3_enabled
+            error('s3=enabled requires an Arrow build with S3 support')
+        endif
+    endif
+    iceberg_bundle_sources = files(
+        'arrow/arrow_c_data_util.cc',
+        'arrow/arrow_io.cc',
+        'arrow/arrow_register.cc',
+        'arrow/literal_util.cc',
+        'arrow/metadata_column_util.cc',
+        'arrow/s3/arrow_s3_file_io.cc',
+        'avro/avro_data_util.cc',
+        'avro/avro_direct_decoder.cc',
+        'avro/avro_direct_encoder.cc',
+        'avro/avro_metrics.cc',
+        'avro/avro_reader.cc',
+        'avro/avro_register.cc',
+        'avro/avro_schema_util.cc',
+        'avro/avro_stream_internal.cc',
+        'avro/avro_writer.cc',
+        'parquet/parquet_data_util.cc',
+        'parquet/parquet_metrics.cc',
+        'parquet/parquet_reader.cc',
+        'parquet/parquet_register.cc',
+        'parquet/parquet_schema_util.cc',
+        'parquet/parquet_writer.cc',
+    )
+    iceberg_bundle_format_deps = [
+        arrow_dep,
+        arrow_filesystem_dep,
+        arrow_json_dep,
+        parquet_dep,
+        avro_dep,
+    ]
+    avro_shared_dep = avro_dep
+    if get_option('default_library') != 'static' and avro_dep.type_name() != 'internal'
+        system_avro_shared_dep = dependency(
+            'avro-cpp',
+            method: 'cmake',
+            modules: ['avro-cpp::avrocpp_shared'],
+            cmake_args: cmake_lookup_args,
+            version: '>=1.13.0',
+            static: false,
+            required: false,
+            allow_fallback: false,
+        )
+        if system_avro_shared_dep.found()
+            avro_shared_dep = system_avro_shared_dep
+        endif
+    endif
+    iceberg_bundle_shared_format_deps = [
+        arrow_dep,
+        arrow_filesystem_dep,
+        arrow_json_dep,
+        parquet_dep,
+        avro_shared_dep,
+    ]
+    if get_option('default_library') != 'static' and arrow_dep.type_name() != 'internal'
+        # Like CMake, prefer system shared format libraries for the shared
+        # bundle. Source fallbacks continue to use static libraries.
+        arrow_shared_dep = dependency(
+            'Arrow',
+            method: 'cmake',
+            modules: ['Arrow::arrow_shared'],
+            cmake_args: cmake_lookup_args,
+            static: false,
+            required: false,
+            allow_fallback: false,
+        )
+        parquet_shared_dep = dependency(
+            'Parquet',
+            method: 'cmake',
+            modules: ['Parquet::parquet_shared'],
+            cmake_args: cmake_lookup_args,
+            static: false,
+            required: false,
+            allow_fallback: false,
+        )
+        iceberg_bundle_shared_format_deps = [
+            arrow_shared_dep.found() ? arrow_shared_dep : arrow_dep,
+            parquet_shared_dep.found() ? parquet_shared_dep : parquet_dep,
+            avro_shared_dep,
+        ]
+    endif
+    iceberg_libraries += {
+        'iceberg_bundle': {
+            'sources': iceberg_bundle_sources,
+            'dependencies': iceberg_bundle_format_deps,
+            'shared_dependencies': iceberg_bundle_shared_format_deps,
+            'public_dependencies': true,
+            'parent': 'iceberg_data',
+            'compile_args': ['-DICEBERG_S3_ENABLED=' + (s3_enabled ? '1' : '0')],
+        },
+    }
+
+    subdir('arrow')
+    subdir('avro')
+    subdir('parquet')
+endif
+
+subdir('catalog')
+
+# Keep static and shared dependency graphs separate, including in `both` mode.
+# This also propagates Windows *_STATIC macros to static consumers only.
+iceberg_variants = get_option('default_library') == 'both' ? [
+    'static',
+    'shared',
+] : [
+    get_option('default_library'),
+]
+iceberg_preferred_variant = get_option('default_library') == 'static' ? 'static' : 'shared'
+foreach name, spec : iceberg_libraries
+    parent = spec.get('parent', '')
+    foreach variant : iceberg_variants
+        deps = spec.get(variant + '_dependencies', spec.get('dependencies', []))
+        public_deps = spec.get('public_dependencies', false) ? deps : []
+        requires = []
+        if parent != ''
+            deps = [get_variable(parent + '_' + variant + '_dep')] + deps
+            requires = [parent + '_' + variant]
+        endif
+        if name == 'iceberg_bundle' and avro_dep.type_name() == 'internal'
+            # The CMake wrapper otherwise makes Avro a private pkg-config requirement.
+            requires += ['avro-cpp']
+        endif
+        interface_args = cpp.get_supported_arguments('/Zc:preprocessor')
+        private_args = spec.get('compile_args', [])
+        output_name = name
+        if variant == 'static'
+            if host_machine.system() == 'windows'
+                interface_args += '-D' + name.to_upper() + '_STATIC'
+                if cpp.get_id() in ['msvc', 'clang-cl']
+                    output_name += '_static'
+                endif
+            endif
+        else
+            private_args += '-D' + name.to_upper() + '_EXPORTING'
+        endif
+        lib = build_target(
+            output_name,
+            target_type: variant + '_library',
+            sources: spec['sources'],
+            dependencies: deps,
+            include_directories: [iceberg_include_dir] + spec.get(
+                'include_directories',
+                [],
+            ),
+            install: true,
+            gnu_symbol_visibility: variant == 'shared' ? 'inlineshidden' : 'default',
+            cpp_args: private_args + interface_args,
+        )
+        dep = declare_dependency(
+            link_with: lib,
+            dependencies: deps,
+            include_directories: iceberg_include_dir,
+            compile_args: interface_args,
+        )
+        set_variable(name + '_' + variant + '_lib', lib)
+        set_variable(name + '_' + variant + '_dep', dep)
+        pkg.generate(
+            lib,
+            libraries: public_deps,
+            filebase: name + '_' + variant,
+            requires: requires,
+            extra_cflags: interface_args,
+        )
+        meson.override_dependency(
+            name.replace('_', '-'),
+            dep,
+            static: variant == 'static',
+        )
+        if variant == iceberg_preferred_variant
+            set_variable(name + '_lib', lib)
+            set_variable(name + '_dep', dep)
+            pkg.generate(
+                lib,
+                libraries: public_deps,
+                filebase: name,
+                requires: requires,
+                extra_cflags: interface_args,
+            )
+        endif
+    endforeach
+endforeach
 
 if get_option('tests').enabled()
     subdir('test')

--- a/src/iceberg/meson.build
+++ b/src/iceberg/meson.build
@@ -291,7 +291,7 @@ cmake_deps = {
             'ARROW_DEPENDENCY_SOURCE': 'BUNDLED',
             'ARROW_MIMALLOC': false,
             'ZLIB_SOURCE': 'SYSTEM',
-            'AWSSDK_SOURCE': 'SYSTEM',
+            'AWSSDK_SOURCE': get_option('bundle_awssdk') ? 'BUNDLED' : 'SYSTEM',
             'BUILD_WARNING_LEVEL': 'PRODUCTION',
             'CMAKE_CXX_STANDARD': '20',
         },
@@ -349,6 +349,7 @@ cmake_build_types = {
 }
 cmake_build_type = cmake_build_types.get(get_option('buildtype'), 'Release')
 arrow_fallback_dep = disabler()
+arrow_aws_sdk_core_dep = disabler()
 avro_fallback_dep = disabler()
 arrow_system_lookup = cmake_deps['arrow']['lookup']
 avro_system_lookup = cmake_deps['avro']['lookup']
@@ -483,8 +484,26 @@ foreach name, spec : cmake_deps
             check: true,
         )
         arrow_thrift_dep = upstream.dependency('thrift')
-        meson.override_dependency('arrow-filesystem', dep, static: true)
-        meson.override_dependency('arrow-json', dep, static: true)
+        if get_option('s3').enabled() and get_option('bundle_awssdk')
+            sdk_libs = run_command(
+                cmake_program,
+                '-E',
+                'cat',
+                cmake_build_dir / 'iceberg-meson-awssdk-libs.txt',
+                check: true,
+            ).stdout().strip().split(
+                '\n',
+            )
+            foreach sdk_lib : sdk_libs
+                pkg.generate(
+                    upstream.target(sdk_lib),
+                    libraries: upstream.dependency(sdk_lib),
+                    filebase: 'iceberg_' + sdk_lib,
+                )
+            endforeach
+            # SigV4 must reuse the SDK linked into Arrow when S3 bundles it.
+            arrow_aws_sdk_core_dep = upstream.dependency('aws-cpp-sdk-core')
+        endif
         meson.override_dependency(
             'parquet',
             upstream.dependency('parquet_static'),
@@ -677,18 +696,6 @@ if not get_option('bundle').disabled()
             kwargs: arrow_system_lookup,
         )
     endif
-    arrow_filesystem_dep = dependency(
-        'arrow-filesystem',
-        static: arrow_fallback_dep.found() or arrow_system_static,
-        required: get_option('bundle'),
-        allow_fallback: false,
-    )
-    arrow_json_dep = dependency(
-        'arrow-json',
-        static: arrow_fallback_dep.found() or arrow_system_static,
-        required: get_option('bundle'),
-        allow_fallback: false,
-    )
     if arrow_dep.type_name() == 'internal'
         parquet_dep = dependency('parquet', allow_fallback: false)
     else
@@ -717,8 +724,6 @@ if not get_option('bundle').disabled()
     endif
     bundle_enabled = (
         arrow_dep.found()
-        and arrow_filesystem_dep.found()
-        and arrow_json_dep.found()
         and parquet_dep.found()
         and avro_dep.found()
     )
@@ -762,13 +767,7 @@ if bundle_enabled
         'parquet/parquet_schema_util.cc',
         'parquet/parquet_writer.cc',
     )
-    iceberg_bundle_format_deps = [
-        arrow_dep,
-        arrow_filesystem_dep,
-        arrow_json_dep,
-        parquet_dep,
-        avro_dep,
-    ]
+    iceberg_bundle_format_deps = [arrow_dep, parquet_dep, avro_dep]
     avro_shared_dep = avro_dep
     if get_option('default_library') != 'static' and avro_dep.type_name() != 'internal'
         system_avro_shared_dep = dependency(
@@ -787,8 +786,6 @@ if bundle_enabled
     endif
     iceberg_bundle_shared_format_deps = [
         arrow_dep,
-        arrow_filesystem_dep,
-        arrow_json_dep,
         parquet_dep,
         avro_shared_dep,
     ]

--- a/src/iceberg/meson.build
+++ b/src/iceberg/meson.build
@@ -487,8 +487,16 @@ foreach name, spec : cmake_deps
         cmake_build_dir / 'iceberg-meson-source-dir.txt',
         check: true,
     ).stdout().strip()
+    system_deps = []
+    if name == 'arrow' and get_option('s3').enabled() and get_option(
+        'bundle_awssdk',
+    ) and host_machine.system() == 'linux'
+        # Meson's CMake conversion drops static OpenSSL flags such as Ubuntu's
+        # -l:libjitterentropy.a. Preserve them in links and .pc files.
+        system_deps += dependency('libcrypto', static: true)
+    endif
     dep = declare_dependency(
-        dependencies: upstream.dependency(spec['target']),
+        dependencies: [upstream.dependency(spec['target'])] + system_deps,
         version: spec['version'],
         compile_args: interface_args,
     )
@@ -518,14 +526,20 @@ foreach name, spec : cmake_deps
                 '\n',
             )
             foreach sdk_lib : sdk_libs
+                sdk_deps = [upstream.dependency(sdk_lib)]
+                if sdk_lib in ['s2n', 'aws-c-cal']
+                    sdk_deps += system_deps
+                endif
                 pkg.generate(
                     upstream.target(sdk_lib),
-                    libraries: upstream.dependency(sdk_lib),
+                    libraries: sdk_deps,
                     filebase: 'iceberg_' + sdk_lib,
                 )
             endforeach
             # SigV4 must reuse the SDK linked into Arrow when S3 bundles it.
-            arrow_aws_sdk_core_dep = upstream.dependency('aws-cpp-sdk-core')
+            arrow_aws_sdk_core_dep = declare_dependency(
+                dependencies: [upstream.dependency('aws-cpp-sdk-core')] + system_deps,
+            )
         endif
         meson.override_dependency(
             'parquet',
@@ -533,7 +547,7 @@ foreach name, spec : cmake_deps
         )
         pkg.generate(
             upstream.target('arrow_static'),
-            libraries: upstream.dependency('arrow_static'),
+            libraries: dep,
             filebase: 'arrow',
             version: spec['version'],
         )

--- a/src/iceberg/meson.build
+++ b/src/iceberg/meson.build
@@ -351,7 +351,7 @@ cmake_build_type = cmake_build_types.get(get_option('buildtype'), 'Release')
 arrow_fallback_dep = disabler()
 arrow_aws_sdk_core_dep = disabler()
 avro_fallback_dep = disabler()
-arrow_system_lookup = cmake_deps['arrow']['lookup']
+arrow_system_dep = disabler()
 avro_system_lookup = cmake_deps['avro']['lookup']
 arrow_system_static = system_format_static
 avro_system_static = system_format_static
@@ -387,8 +387,21 @@ foreach name, spec : cmake_deps
                 kwargs: lookup,
             )
             if name == 'arrow'
-                arrow_system_lookup = lookup
                 arrow_system_static = variant == 'static'
+                if system_dep.found()
+                    # These features are part of Arrow's main CMake target;
+                    # their separate pkg-config files need not be installed.
+                    foreach feature : ['ARROW_FILESYSTEM', 'ARROW_JSON']
+                        if not cpp.has_header_symbol(
+                            'arrow/util/config.h',
+                            feature,
+                            dependencies: system_dep,
+                        )
+                            system_dep = disabler()
+                            break
+                        endif
+                    endforeach
+                endif
                 if system_dep.found()
                     system_parquet_dep = dependency(
                         'Parquet',
@@ -411,6 +424,16 @@ foreach name, spec : cmake_deps
                 break
             endif
         endforeach
+        if name == 'arrow'
+            arrow_system_dep = system_dep
+            if not system_dep.found() and get_option('wrap_mode') == 'nofallback' and get_option(
+                'bundle',
+            ).enabled()
+                error(
+                    'bundle=enabled requires Arrow with filesystem and JSON support and matching Parquet libraries',
+                )
+            endif
+        endif
         if name == 'sqlpp23' and (system_dep.found() or get_option('wrap_mode') == 'nofallback')
             meson.override_dependency('sqlpp23', system_dep, static: true)
         endif
@@ -688,13 +711,7 @@ if not get_option('bundle').disabled()
     if arrow_fallback_dep.found()
         arrow_dep = arrow_fallback_dep
     else
-        arrow_dep = dependency(
-            'Arrow',
-            static: arrow_system_static,
-            required: get_option('bundle'),
-            allow_fallback: false,
-            kwargs: arrow_system_lookup,
-        )
+        arrow_dep = arrow_system_dep
     endif
     if arrow_dep.type_name() == 'internal'
         parquet_dep = dependency('parquet', allow_fallback: false)

--- a/src/iceberg/parquet/meson.build
+++ b/src/iceberg/parquet/meson.build
@@ -15,20 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-benchmark_dep = dependency(
-    'benchmark',
-    required: true,
-    static: true,
-    default_options: ['default_library=static'],
+install_headers(
+    ['parquet_reader.h', 'parquet_register.h', 'parquet_writer.h'],
+    subdir: 'iceberg/parquet',
 )
-
-benchmark_smoke = executable(
-    'benchmark_smoke',
-    sources: files('benchmark_smoke.cc'),
-    dependencies: [
-        get_variable('iceberg_static_dep', iceberg_dep),
-        benchmark_dep,
-    ],
-)
-
-benchmark('benchmark_smoke', benchmark_smoke)

--- a/src/iceberg/test/meson.build
+++ b/src/iceberg/test/meson.build
@@ -23,9 +23,53 @@ configure_file(
     input: 'test_config.h.in',
     output: 'test_config.h',
     configuration: conf_data,
-    install: true,
-    install_dir: get_option('includedir') / 'iceberg/test',
 )
+
+# CMake's tests prefer static libraries because they also exercise internal
+# helpers. Keep those symbols private in installed shared libraries. Reuse
+# compiled objects on Unix; Windows needs sources compiled with *_STATIC so
+# references between the test libraries do not use DLL imports.
+foreach name, spec : iceberg_libraries
+    deps = spec.get('dependencies', [])
+    parent = spec.get('parent', '')
+    if parent != ''
+        deps = [get_variable(parent + '_test_dep')] + deps
+    endif
+    test_args = spec.get('compile_args', [])
+    if host_machine.system() == 'windows'
+        test_args += '-D' + name.to_upper() + '_STATIC'
+    endif
+    if get_option('default_library') != 'shared'
+        lib = get_variable(name + '_static_lib')
+    elif host_machine.system() == 'windows'
+        lib = static_library(
+            name + '_test',
+            sources: spec['sources'],
+            dependencies: deps,
+            include_directories: [iceberg_include_dir] + spec.get(
+                'include_directories',
+                [],
+            ),
+            cpp_args: test_args,
+        )
+    else
+        lib = static_library(
+            name + '_test',
+            objects: get_variable(name + '_shared_lib').extract_all_objects(
+                recursive: true,
+            ),
+        )
+    endif
+    set_variable(
+        name + '_test_dep',
+        declare_dependency(
+            link_with: lib,
+            dependencies: deps,
+            include_directories: iceberg_include_dir,
+            compile_args: test_args,
+        ),
+    )
+endforeach
 
 iceberg_tests = {
     'schema_test': {
@@ -49,10 +93,10 @@ iceberg_tests = {
         'sources': files(
             'catalog_util_test.cc',
             'location_provider_test.cc',
-            'metadata_table_test.cc',
             'metrics_config_test.cc',
             'metrics_reporter_test.cc',
             'metrics_test.cc',
+            'snapshot_summary_builder_test.cc',
             'snapshot_test.cc',
             'snapshot_util_test.cc',
             'table_metadata_builder_test.cc',
@@ -60,7 +104,6 @@ iceberg_tests = {
             'table_requirements_test.cc',
             'table_test.cc',
             'table_update_test.cc',
-            'update_schema_test.cc',
         ),
     },
     'logging_test': {
@@ -133,7 +176,6 @@ iceberg_tests = {
     },
     'puffin_test': {
         'sources': files(
-            'dv_writer_test.cc',
             'puffin_format_test.cc',
             'puffin_json_test.cc',
             'puffin_reader_writer_test.cc',
@@ -141,6 +183,114 @@ iceberg_tests = {
         'use_data': true,
     },
 }
+
+if bundle_enabled
+    iceberg_tests += {
+        'avro_test': {
+            'sources': files(
+                'avro_data_test.cc',
+                'avro_schema_test.cc',
+                'avro_stream_test.cc',
+                'avro_test.cc',
+            ),
+            'use_bundle': true,
+        },
+        'arrow_test': {
+            'sources': files(
+                'arrow_io_test.cc',
+                'arrow_test.cc',
+                'gzip_decompress_test.cc',
+                'metadata_io_test.cc',
+                'struct_like_test.cc',
+            ),
+            'use_bundle': true,
+        },
+        'catalog_test': {
+            'sources': files('in_memory_catalog_test.cc'),
+            'use_bundle': true,
+        },
+        'metadata_table_test': {
+            'sources': files('metadata_table_test.cc'),
+            'use_bundle': true,
+        },
+        'eval_expr_test': {
+            'sources': files('eval_expr_test.cc', 'evaluator_test.cc'),
+            'use_bundle': true,
+        },
+        'manifest_test': {
+            'sources': files(
+                'delete_file_index_test.cc',
+                'manifest_group_test.cc',
+                'manifest_list_versions_test.cc',
+                'manifest_merge_manager_test.cc',
+                'manifest_reader_stats_test.cc',
+                'manifest_reader_test.cc',
+                'manifest_writer_versions_test.cc',
+                'rolling_manifest_writer_test.cc',
+            ),
+            'use_bundle': true,
+        },
+        'parquet_test': {
+            'sources': files(
+                'metrics_test_base.cc',
+                'parquet_data_test.cc',
+                'parquet_metrics_test.cc',
+                'parquet_schema_test.cc',
+                'parquet_test.cc',
+            ),
+            'use_bundle': true,
+        },
+        'scan_test': {
+            'sources': files(
+                'file_scan_task_test.cc',
+                'incremental_append_scan_test.cc',
+                'incremental_changelog_scan_test.cc',
+                'scan_planning_metrics_test.cc',
+                'table_scan_test.cc',
+            ),
+            'use_bundle': true,
+        },
+        'table_update_test': {
+            'sources': files(
+                'delete_files_test.cc',
+                'expire_snapshots_test.cc',
+                'fast_append_test.cc',
+                'manifest_filter_manager_test.cc',
+                'merge_append_test.cc',
+                'merging_snapshot_update_test.cc',
+                'name_mapping_update_test.cc',
+                'overwrite_files_test.cc',
+                'replace_partitions_test.cc',
+                'rewrite_files_test.cc',
+                'row_delta_test.cc',
+                'snapshot_manager_test.cc',
+                'transaction_test.cc',
+                'update_location_test.cc',
+                'update_partition_spec_test.cc',
+                'update_partition_statistics_test.cc',
+                'update_properties_test.cc',
+                'update_schema_test.cc',
+                'update_sort_order_test.cc',
+                'update_statistics_test.cc',
+            ),
+            'use_bundle': true,
+        },
+        'data_test': {
+            'sources': files(
+                'arrow_c_data_util_test.cc',
+                'arrow_row_builder_test.cc',
+                'data_writer_test.cc',
+                'default_value_test.cc',
+                'delete_filter_test.cc',
+                'delete_loader_test.cc',
+                'dv_writer_test.cc',
+                'file_scan_task_reader_test.cc',
+                'literal_util_test.cc',
+            ),
+            'use_bundle': true,
+        },
+    }
+endif
 
 if get_option('rest').enabled()
     iceberg_tests += {
@@ -154,14 +304,23 @@ if get_option('rest').enabled()
                 'rest_metrics_reporter_test.cc',
                 'rest_util_test.cc',
             ),
-            'dependencies': [iceberg_rest_dep],
+            'dependencies': [iceberg_rest_test_dep],
         },
     }
+    if bundle_enabled
+        iceberg_tests += {
+            'rest_arrow_file_io_test': {
+                'sources': files('rest_arrow_file_io_test.cc'),
+                'dependencies': [iceberg_rest_test_dep],
+                'use_bundle': true,
+            },
+        }
+    endif
     if aws_sdk_core_dep.found()
         iceberg_tests += {
             'sigv4_auth_test': {
                 'sources': files('sigv4_auth_test.cc'),
-                'dependencies': [iceberg_rest_dep, aws_sdk_core_dep],
+                'dependencies': [iceberg_rest_test_dep, aws_sdk_core_dep],
             },
         }
     endif
@@ -170,25 +329,53 @@ if get_option('rest').enabled()
             warning('Cannot build rest integration test on Windows, skipping.')
         else
             iceberg_tests += {
-                'rest_integration_test': {
+                'rest_catalog_integration_test': {
                     'sources': files(
                         'rest_catalog_integration_test.cc',
                         'util/cmd_util.cc',
                         'util/docker_compose_util.cc',
                     ),
-                    'dependencies': [iceberg_rest_dep],
+                    'dependencies': [iceberg_rest_test_dep],
                 },
             }
         endif
     endif
 endif
 
+if s3_enabled
+    iceberg_tests += {
+        'file_io_test': {
+            'sources': files('arrow_s3_file_io_test.cc'),
+            'use_bundle': true,
+        },
+    }
+endif
+if get_option('hive').enabled()
+    iceberg_tests += {
+        'hive_catalog_test': {
+            'sources': files('hms_client_test.cc'),
+            'dependencies': [iceberg_hive_test_dep],
+        },
+    }
+endif
+if get_option('sql_catalog').enabled() and sql_sqlite_enabled and bundle_enabled
+    iceberg_tests += {
+        'sql_catalog_test': {
+            'sources': files('sql_catalog_test.cc'),
+            'dependencies': [iceberg_sql_catalog_test_dep],
+            'use_bundle': true,
+        },
+    }
+endif
+
 foreach test_name, values : iceberg_tests
     test_deps = [gmock_main_dep] + values.get('dependencies', [])
-    if values.get('use_data', false)
-        test_deps = [iceberg_data_dep] + test_deps
+    if values.get('use_bundle', false)
+        test_deps = [iceberg_bundle_test_dep] + test_deps
+    elif values.get('use_data', false)
+        test_deps = [iceberg_data_test_dep] + test_deps
     else
-        test_deps = [iceberg_dep] + test_deps
+        test_deps = [iceberg_test_dep] + test_deps
     endif
 
     exc = executable(

--- a/subprojects/arrow.wrap
+++ b/subprojects/arrow.wrap
@@ -15,20 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-benchmark_dep = dependency(
-    'benchmark',
-    required: true,
-    static: true,
-    default_options: ['default_library=static'],
-)
+[wrap-file]
+directory = apache-arrow-25.0.0
+source_url = https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-25.0.0/apache-arrow-25.0.0.tar.gz
+source_fallback_url = https://archive.apache.org/dist/arrow/arrow-25.0.0/apache-arrow-25.0.0.tar.gz
+source_filename = apache-arrow-25.0.0.tar.gz
+source_hash = 12afc2dc8137bdd4a68876cec939f664c9d55cfc7b75f55b45163ebb4e344d81
+patch_directory = arrow
+method = cmake
 
-benchmark_smoke = executable(
-    'benchmark_smoke',
-    sources: files('benchmark_smoke.cc'),
-    dependencies: [
-        get_variable('iceberg_static_dep', iceberg_dep),
-        benchmark_dep,
-    ],
-)
-
-benchmark('benchmark_smoke', benchmark_smoke)
+[provide]
+arrow = arrow_static_dep
+parquet = parquet_static_dep

--- a/subprojects/avro.wrap
+++ b/subprojects/avro.wrap
@@ -15,20 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-benchmark_dep = dependency(
-    'benchmark',
-    required: true,
-    static: true,
-    default_options: ['default_library=static'],
-)
+# Keep this revision aligned with resolve_avro_dependency() in CMake.
+[wrap-file]
+directory = avro-997d50d312613e921598aaed30b082f9bcf9c6ea
+source_url = https://github.com/apache/avro/archive/997d50d312613e921598aaed30b082f9bcf9c6ea.tar.gz
+source_filename = avro-997d50d312613e921598aaed30b082f9bcf9c6ea.tar.gz
+source_hash = 8cf9ba3f54a9745ad7418d04e9f2104af3a4398140f93fa888f4fc70093411c8
+patch_directory = avro
+method = cmake
 
-benchmark_smoke = executable(
-    'benchmark_smoke',
-    sources: files('benchmark_smoke.cc'),
-    dependencies: [
-        get_variable('iceberg_static_dep', iceberg_dep),
-        benchmark_dep,
-    ],
-)
-
-benchmark('benchmark_smoke', benchmark_smoke)
+[provide]
+avro-cpp = avrocpp_s_dep

--- a/subprojects/packagefiles/arrow/CMakeLists.txt
+++ b/subprojects/packagefiles/arrow/CMakeLists.txt
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cmake_minimum_required(VERSION 3.25)
+project(IcebergArrow LANGUAGES C CXX)
+
+# Meson's CMake module imports library targets but not header installation.
+# Keep upstream's header selection and destinations in a separate component.
+function(install)
+  if(ARGV0 MATCHES "^(FILES|DIRECTORY)$")
+    cmake_parse_arguments(HEADER_INSTALL
+                          ""
+                          "DESTINATION"
+                          ""
+                          ${ARGN})
+    if(HEADER_INSTALL_DESTINATION MATCHES "^${CMAKE_INSTALL_INCLUDEDIR}(/|$)")
+      set(HEADER_ARGS ${ARGV})
+      list(FIND HEADER_ARGS DESTINATION DESTINATION_INDEX)
+      math(EXPR COMPONENT_INDEX "${DESTINATION_INDEX} + 2")
+      list(INSERT
+           HEADER_ARGS
+           ${COMPONENT_INDEX}
+           COMPONENT
+           iceberg_dependency_headers)
+      _install(${HEADER_ARGS})
+      return()
+    endif()
+  endif()
+  _install(${ARGV})
+endfunction()
+
+# Older Thrift releases are removed from the live Apache mirrors.
+if(NOT DEFINED ENV{ARROW_THRIFT_URL})
+  set(ENV{ARROW_THRIFT_URL}
+      "https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz")
+endif()
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/cpp" upstream)
+
+# Meson needs compile flags to recognize PIC on archives of object libraries.
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/meson_static.cc" "")
+foreach(target arrow_static parquet_static)
+  target_sources(${target} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/meson_static.cc")
+  set_target_properties(${target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endforeach()
+
+# Meson's CMake conversion does not propagate system libraries through Arrow's
+# object libraries. Reuse the install interface computed by upstream CMake.
+get_directory_property(ARROW_MESON_SYSTEM_LIBS
+                       DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/cpp/src/arrow" DEFINITION
+                                 ARROW_STATIC_INSTALL_INTERFACE_LIBS)
+list(REMOVE_ITEM ARROW_MESON_SYSTEM_LIBS Arrow::arrow_bundled_dependencies)
+set_property(TARGET arrow_static
+             APPEND
+             PROPERTY INTERFACE_LINK_LIBRARIES ${ARROW_MESON_SYSTEM_LIBS})
+
+# Preserve Thrift when Meson flattens Arrow's object libraries.
+target_link_libraries(arrow_static INTERFACE thrift)
+target_link_libraries(parquet_static INTERFACE thrift)
+
+if(WIN32)
+  target_compile_definitions(thrift INTERFACE THRIFT_STATIC_DEFINE)
+endif()

--- a/subprojects/packagefiles/arrow/CMakeLists.txt
+++ b/subprojects/packagefiles/arrow/CMakeLists.txt
@@ -48,6 +48,22 @@ if(NOT DEFINED ENV{ARROW_THRIFT_URL})
   set(ENV{ARROW_THRIFT_URL}
       "https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz")
 endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux"
+   AND ARROW_S3
+   AND AWSSDK_SOURCE STREQUAL "BUNDLED")
+  # Meson cannot translate s2n's libcrypto symbol rewriting commands. Use the
+  # same system OpenSSL as Arrow and aws-c-cal instead of embedding AWS-LC.
+  set(FETCHCONTENT_SOURCE_DIR_AWS-LC "${CMAKE_CURRENT_LIST_DIR}/openssl")
+  include(FetchContent)
+  macro(FetchContent_MakeAvailable)
+    if("${ARGV0}" STREQUAL "s2n-tls")
+      set(S2N_INTERN_LIBCRYPTO OFF)
+      set(ADDITIONAL_FLAGS "-DCOMPILE_DEFINITIONS=-I${OPENSSL_INCLUDE_DIR}")
+    endif()
+    _fetchcontent_makeavailable(${ARGV})
+  endmacro()
+endif()
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/cpp" upstream)
 
 # Meson needs compile flags to recognize PIC on archives of object libraries.

--- a/subprojects/packagefiles/arrow/CMakeLists.txt
+++ b/subprojects/packagefiles/arrow/CMakeLists.txt
@@ -71,6 +71,28 @@ set_property(TARGET arrow_static
 target_link_libraries(arrow_static INTERFACE thrift)
 target_link_libraries(parquet_static INTERFACE thrift)
 
+if(ARROW_S3 AND AWSSDK_SOURCE STREQUAL "BUNDLED")
+  # Preserve the SDK libraries when Meson flattens Arrow's filesystem objects.
+  get_directory_property(ARROW_MESON_AWSSDK_LIBS
+                         DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/cpp" DEFINITION
+                                   AWSSDK_LINK_LIBRARIES)
+  target_link_libraries(arrow_static INTERFACE ${ARROW_MESON_AWSSDK_LIBS})
+  if(APPLE)
+    # Meson's CMake conversion drops the SDK's "-framework ..." library strings.
+    # Link options preserve them for both build and installed consumers.
+    target_link_options(aws-c-common INTERFACE "-Wl,-framework,CoreFoundation")
+    target_link_options(aws-c-cal INTERFACE "-Wl,-framework,Security")
+    target_link_options(aws-c-io INTERFACE "-Wl,-framework,Security"
+                        "-Wl,-framework,Network")
+  endif()
+  # Export leaves first so Meson can generate pkg-config requirements without
+  # repeatedly expanding the SDK's transitive dependency graph.
+  list(REVERSE ARROW_MESON_AWSSDK_LIBS)
+  list(JOIN ARROW_MESON_AWSSDK_LIBS "\n" ARROW_MESON_AWSSDK_LIBS)
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/iceberg-meson-awssdk-libs.txt"
+       "${ARROW_MESON_AWSSDK_LIBS}\n")
+endif()
+
 if(WIN32)
   target_compile_definitions(thrift INTERFACE THRIFT_STATIC_DEFINE)
 endif()

--- a/subprojects/packagefiles/arrow/CMakeLists.txt
+++ b/subprojects/packagefiles/arrow/CMakeLists.txt
@@ -55,14 +55,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux"
   # Meson cannot translate s2n's libcrypto symbol rewriting commands. Use the
   # same system OpenSSL as Arrow and aws-c-cal instead of embedding AWS-LC.
   set(FETCHCONTENT_SOURCE_DIR_AWS-LC "${CMAKE_CURRENT_LIST_DIR}/openssl")
-  include(FetchContent)
-  macro(FetchContent_MakeAvailable)
-    if("${ARGV0}" STREQUAL "s2n-tls")
-      set(S2N_INTERN_LIBCRYPTO OFF)
-      set(ADDITIONAL_FLAGS "-DCOMPILE_DEFINITIONS=-I${OPENSSL_INCLUDE_DIR}")
-    endif()
-    _fetchcontent_makeavailable(${ARGV})
-  endmacro()
+  set(CMAKE_PROJECT_s2n_INCLUDE "${CMAKE_CURRENT_LIST_DIR}/openssl/s2n.cmake")
 endif()
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/cpp" upstream)
 

--- a/subprojects/packagefiles/arrow/openssl/CMakeLists.txt
+++ b/subprojects/packagefiles/arrow/openssl/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cmake_minimum_required(VERSION 3.25)
+
+# Provide s2n's expected target without introducing a second libcrypto.
+find_package(OpenSSL REQUIRED GLOBAL)
+add_library(crypto INTERFACE IMPORTED GLOBAL)
+target_link_libraries(crypto INTERFACE OpenSSL::Crypto)

--- a/subprojects/packagefiles/arrow/openssl/s2n.cmake
+++ b/subprojects/packagefiles/arrow/openssl/s2n.cmake
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Apply after Arrow's SDK builder sets its defaults and before s2n configures.
+set(S2N_INTERN_LIBCRYPTO OFF)
+set(ADDITIONAL_FLAGS "-DCOMPILE_DEFINITIONS=-I${OPENSSL_INCLUDE_DIR}")

--- a/subprojects/packagefiles/avro/CMakeLists.txt
+++ b/subprojects/packagefiles/avro/CMakeLists.txt
@@ -15,20 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-benchmark_dep = dependency(
-    'benchmark',
-    required: true,
-    static: true,
-    default_options: ['default_library=static'],
-)
-
-benchmark_smoke = executable(
-    'benchmark_smoke',
-    sources: files('benchmark_smoke.cc'),
-    dependencies: [
-        get_variable('iceberg_static_dep', iceberg_dep),
-        benchmark_dep,
-    ],
-)
-
-benchmark('benchmark_smoke', benchmark_smoke)
+cmake_minimum_required(VERSION 3.25)
+project(IcebergAvro LANGUAGES C CXX)
+add_subdirectory(lang/c++ upstream)

--- a/subprojects/sqlpp23.wrap
+++ b/subprojects/sqlpp23.wrap
@@ -15,20 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-benchmark_dep = dependency(
-    'benchmark',
-    required: true,
-    static: true,
-    default_options: ['default_library=static'],
-)
+[wrap-file]
+directory = sqlpp23-0.69
+source_url = https://github.com/rbock/sqlpp23/archive/refs/tags/0.69.tar.gz
+source_filename = sqlpp23-0.69.tar.gz
+source_hash = ff4a31f4f110623781e3fd5c49846f76bb758f0c877cb15395c50cfad7a71253
+method = cmake
 
-benchmark_smoke = executable(
-    'benchmark_smoke',
-    sources: files('benchmark_smoke.cc'),
-    dependencies: [
-        get_variable('iceberg_static_dep', iceberg_dep),
-        benchmark_dep,
-    ],
-)
-
-benchmark('benchmark_smoke', benchmark_smoke)
+[provide]
+sqlpp23 = sqlpp23_dep


### PR DESCRIPTION
Provide the same library modules through Meson and CMake, including the bundle, Hive, and SQL catalogs, so applications can use either build system.

Keep installed static and shared libraries usable by downstream consumers and cover their public interfaces with installation checks.

Closes #256

AI assistance was used in this change.