### PR TITLE
refactor: expose snapshot utilities in a public header

### DIFF
--- a/src/iceberg/table_scan.cc
+++ b/src/iceberg/table_scan.cc
@@ -39,7 +39,7 @@
 #include "iceberg/table_metadata.h"
 #include "iceberg/util/content_file_util.h"
 #include "iceberg/util/macros.h"
-#include "iceberg/util/snapshot_util_internal.h"
+#include "iceberg/util/snapshot_util.h"
 #include "iceberg/util/timepoint.h"
 #include "iceberg/util/type_util.h"
 

--- a/src/iceberg/test/snapshot_util_test.cc
+++ b/src/iceberg/test/snapshot_util_test.cc
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include "iceberg/util/snapshot_util.h"
+
 #include <chrono>
 #include <memory>
 #include <vector>
@@ -33,7 +35,6 @@
 #include "iceberg/test/matchers.h"
 #include "iceberg/test/mock_catalog.h"
 #include "iceberg/test/mock_io.h"
-#include "iceberg/util/snapshot_util_internal.h"
 #include "iceberg/util/timepoint.h"
 
 namespace iceberg {

--- a/src/iceberg/update/expire_snapshots.cc
+++ b/src/iceberg/update/expire_snapshots.cc
@@ -44,7 +44,7 @@
 #include "iceberg/util/executor_util_internal.h"
 #include "iceberg/util/macros.h"
 #include "iceberg/util/retry_util.h"
-#include "iceberg/util/snapshot_util_internal.h"
+#include "iceberg/util/snapshot_util.h"
 #include "iceberg/util/string_util.h"
 #include "iceberg/util/task_group.h"
 

--- a/src/iceberg/update/merging_snapshot_update.cc
+++ b/src/iceberg/update/merging_snapshot_update.cc
@@ -53,7 +53,7 @@
 #include "iceberg/transaction.h"
 #include "iceberg/util/content_file_util.h"
 #include "iceberg/util/macros.h"
-#include "iceberg/util/snapshot_util_internal.h"
+#include "iceberg/util/snapshot_util.h"
 #include "iceberg/util/struct_like_set.h"
 
 namespace iceberg {

--- a/src/iceberg/update/row_delta.cc
+++ b/src/iceberg/update/row_delta.cc
@@ -34,7 +34,7 @@
 #include "iceberg/util/error_collector.h"
 #include "iceberg/util/formatter_internal.h"
 #include "iceberg/util/macros.h"
-#include "iceberg/util/snapshot_util_internal.h"
+#include "iceberg/util/snapshot_util.h"
 
 namespace iceberg {
 

--- a/src/iceberg/update/set_snapshot.cc
+++ b/src/iceberg/update/set_snapshot.cc
@@ -28,7 +28,7 @@
 #include "iceberg/transaction.h"
 #include "iceberg/util/error_collector.h"
 #include "iceberg/util/macros.h"
-#include "iceberg/util/snapshot_util_internal.h"
+#include "iceberg/util/snapshot_util.h"
 #include "iceberg/util/timepoint.h"
 
 namespace iceberg {

--- a/src/iceberg/update/snapshot_update.cc
+++ b/src/iceberg/update/snapshot_update.cc
@@ -39,7 +39,7 @@
 #include "iceberg/transaction.h"
 #include "iceberg/util/executor_util_internal.h"
 #include "iceberg/util/macros.h"
-#include "iceberg/util/snapshot_util_internal.h"
+#include "iceberg/util/snapshot_util.h"
 #include "iceberg/util/string_util.h"
 #include "iceberg/util/task_group.h"
 #include "iceberg/util/uuid.h"

--- a/src/iceberg/update/update_snapshot_reference.cc
+++ b/src/iceberg/update/update_snapshot_reference.cc
@@ -28,7 +28,7 @@
 #include "iceberg/table_metadata.h"
 #include "iceberg/transaction.h"
 #include "iceberg/util/macros.h"
-#include "iceberg/util/snapshot_util_internal.h"
+#include "iceberg/util/snapshot_util.h"
 
 namespace iceberg {
 

--- a/src/iceberg/util/meson.build
+++ b/src/iceberg/util/meson.build
@@ -39,6 +39,7 @@ install_headers(
         'partition_value_util.h',
         'property_util.h',
         'retry_util.h',
+        'snapshot_util.h',
         'string_util.h',
         'struct_like_set.h',
         'task_group.h',

--- a/src/iceberg/util/snapshot_util.cc
+++ b/src/iceberg/util/snapshot_util.cc
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include "iceberg/util/snapshot_util.h"
+
 #include <ranges>
 
 #include "iceberg/schema.h"
@@ -24,7 +26,6 @@
 #include "iceberg/table.h"
 #include "iceberg/table_metadata.h"
 #include "iceberg/util/macros.h"
-#include "iceberg/util/snapshot_util_internal.h"
 #include "iceberg/util/timepoint.h"
 #include "iceberg/util/uuid.h"
 

--- a/src/iceberg/util/snapshot_util.h
+++ b/src/iceberg/util/snapshot_util.h
@@ -19,6 +19,9 @@
 
 #pragma once
 
+/// \file iceberg/util/snapshot_util.h
+/// \brief Utility functions for working with snapshots.
+
 #include <functional>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
Making SnapshotUtil public lets downstream integrations reuse snapshot traversal, time lookup, and schema resolution logic. Java impl already uses it outside the core library: Spark uses `schemaFor`, and Flink uses `ancestorsBetween`.
Exposing the C++ equivalent would support similar use cases without duplicating that logic.