### PR TITLE
build: install the public headers under iceberg/catalog

### DIFF
--- a/src/iceberg/catalog/CMakeLists.txt
+++ b/src/iceberg/catalog/CMakeLists.txt
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+iceberg_install_all_headers(iceberg/catalog)
+
 add_subdirectory(memory)
 
 if(ICEBERG_BUILD_REST)


### PR DESCRIPTION
`rest_catalog.h` is installed and includes `iceberg/catalog/session_catalog.h`, which is not — so a downstream project consuming the installed package and using the REST catalog fails to compile:

  fatal error: iceberg/catalog/session_catalog.h: No such file or directory

  The three headers under `src/iceberg/catalog` (`session_catalog.h`, `session_context.h`, `catalog_util.h`) are already installed by the Meson build, and every sibling directory in CMake (`data`, `expression`, `manifest`, …) calls `iceberg_install_all_headers`. Only `src/iceberg/catalog/CMakeLists.txt` was missing the call
  — another instance of #894.

  Verified by installing from `main` and building a downstream `find_package(iceberg CONFIG REQUIRED COMPONENTS bundle rest)` project that includes `rest_catalog.h`: it fails before this change and builds after.