### PR TITLE
chore(test): run REST fixture's SQLite backend in WAL mode

### DIFF
--- a/src/iceberg/test/resources/iceberg-rest-fixture/docker-compose.yml
+++ b/src/iceberg/test/resources/iceberg-rest-fixture/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     image: apache/iceberg-rest-fixture:latest
     environment:
       - CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
-      - CATALOG_URI=jdbc:sqlite:file:/tmp/iceberg_rest_mode=memory
+      - CATALOG_URI=jdbc:sqlite:/tmp/iceberg_catalog.db?journal_mode=WAL
       - CATALOG_WAREHOUSE=file:///tmp/iceberg_warehouse
     ports:
       - "8181:8181"


### PR DESCRIPTION
Part of apache/iceberg#18043

The REST fixture compose sets `CATALOG_URI=jdbc:sqlite:file:/tmp/iceberg_rest_mode=memory`, carried over from the old databricks image. That isn't an in-memory db, there's no `?` so `iceberg_rest_mode=memory` is just part of the filename. It's a file-backed SQLite db on the default rollback journal, which only lets one connection touch the db at a time, so parallel clients can fail with `SQLITE_BUSY` ("database is locked").

This switches it to `jdbc:sqlite:/tmp/iceberg_catalog.db?journal_mode=WAL`, matching the new fixture default in apache/iceberg#18044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
